### PR TITLE
Update cm classes definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,7 @@
 ﻿# next-version: RiC-O v0.2 development branch
 
-The branch where everything thas has to be done for building RiC-O v0.2 will be done.
+Updating the definitions (rdfs:comment, skos:scopeNote mainly) of RiC-O classes that correspond to RiC-CM entities (see issue #8)
 
-Other branches, each for one development specific task, will be created, then merged into this one. These branches will be associated with one or many issues.
+ThThis branch will be  merged into the next-version branch in the end.
 
-Once everything necessary is done, the next-version branch will be merged into the master one.
-
-It has been decided that RiC-O v0.2 will have the following features that make it different from RiC-O v0.1:
-
-* it will be compliant with RiC-CM v0.2 full draft, that should be released the same time. In RiC-CM v0.2 full draft, ICA/EGAD has introduced various updates from RiC-CM v0.2 preview:
-
-    ** most of the textual definitions and scope notes of the classes, attributes and relations have been rephrased;
-    
-    ** some of the attributes have changed domain and other features (e.g. value schema or specifications)
-    
-    ** few relations have been removed, some may still be added
-    
-    ** some relations have changed name
-    
-* its metadata will be more complete, in order to conform to best practices
-
-* each update for any component will be documented
-
-* the introduction will, if EGAD has enough time, include a few diagrams
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-﻿# next-version: RiC-O v0.2 development branch
+﻿# update-CM-classes-definitions branch
 
 Updating the definitions (rdfs:comment, skos:scopeNote mainly) of RiC-O classes that correspond to RiC-CM entities (see issue #8)
 
-ThThis branch will be  merged into the next-version branch in the end.
+This branch will be  merged into the next-version branch in the end.
 
 

--- a/ontology/current-version/RiC-O_v0-2.rdf
+++ b/ontology/current-version/RiC-O_v0-2.rdf
@@ -8490,27 +8490,6 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#IdentifierType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#IdentifierType">
-      <rdfs:label xml:lang="en">Identifier Type</rdfs:label>
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
-      <rdfs:subClassOf>
-         <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#isIdentifierTypeOf"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Identifier"
-            />
-         </owl:Restriction>
-      </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Categorization of an Identifier.</rdfs:comment>
-      <skos:scopeNote xml:lang="en">For example, 'old identifier' ; 'ISNI' (for a person or
-         corporate body), etc.</skos:scopeNote>
-      <skos:changeNote rdf:parseType="Resource">
-         <rdf:value>Class added along with hasIdentifierType and isIdentifierTypeOf object
-            properties.</rdf:value>
-         <dc:date>2020-10-19</dc:date>
-      </skos:changeNote>
-   </owl:Class>
-   <!-- https://www.ica.org/standards/RiC/ontology#IdentifierType -->
-   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#IdentifierType">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:subClassOf>
          <owl:Restriction>
@@ -9929,23 +9908,6 @@
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>Class added along with hasRuleType and isRuleTypeOf object
             properties.</rdf:value>
-         <dc:date>2020-10-19</dc:date>
-      </skos:changeNote>
-   </owl:Class>
-   <!-- https://www.ica.org/standards/RiC/ontology#RuleType -->
-   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RuleType">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
-      <rdfs:subClassOf>
-         <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleTypeOf"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
-         </owl:Restriction>
-      </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Categorization of a Rule.</rdfs:comment>
-      <rdfs:label xml:lang="en">Rule Type</rdfs:label>
-      <skos:scopeNote xml:lang="en">For example, for rules that can be applied to record resources : access rule, use rule, etc.</skos:scopeNote>
-      <skos:changeNote rdf:parseType="Resource">
-         <rdf:value>Class added along with hasRuleType and isRuleTypeOf object properties.</rdf:value>
          <dc:date>2020-10-19</dc:date>
       </skos:changeNote>
    </owl:Class>

--- a/ontology/current-version/RiC-O_v0-2.rdf
+++ b/ontology/current-version/RiC-O_v0-2.rdf
@@ -1,45 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns="https://www.ica.org/standards/RiC/ontology#"
-         xmlns:cc="http://creativecommons.org/ns#"
-         xmlns:dc="http://purl.org/dc/elements/1.1/"
-         xmlns:owl="http://www.w3.org/2002/07/owl#"
-         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-         xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-         xmlns:html="http://www.w3.org/1999/xhtml"
-         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-         xmlns:rico="https://www.ica.org/standards/RiC/ontology#"
-         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-         xmlns:skos1="skos:"
-         xmlns:dcterms="http://purl.org/dc/terms/"
-         xmlns:ric-dft="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes#"
-         xmlns:ric-rst="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#"
-         xml:base="https://www.ica.org/standards/RiC/ontology">
+   xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:owl="http://www.w3.org/2002/07/owl#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:html="http://www.w3.org/1999/xhtml"
+   xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+   xmlns:rico="https://www.ica.org/standards/RiC/ontology#"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcterms="http://purl.org/dc/terms/"
+   xmlns:vann="http://purl.org/vocab/vann/"
+   xmlns:ric-dft="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes#"
+   xmlns:ric-rst="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#"
+   xml:base="https://www.ica.org/standards/RiC/ontology">
    <owl:Ontology rdf:about="https://www.ica.org/standards/RiC/ontology">
       <cc:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
-      <dc:contributor xml:lang="en">Aaron Rubinstein (University of Massachusetts Amherst, USA), member of EGAD</dc:contributor>
+      <dc:contributor xml:lang="en">Aaron Rubinstein (University of Massachusetts Amherst, USA),
+         member of EGAD</dc:contributor>
       <dc:contributor xml:lang="en">Daniel Pitti (University of Virginia, USA), chair of
-            EGAD</dc:contributor>
-      <dc:contributor xml:lang="en">Miia Herrala (National Archives of Finland), member of EGAD</dc:contributor>
-      <dc:contributor xml:lang="en">Tobias Wildi (Docuteam GmbH, Switzerland), member of EGAD</dc:contributor>
-      <dc:creator xml:lang="en">Florence Clavaud (Archives nationales de France), member of EGAD, lead of EGAD RiC-O team</dc:creator>
+         EGAD</dc:contributor>
+      <dc:contributor xml:lang="en">Miia Herrala (National Archives of Finland), member of
+         EGAD</dc:contributor>
+      <dc:contributor xml:lang="en">Tobias Wildi (Docuteam GmbH, Switzerland), member of
+         EGAD</dc:contributor>
+      <dc:creator xml:lang="en">Florence Clavaud (Archives nationales de France), member of EGAD,
+         lead of EGAD RiC-O team</dc:creator>
       <dc:creator xml:lang="en">International Council on Archives Expert Group on Archival
-            Description (ICA EGAD)</dc:creator>
+         Description (ICA EGAD)</dc:creator>
       <dc:publisher xml:lang="en">International Council on Archives</dc:publisher>
-      <dc:rights xml:lang="en">Copyright 2019, International Council on Archives
-            (ICA)</dc:rights>
+      <dc:rights xml:lang="en">Copyright 2019-...., International Council on Archives
+         (ICA)</dc:rights>
       <dcterms:abstract rdf:parseType="Literal">
          <html:div xml:lang="en">
-            <html:p>RiC-O (Records in Contexts-Ontology) is an OWL ontology for describing
-                    archival record resources. As the second part of Records in Contexts standard,
-                    it is a formal representation of Records in Contexts Conceptual Model (RiC-CM). </html:p>
-            <html:p>The current official version is v0.1; it is <html:b>compliant with <html:a href="https://www.ica.org/sites/default/files/ric-cm-0.2_preview.pdf">RiC-CM v0.2 preview</html:a>
-               </html:b>,
-                    that was published on 2019, December 12.</html:p>
-            <html:p>RiC-O provides a generic vocabulary and formal rules for creating RDF
-                    datasets (or generating them from existing archival metadata) that describe in a
-                    consistent way any kind of archival record resource. It can support publishing
-                    RDF datasets as Linked Data, querying them using SPARQL, and making inferences
-                    using the logic of the ontology.</html:p>
+            <html:p>RiC-O (Records in Contexts-Ontology) is an OWL ontology for describing archival
+               record resources. As the second part of Records in Contexts standard, it is a formal
+               representation of Records in Contexts Conceptual Model (RiC-CM). </html:p>
+            <html:p>The current official version is v0.1; it is <html:b>compliant with <html:a
+                     href="https://www.ica.org/sites/default/files/ric-cm-0.2_preview.pdf">RiC-CM
+                     v0.2 preview</html:a>
+               </html:b>, that was published on 2019, December 12.</html:p>
+            <html:p>RiC-O provides a generic vocabulary and formal rules for creating RDF datasets
+               (or generating them from existing archival metadata) that describe in a consistent
+               way any kind of archival record resource. It can support publishing RDF datasets as
+               Linked Data, querying them using SPARQL, and making inferences using the logic of the
+               ontology.</html:p>
          </html:div>
       </dcterms:abstract>
       <dcterms:contributor rdf:resource="http://www.isni.org/0000000039584825"/>
@@ -47,363 +49,397 @@
       <dcterms:description rdf:parseType="Literal">
          <html:div xml:lang="en" id="introduction">
             <html:h3>Introduction</html:h3>
-            <html:p>RiC-O (Records in Contexts-Ontology) is an OWL ontology for describing
-                    archival record resources. As the second part of Records in Contexts standard,
-                    it is a formal representation of Records in Contexts Conceptual Model (RiC-CM).
-                    This version, which is v0.1, is the current official release, it is compliant
-                    with <html:a href="https://www.ica.org/sites/default/files/ric-cm-0.2_preview.pdf">RiC-CM v0.2 preview</html:a>, that was published on 2019, December 12. </html:p>
+            <html:p>RiC-O (Records in Contexts-Ontology) is an OWL ontology for describing archival
+               record resources. As the second part of Records in Contexts standard, it is a formal
+               representation of Records in Contexts Conceptual Model (RiC-CM). This version, which
+               is v0.1, is the current official release, it is compliant with <html:a
+                  href="https://www.ica.org/sites/default/files/ric-cm-0.2_preview.pdf">RiC-CM v0.2
+                  preview</html:a>, that was published on 2019, December 12. </html:p>
             <html:div id="design-principles">
                <html:h4>RiC-O design principles</html:h4>
-               <html:p>The following design principles were followed when developing
-                        RiC-O.</html:p>
+               <html:p>The following design principles were followed when developing RiC-O.</html:p>
                <html:p>
-                  <html:strong>RiC-O is a domain or reference ontology</html:strong>. It
-                        provides a generic vocabulary and formal rules for creating RDF datasets (or
-                        generating them from existing archival metadata) that describe in a
-                        consistent way any kind of archival record resource. It can support
-                        publishing RDF datasets as Linked Data, querying them using SPARQL, and
-                        making inferences using the logic of the ontology.</html:p>
+                  <html:strong>RiC-O is a domain or reference ontology</html:strong>. It provides a
+                  generic vocabulary and formal rules for creating RDF datasets (or generating them
+                  from existing archival metadata) that describe in a consistent way any kind of
+                  archival record resource. It can support publishing RDF datasets as Linked Data,
+                  querying them using SPARQL, and making inferences using the logic of the
+                  ontology.</html:p>
                <html:p>While some projects have built some specific ontologies for describing
-                        archives, at this time no generic, domain, ontology exists that addresses
-                        this need. This is why EGAD decided to develop RiC-O as the second part of
-                        RiC standard.</html:p>
-               <html:p>Apart this first, main target, RiC-O also can help archival institutions
-                        and engineers to design and develop other technical implementations of
-                        RiC-CM that represent record resources and their layers of contexts as
-                        oriented, interconnected graphs. Of course, other technical implementations
-                        may be developed later on, including XML models, or (hopefully) new versions
-                        of EAD and EAC-CPF XML models.</html:p>
-               <html:p>As RiC-O is a generic, domain ontology, it does not address by itself
-                        every specific need or expectation that may occur in every archival
-                        institution or project. It is rather a high level framework, from which a project
-                        can either select some components, or create subcomponents, or both
-                        simultaneously.</html:p>
+                  archives, at this time no generic, domain, ontology exists that addresses this
+                  need. This is why EGAD decided to develop RiC-O as the second part of RiC
+                  standard.</html:p>
+               <html:p>Apart this first, main target, RiC-O also can help archival institutions and
+                  engineers to design and develop other technical implementations of RiC-CM that
+                  represent record resources and their layers of contexts as oriented,
+                  interconnected graphs. Of course, other technical implementations may be developed
+                  later on, including XML models, or (hopefully) new versions of EAD and EAC-CPF XML
+                  models.</html:p>
+               <html:p>As RiC-O is a generic, domain ontology, it does not address by itself every
+                  specific need or expectation that may occur in every archival institution or
+                  project. It is rather a high level framework, from which a project can either
+                  select some components, or create subcomponents, or both simultaneously.</html:p>
                <html:p>As a domain ontology, RiC-O, at this stage at least, does not borrow any
-                        component from other existing ontologies (such as the cultural heritage
-                        models – IFLA-LRM and CIDOC-CRM, PREMIS, or PROV-O). It should therefore be
-                        easier, for an archival institution or archival project, to understand,
-                        implement and maintain RiC-O within its system.</html:p>
-               <html:p>RiC-O will rather, later on, be aligned with these models. This is of
-                        course essential for interconnecting RDF datasets conforming to RiC-O with
-                        other datasets, or for using parts of RiC-O in other contexts than an
-                        archival or record management context.</html:p>
+                  component from other existing ontologies (such as the cultural heritage models –
+                  IFLA-LRM and CIDOC-CRM, PREMIS, or PROV-O). It should therefore be easier, for an
+                  archival institution or archival project, to understand, implement and maintain
+                  RiC-O within its system.</html:p>
+               <html:p>RiC-O will rather, later on, be aligned with these models. This is of course
+                  essential for interconnecting RDF datasets conforming to RiC-O with other
+                  datasets, or for using parts of RiC-O in other contexts than an archival or record
+                  management context.</html:p>
                <html:p>
                   <html:strong>RiC-O must be immediately usable.</html:strong>
                </html:p>
-               <html:p>This is a key feature for a new model. In particular, it is very
-                        important that existing archival metadata, that are created or generated in
-                        current information systems, can be converted to RDF conforming to RiC-O,
-                        without losing any data, structural or partially implicit information. What
-                        is at stake here is that metadata conforming to the previous existing ICA
-                        standards can be processed successfully.</html:p>
-               <html:p>During the ongoing development process, a lot of successful testing has
-                        been made, using XML/EAD finding aids and XML/EAC-CPF authority records,
-                        that have been converted to RDF datasets, either by hand or using scripts. A
-                        conversion software is being developed and will soon be available.</html:p>
-               <html:p>While some existing metadata sets may have a very fine level of
-                        granularity and accuracy, already using, for example, controlled
-                        vocabularies, or describing curation events separately, often these metadata
-                        don’t have the very precise structure that RiC-CM recommends. Even then,
-                        such a conversion process should remain possible. In order to allow this,
-                        RiC-O sometimes provides several methods for representing information (as
-                        described below). From this point of view, the current official version of
-                        RiC-O may be considered a transitional ontology, in which some components
-                        may be deprecated later on.</html:p>
-               <html:p> The usability of a model also depends on its documentation. That’s why
-                        the current official release has been fully documented (this documentation
-                        will be continously improved).</html:p>
-               <html:p>RiC-O will also soon be
-                        acompanied with examples (RDF datasets). Some tutorials should also be
-                        written, and EGAD will organize practical workshops.</html:p>
+               <html:p>This is a key feature for a new model. In particular, it is very important
+                  that existing archival metadata, that are created or generated in current
+                  information systems, can be converted to RDF conforming to RiC-O, without losing
+                  any data, structural or partially implicit information. What is at stake here is
+                  that metadata conforming to the previous existing ICA standards can be processed
+                  successfully.</html:p>
+               <html:p>During the ongoing development process, a lot of successful testing has been
+                  made, using XML/EAD finding aids and XML/EAC-CPF authority records, that have been
+                  converted to RDF datasets, either by hand or using scripts. A conversion software
+                  is being developed and will soon be available.</html:p>
+               <html:p>While some existing metadata sets may have a very fine level of granularity
+                  and accuracy, already using, for example, controlled vocabularies, or describing
+                  curation events separately, often these metadata don’t have the very precise
+                  structure that RiC-CM recommends. Even then, such a conversion process should
+                  remain possible. In order to allow this, RiC-O sometimes provides several methods
+                  for representing information (as described below). From this point of view, the
+                  current official version of RiC-O may be considered a transitional ontology, in
+                  which some components may be deprecated later on.</html:p>
+               <html:p> The usability of a model also depends on its documentation. That’s why the
+                  current official release has been fully documented (this documentation will be
+                  continously improved).</html:p>
+               <html:p>RiC-O will also soon be acompanied with examples (RDF datasets). Some
+                  tutorials should also be written, and EGAD will organize practical
+                  workshops.</html:p>
                <html:p>
-                  <html:strong>RiC-O has to provide a flexible
-                        framework</html:strong>.</html:p>
+                  <html:strong>RiC-O has to provide a flexible framework</html:strong>.</html:p>
                <html:p>This is a very important principle too. It is related with the usability
-                        principle quoted above. Moreover, archival description is flexible by
-                        essence. It is quite commonly noted that the level of granularity of
-                        information varies from one finding aid to another (or from one authority
-                        record to another), or even within the same finding aid. Some series or
-                        agents are described summarily because little is known about them and there
-                        is little time for extensive research, while other series, even records, or
-                        agents are described in detail; some relations (e.g. that relating to
-                        provenance) may be described without any detail while others may be
-                        thoroughly documented, as ISAAR(CPF) and EAC-CPF allow it.</html:p>
+                  principle quoted above. Moreover, archival description is flexible by essence. It
+                  is quite commonly noted that the level of granularity of information varies from
+                  one finding aid to another (or from one authority record to another), or even
+                  within the same finding aid. Some series or agents are described summarily because
+                  little is known about them and there is little time for extensive research, while
+                  other series, even records, or agents are described in detail; some relations
+                  (e.g. that relating to provenance) may be described without any detail while
+                  others may be thoroughly documented, as ISAAR(CPF) and EAC-CPF allow it.</html:p>
                <html:p>Being generally flexible, for an OWL ontology, depends first on the
-                        polyhierarchical systems of classes and properties it provides. A
-                        superproperty or superclass, more general or generic than its subproperties
-                        or subclasses, must exist and be available for handling information, while
-                        at the same time more accurate subcomponents must be there for handling more
-                        accurate description. Also, RiC-O should provide several methods for
-                        expressing whether relations are well attested and certain or are more vague
-                        as well as direct and short paths between entities alongside more complex
-                        ones.</html:p>
+                  polyhierarchical systems of classes and properties it provides. A superproperty or
+                  superclass, more general or generic than its subproperties or subclasses, must
+                  exist and be available for handling information, while at the same time more
+                  accurate subcomponents must be there for handling more accurate description. Also,
+                  RiC-O should provide several methods for expressing whether relations are well
+                  attested and certain or are more vague as well as direct and short paths between
+                  entities alongside more complex ones.</html:p>
                <html:p>
                   <html:strong>RiC-O must be useful.</html:strong>
                </html:p>
                <html:p>This may be considered obvious. This means that Linked Data tools and
-                        interfaces should enable end users to go through RDF/RiC-O graphs, to query
-                        them using SPARQL in an efficient way, hopefully asking new questions and
-                        reveal information. As an example, an end user should be able to ask « What
-                        are (according to your dataset) the corporate bodies that succeeded to this
-                        given entity from its end of existence, by 1840, to nowadays (as concerns
-                        this given activity) ?» or « tell me what instantiations of this photograph
-                        exist? » « what are the existing copies of this original charter?», and get
-                        a list of these entities. In other words, institutions or projects that will
-                        have made efforts to implement RiC-O must get interesting outcomes. It
-                        should be even more interesting if you can infer new assertions from the RDF
-                        datasets you built, and of course link your datasets to other ones.</html:p>
+                  interfaces should enable end users to go through RDF/RiC-O graphs, to query them
+                  using SPARQL in an efficient way, hopefully asking new questions and reveal
+                  information. As an example, an end user should be able to ask « What are
+                  (according to your dataset) the corporate bodies that succeeded to this given
+                  entity from its end of existence, by 1840, to nowadays (as concerns this given
+                  activity) ?» or « tell me what instantiations of this photograph exist? » « what
+                  are the existing copies of this original charter?», and get a list of these
+                  entities. In other words, institutions or projects that will have made efforts to
+                  implement RiC-O must get interesting outcomes. It should be even more interesting
+                  if you can infer new assertions from the RDF datasets you built, and of course
+                  link your datasets to other ones.</html:p>
                <html:p>
                   <html:strong>RiC-O should be extensible</html:strong>.</html:p>
                <html:p>It should be easy to adapt the ontology by adding new subclasses or
-                        subproperties. It must also be linkable or even partially reusable in other
-                        contexts than purely archival ones. This implies that hierarchies of classes
-                        and properties are defined and that mappings are developed with other
-                        ontologies as mentioned above. It may also imply that RiC-O should provide
-                        “hooks” enabling connexions with, for example, existing SKOS
-                        vocabularies.</html:p>
+                  subproperties. It must also be linkable or even partially reusable in other
+                  contexts than purely archival ones. This implies that hierarchies of classes and
+                  properties are defined and that mappings are developed with other ontologies as
+                  mentioned above. It may also imply that RiC-O should provide “hooks” enabling
+                  connexions with, for example, existing SKOS vocabularies.</html:p>
             </html:div>
             <html:div id="understanding-RiCO">
                <html:h4>Understanding RiC-O: a quick overview of some features</html:h4>
                <html:div id="fromRiCCM-to-RiCO">
                   <html:h5>From RiC-CM to RiC-O</html:h5>
-                  <html:p>In the <html:strong>system of classes of RiC-O</html:strong>, for
-                            each RiC-CM entity, you can find a corresponding class. These classes
-                            are organized according to the same hierarchy as in RiC-CM. In some
-                            projects, you may need very few of them (e.g. Agent, Record Resource and
-                            Activity only), while in other ones, you may need more (e.g. Corporate
-                            Body and Person ; Record ; Place ; Provenance Relation).</html:p>
-                  <html:p>Other classes exist in RiC-O. These additional classes address
-                            various needs:</html:p>
+                  <html:p>In the <html:strong>system of classes of RiC-O</html:strong>, for each
+                     RiC-CM entity, you can find a corresponding class. These classes are organized
+                     according to the same hierarchy as in RiC-CM. In some projects, you may need
+                     very few of them (e.g. Agent, Record Resource and Activity only), while in
+                     other ones, you may need more (e.g. Corporate Body and Person ; Record ; Place
+                     ; Provenance Relation).</html:p>
+                  <html:p>Other classes exist in RiC-O. These additional classes address various
+                     needs:</html:p>
                   <html:ul>
                      <html:li>some correspond to RiC-CM attributes, when it may be considered
-                                necessary to handle them as full entities. This is the case for
-                                    <html:a href="#rico:Type">Type</html:a> and its subclasses, that
-                                correspond to RiC-CM attributes that have a controlled value, and
-                                that can help to articulate RiC-O with external RDF resources like
-                                SKOS vocabularies; and also for <html:a href="#rico:Language">Language</html:a>, <html:a href="#rico:Name">Name</html:a> and
-                                    <html:a href="#rico:Identifier">Identifier</html:a>, that can be
-                                considered as full entities and as key linking nodes in a RDF graph.
-                                All these classes have been grouped under a <html:a href="#rico:Concept">Concept</html:a> class. </html:li>
-                     <html:li>some classes have been added in order to provide a more
-                                accurate definition and model for some entities. <html:a href="#rico:Place">Place</html:a> thus comes along with a
-                                    <html:a href="#rico:PhysicalLocation">Physical Location
-                                    class</html:a>, and with a <html:a href="#rico:Coordinates">Coordinates class</html:a>. A
-                                Place is considered a both geographical and historical entity. As a
-                                historical entity, among other features, it has a history, and may
-                                be preceded or succeeded by other Places. A Place also may have zero
-                                to many Physical Location through time (for instance, its
-                                boundaries, if it is an administrative area or a country, may
-                                change). Each Physical Location may be connected to zero to many
-                                Coordinates. This model is quite close to the Linked Places Format
-                                    (<html:a href="https://github.com/LinkedPasts/linked-places">https://github.com/LinkedPasts/linked-places</html:a>). Another
-                                example of such an addition is the <html:a href="#rico:Proxy">Proxy
-                                    class</html:a>, that represents (stands for) a Record Resource
-                                as it exists in a specific Record Set.</html:li>
-                     <html:li>finally, a system of classes corresponds to the Relations
-                                section in RiC-CM.<html:br/> While these relations also are
-                                represented as simple, binary object properties (e.g. <html:a href="#rico:hasProvenance">‘hasProvenance’</html:a> that
-                                corresponds to RiC-R026 relation), you may need to assign attributes
-                                to relations, e.g. date, certainty, description…, just like one can
-                                already do so in an XML/EAC-CPF file. Though RDF* (RDF 2.0), if and
-                                when it is released, should provide a far simpler method (allowing
-                                to consider a triple as the subject or object of another triple; see
-                                    <html:a href="http://blog.liu.se/olafhartig/2019/01/10/position-statement-rdf-star-and-sparql-star/">http://blog.liu.se/olafhartig/2019/01/10/position-statement-rdf-star-and-sparql-star/</html:a>),
-                                the only available method for representing such a documented
-                                relation in RDF for now is to use a class. Thus, for example, an
-                                    <html:a href="#rico:AgentOriginationRelation">AgentOriginationRelation class</html:a> exists. This class may
-                                connect one to many Agents to one to many created or accumulated
-                                Record Resources or Instantiations, and has some specific object
-                                properties (certainty, date, description, source). Back to the
-                                ‘hasProvenance’ object property, let us add that it is formally
-                                defined, using OWL property chain axiom (see <html:a href="https://www.w3.org/TR/owl2-new-features/">https://www.w3.org/TR/owl2-new-features/</html:a>, as a ‘shortcut’ for the
-                                longer path
-                                ‘recordResourceOrInstantiationIsSourceOfAgentOriginationRelation/agentOriginationRelationHasTarget’,
-                                where the intermediate node is an instance of Agent Origination Relation:<html:br/>
-                        <html:code> &lt;owl:propertyChainAxiom
-                                    rdf:parseType="Collection"&gt; <html:br/> &lt;rdf:Description
-                                    rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/&gt;
-                                    <html:br/> &lt;rdf:Description
-                                    rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/&gt;
-                                    <html:br/> &lt;/owl:propertyChainAxiom&gt; </html:code>
-                        <html:br/>A triplestore, with the appropriate configuration, may
-                                thus infer the direct ‘hasProvenance’ from this long path.</html:li>
+                        necessary to handle them as full entities. This is the case for <html:a
+                           href="#rico:Type">Type</html:a> and its subclasses, that correspond to
+                        RiC-CM attributes that have a controlled value, and that can help to
+                        articulate RiC-O with external RDF resources like SKOS vocabularies; and
+                        also for <html:a href="#rico:Language">Language</html:a>, <html:a
+                           href="#rico:Name">Name</html:a> and <html:a href="#rico:Identifier"
+                           >Identifier</html:a>, that can be considered as full entities and as key
+                        linking nodes in a RDF graph. All these classes have been grouped under a
+                           <html:a href="#rico:Concept">Concept</html:a> class. </html:li>
+                     <html:li>some classes have been added in order to provide a more accurate
+                        definition and model for some entities. <html:a href="#rico:Place"
+                           >Place</html:a> thus comes along with a <html:a
+                           href="#rico:PhysicalLocation">Physical Location class</html:a>, and with
+                        a <html:a href="#rico:Coordinates">Coordinates class</html:a>. A Place is
+                        considered a both geographical and historical entity. As a historical
+                        entity, among other features, it has a history, and may be preceded or
+                        succeeded by other Places. A Place also may have zero to many Physical
+                        Location through time (for instance, its boundaries, if it is an
+                        administrative area or a country, may change). Each Physical Location may be
+                        connected to zero to many Coordinates. This model is quite close to the
+                        Linked Places Format (<html:a
+                           href="https://github.com/LinkedPasts/linked-places"
+                           >https://github.com/LinkedPasts/linked-places</html:a>). Another example
+                        of such an addition is the <html:a href="#rico:Proxy">Proxy class</html:a>,
+                        that represents (stands for) a Record Resource as it exists in a specific
+                        Record Set.</html:li>
+                     <html:li>finally, a system of classes corresponds to the Relations section in
+                        RiC-CM.<html:br/> While these relations also are represented as simple,
+                        binary object properties (e.g. <html:a href="#rico:hasProvenance"
+                           >‘hasProvenance’</html:a> that corresponds to RiC-R026 relation), you may
+                        need to assign attributes to relations, e.g. date, certainty, description…,
+                        just like one can already do so in an XML/EAC-CPF file. Though RDF* (RDF
+                        2.0), if and when it is released, should provide a far simpler method
+                        (allowing to consider a triple as the subject or object of another triple;
+                        see <html:a
+                           href="http://blog.liu.se/olafhartig/2019/01/10/position-statement-rdf-star-and-sparql-star/"
+                           >http://blog.liu.se/olafhartig/2019/01/10/position-statement-rdf-star-and-sparql-star/</html:a>),
+                        the only available method for representing such a documented relation in RDF
+                        for now is to use a class. Thus, for example, an <html:a
+                           href="#rico:AgentOriginationRelation">AgentOriginationRelation
+                           class</html:a> exists. This class may connect one to many Agents to one
+                        to many created or accumulated Record Resources or Instantiations, and has
+                        some specific object properties (certainty, date, description, source). Back
+                        to the ‘hasProvenance’ object property, let us add that it is formally
+                        defined, using OWL property chain axiom (see <html:a
+                           href="https://www.w3.org/TR/owl2-new-features/"
+                           >https://www.w3.org/TR/owl2-new-features/</html:a>, as a ‘shortcut’ for
+                        the longer path
+                        ‘recordResourceOrInstantiationIsSourceOfAgentOriginationRelation/agentOriginationRelationHasTarget’,
+                        where the intermediate node is an instance of Agent Origination Relation:<html:br/>
+                        <html:code> &lt;owl:propertyChainAxiom rdf:parseType="Collection"&gt;
+                           <html:br/> &lt;rdf:Description
+                           rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/&gt;
+                           <html:br/> &lt;rdf:Description
+                           rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/&gt;
+                           <html:br/> &lt;/owl:propertyChainAxiom&gt; </html:code>
+                        <html:br/>A triplestore, with the appropriate configuration, may thus infer
+                        the direct ‘hasProvenance’ from this long path.</html:li>
                   </html:ul>
                   <html:p>Most of the <html:strong>datatype properties in RiC-O
-                            </html:strong>correspond to a RiC-CM attribute that has ‘free text’ as a
-                            schema value. See for example <html:a href="#rico:descriptiveNote">rico:descriptiveNote</html:a>, <html:a href="#rico:history">rico:history</html:a> and <html:a href="#scopeAndContent">rico:scopeAndContent</html:a>.</html:p>
+                     </html:strong>correspond to a RiC-CM attribute that has ‘free text’ as a schema
+                     value. See for example <html:a href="#rico:descriptiveNote"
+                        >rico:descriptiveNote</html:a>, <html:a href="#rico:history"
+                        >rico:history</html:a> and <html:a href="#scopeAndContent"
+                        >rico:scopeAndContent</html:a>.</html:p>
                   <html:p>In addition to these datatype properties, as already said, Name and
-                            Identifier RiC-CM attributes also have their corresponding classes
-                            (subclasses of <html:a href="#rico:Appellation">rico:Appellation</html:a>). For users who would like, for instance,
-                            to consider Names as full entities (like librarians do) and thus, among
-                            other reasons, be able to align their names to name authorities, the
-                            Name class is important; while many users will simply use the name
-                            datatype property at least for a while.</html:p>
-                  <html:p>The Location RiC-CM attribute also has a <html:a href="#rico:PhysicalLocation">rico:Physical Location corresponding
-                                class</html:a> (for users who want to use Place, Physical Location
-                            and Coordinates for handling places).</html:p>
-                  <html:p>As already said too, every RiC-CM attribute that has ‘controlled
-                            value’ or ‘rule-based’ as a schema value, has a class as corresponding
-                            component in RiC-O. For these CM attributes that correspond to a RiC-O
-                            class, as it is necessary to provide an immediately usable ontology, two
-                            supplementary datatype properties exist that allow not to use the
-                            classes, at least for a while, if you want to implement RiC-O and create
-                            RiC-O/RDF datasets from existing archival metadata without being able to
-                            handle URIs for the information you have.</html:p>
-                  <html:p>For example, you may not be able to handle and maintain URis for
-                            some controlled values you use in EAD finding aids for carrier types:
-                            maybe your information system does not use a vocabulary for this, and
-                            you cannot for a while consider these carrier types as full entities.
-                            Nevertheless you want to produce RiC-O datasets where every piece of
-                            information is kept, and you want to avoid blank nodes. If RiC-O would
-                            only provide the Carrier Type class, it would be an issue for you. So
-                            RiC-O provides a <html:a href="#rico:type">rico:type datatype
-                                property</html:a>, with range rdfs:literal, which allows you to move
-                            forward.</html:p>
-                  <html:p>Therefore, for the RiC-CM *Type attributes, you thus also have
-                                <html:a href="#rico:type">rico:type datatype property</html:a>). For
-                            RiC-CM Coordinates attribute, you also have <html:a href="#rico:geographicalCoordinates">rico:geographicalCoordinates
-                                datatype property</html:a>.</html:p>
-                  <html:p>These datatype properties have a skos:scopeNote which says (for
-                            example) "Provided for usability reasons. May be made deprecated or
-                            removed later on. Use only if you don't use Physical Location and
-                            Coordinates classes with Place."</html:p>
-                  <html:p>The same key design principle (RiC-O must be immediately usable)
-                            lead us to define some datatype properties that would enable users to
-                            use RiC-O even if they do not want to consider dates and rules as full
-                            entities. Thus, there of course is Date and Rule classes in RiC-O (since
-                            there are Date and Rule entities in RiC-CM). And you also have 'date'
-                            datatype properties; plus a <html:a href="#rico:ruleFollowed">rico:ruleFollowed datatype property</html:a>. The same analysis
-                            lead us to keep the <html:a href="#rico:history">rico:history</html:a>
-                            datatype property in RiC-O (same as RiC-CM history attribute), while
-                            RiC-CM and RiC-O also provide the <html:a href="#Event">Event
-                                class</html:a>, and using a series of Events may of course be a
-                            better method, easier to query, link and display, than simply using a
-                            history prose discourse. The two methods may often in the end be used in
-                            the same dataset by an institution that, for example, would decide to
-                            emphasize only the accession, appraisal and description events among the
-                            whole history of Record resources.</html:p>
+                     Identifier RiC-CM attributes also have their corresponding classes (subclasses
+                     of <html:a href="#rico:Appellation">rico:Appellation</html:a>). For users who
+                     would like, for instance, to consider Names as full entities (like librarians
+                     do) and thus, among other reasons, be able to align their names to name
+                     authorities, the Name class is important; while many users will simply use the
+                     name datatype property at least for a while.</html:p>
+                  <html:p>The Location RiC-CM attribute also has a <html:a
+                        href="#rico:PhysicalLocation">rico:Physical Location corresponding
+                        class</html:a> (for users who want to use Place, Physical Location and
+                     Coordinates for handling places).</html:p>
+                  <html:p>As already said too, every RiC-CM attribute that has ‘controlled value’ or
+                     ‘rule-based’ as a schema value, has a class as corresponding component in
+                     RiC-O. For these CM attributes that correspond to a RiC-O class, as it is
+                     necessary to provide an immediately usable ontology, two supplementary datatype
+                     properties exist that allow not to use the classes, at least for a while, if
+                     you want to implement RiC-O and create RiC-O/RDF datasets from existing
+                     archival metadata without being able to handle URIs for the information you
+                     have.</html:p>
+                  <html:p>For example, you may not be able to handle and maintain URis for some
+                     controlled values you use in EAD finding aids for carrier types: maybe your
+                     information system does not use a vocabulary for this, and you cannot for a
+                     while consider these carrier types as full entities. Nevertheless you want to
+                     produce RiC-O datasets where every piece of information is kept, and you want
+                     to avoid blank nodes. If RiC-O would only provide the Carrier Type class, it
+                     would be an issue for you. So RiC-O provides a <html:a href="#rico:type"
+                        >rico:type datatype property</html:a>, with range rdfs:literal, which allows
+                     you to move forward.</html:p>
+                  <html:p>Therefore, for the RiC-CM *Type attributes, you thus also have <html:a
+                        href="#rico:type">rico:type datatype property</html:a>). For RiC-CM
+                     Coordinates attribute, you also have <html:a
+                        href="#rico:geographicalCoordinates">rico:geographicalCoordinates datatype
+                        property</html:a>.</html:p>
+                  <html:p>These datatype properties have a skos:scopeNote which says (for example)
+                     "Provided for usability reasons. May be made deprecated or removed later on.
+                     Use only if you don't use Physical Location and Coordinates classes with
+                     Place."</html:p>
+                  <html:p>The same key design principle (RiC-O must be immediately usable) lead us
+                     to define some datatype properties that would enable users to use RiC-O even if
+                     they do not want to consider dates and rules as full entities. Thus, there of
+                     course is Date and Rule classes in RiC-O (since there are Date and Rule
+                     entities in RiC-CM). And you also have 'date' datatype properties; plus a
+                        <html:a href="#rico:ruleFollowed">rico:ruleFollowed datatype
+                        property</html:a>. The same analysis lead us to keep the <html:a
+                        href="#rico:history">rico:history</html:a> datatype property in RiC-O (same
+                     as RiC-CM history attribute), while RiC-CM and RiC-O also provide the <html:a
+                        href="#Event">Event class</html:a>, and using a series of Events may of
+                     course be a better method, easier to query, link and display, than simply using
+                     a history prose discourse. The two methods may often in the end be used in the
+                     same dataset by an institution that, for example, would decide to emphasize
+                     only the accession, appraisal and description events among the whole history of
+                     Record resources.</html:p>
                   <html:p>These data properties have the same kind of skos:scopeNote as
-                            above.</html:p>
-                  <html:p>Finally, we have introduced a few data properties that do not
-                            correspond to any RiC-CM attribute.</html:p>
-                  <html:p>Some are superproperties, and thus group datatype properties
-                                (<html:a href="#rico:physicalOrLogicalExtent">rico:physicalOrLogicalExtent</html:a>, with rico:carrierExtent and
-                            rico:instantiationExtent as subproperties ; <html:a href="#rico:textualValue">rico:textualValue</html:a>, with
-                            rico:expressedDate and rico:normalizedValue as subproperties; <html:a href="#rico:measure">rico:measure</html:a> (and its subproperties);
-                                <html:a href="#rico:referenceSystem">rico:referenceSystem</html:a>,
-                            superproperty of rico:dateStandard (and of other datatype properties
-                            that do not exist in RiC-CM.)</html:p>
-                  <html:p>Some are simply more specific properties : <html:a href="#rico:accrualStatus">rico:accrualStatus</html:a> ; <html:a href="#rico:recordResourceStructure">rico:recordResourceStructure</html:a> and <html:a href="#rico:instantiationStructure">rico:instantiationStructure</html:a>, subproperties of
-                            rico:structure ; <html:a href="#rico:title">rico:title</html:a>
-                            (subproperty of rico:name) ; rico:altitude, rico:latitude,
-                            rico:longitude (subproperties of rico:measure), rico:geodesicSystem and
-                            rico:altimetricSystem (subproperties of rico:referenceSystem).</html:p>
-                  <html:p>In order to connect all the classes created, <html:strong>a
-                                significant number of object properties have been
-                                defined</html:strong>. While their 'flat' list is a long one, they are grouped hierarchically, so that one
-                            can use the upper to intermediate level ones for simplicity sake, or
-                            choose the most accurate and expressive ones, or extend the system
-                            adding a subproperty easily. It is expected that, in most use cases, a subset of these properties only will be needed. As already said above, some of the object
-                            properties are also formally defined as shortcuts.</html:p>
+                     above.</html:p>
+                  <html:p>Finally, we have introduced a few data properties that do not correspond
+                     to any RiC-CM attribute.</html:p>
+                  <html:p>Some are superproperties, and thus group datatype properties (<html:a
+                        href="#rico:physicalOrLogicalExtent">rico:physicalOrLogicalExtent</html:a>,
+                     with rico:carrierExtent and rico:instantiationExtent as subproperties ; <html:a
+                        href="#rico:textualValue">rico:textualValue</html:a>, with
+                     rico:expressedDate and rico:normalizedValue as subproperties; <html:a
+                        href="#rico:measure">rico:measure</html:a> (and its subproperties); <html:a
+                        href="#rico:referenceSystem">rico:referenceSystem</html:a>, superproperty of
+                     rico:dateStandard (and of other datatype properties that do not exist in
+                     RiC-CM.)</html:p>
+                  <html:p>Some are simply more specific properties : <html:a
+                        href="#rico:accrualStatus">rico:accrualStatus</html:a> ; <html:a
+                        href="#rico:recordResourceStructure">rico:recordResourceStructure</html:a>
+                     and <html:a href="#rico:instantiationStructure"
+                        >rico:instantiationStructure</html:a>, subproperties of rico:structure ;
+                        <html:a href="#rico:title">rico:title</html:a> (subproperty of rico:name) ;
+                     rico:altitude, rico:latitude, rico:longitude (subproperties of rico:measure),
+                     rico:geodesicSystem and rico:altimetricSystem (subproperties of
+                     rico:referenceSystem).</html:p>
+                  <html:p>In order to connect all the classes created, <html:strong>a significant
+                        number of object properties have been defined</html:strong>. While their
+                     'flat' list is a long one, they are grouped hierarchically, so that one can use
+                     the upper to intermediate level ones for simplicity sake, or choose the most
+                     accurate and expressive ones, or extend the system adding a subproperty easily.
+                     It is expected that, in most use cases, a subset of these properties only will
+                     be needed. As already said above, some of the object properties are also
+                     formally defined as shortcuts.</html:p>
                   <html:p>Finally, let us mention that we added to RiC-O six individuals,
-                            considering that they would address current and frequent needs:</html:p>
+                     considering that they would address current and frequent needs:</html:p>
                   <html:ul>
-                     <html:li>Two (<html:a href="#FindingAid">FindingAid</html:a>
-                                and <html:a href="#AuthorityRecord">AuthorityRecord</html:a>) are both instances of the
-                                Documentary Form Type class, and of skos:Concept. They can be used
-                                for categorizing Records, finding aids and authority records being
-                                considered as Records. A Record that would have ‘Finding Aid’ as a
-                                Documentary Form Type, can be connected to one to many Record
-                                Resources using 'rico:describes’ object property.</html:li>
-                     <html:li>Four (<html:a href="#Fonds">Fonds</html:a>, <html:a href="#Series">Series</html:a>, <html:a href="#File">File</html:a>, and <html:a href="Collection">Collection</html:a>) are both
-                                instances of the Record Set Type class, and of skos:Concept. Their
-                                definition is taken from the ISAD(G) glossary. They can be used for
-                                categorizing Record Sets.</html:li>
+                     <html:li>Two (<html:a href="#FindingAid">FindingAid</html:a> and <html:a
+                           href="#AuthorityRecord">AuthorityRecord</html:a>) are both instances of
+                        the Documentary Form Type class, and of skos:Concept. They can be used for
+                        categorizing Records, finding aids and authority records being considered as
+                        Records. A Record that would have ‘Finding Aid’ as a Documentary Form Type,
+                        can be connected to one to many Record Resources using 'rico:describes’
+                        object property.</html:li>
+                     <html:li>Four (<html:a href="#Fonds">Fonds</html:a>, <html:a href="#Series"
+                           >Series</html:a>, <html:a href="#File">File</html:a>, and <html:a
+                           href="Collection">Collection</html:a>) are both instances of the Record
+                        Set Type class, and of skos:Concept. Their definition is taken from the
+                        ISAD(G) glossary. They can be used for categorizing Record Sets.</html:li>
                   </html:ul>
-                  <html:p>In the future, we can imagine that many other categories of the kind
-                            will be defined by the archival community, forming at least rich SKOS
-                            (hopefully multilingual) vocabularies. Considering the concepts thus
-                            defined as being also instances of some RiC-O classes may be of great
-                            interest for producing a richer description (for example, an instance of
-                            the <html:a href="#rico:DocumentaryFormType">Documentary Form Type
-                                class</html:a> may have a history and some temporal relations to
-                            other documentary form types).</html:p>
+                  <html:p>In the future, we can imagine that many other categories of the kind will
+                     be defined by the archival community, forming at least rich SKOS (hopefully
+                     multilingual) vocabularies. Considering the concepts thus defined as being also
+                     instances of some RiC-O classes may be of great interest for producing a richer
+                     description (for example, an instance of the <html:a
+                        href="#rico:DocumentaryFormType">Documentary Form Type class</html:a> may
+                     have a history and some temporal relations to other documentary form
+                     types).</html:p>
                </html:div>
                <html:div id="RiCO-documentation">
                   <html:h5>RiC-O documentation and annotation properties</html:h5>
-                  <html:p>Each class or property has an English label (rdfs:label) and
-                            description (rdfs:comment). Some have a skos:scopeNote.</html:p>
-                  <html:p>When a RiC-O class or property corresponds in a way to a RiC-CM
-                            component, its description and scope note are, either the same as, or
-                            derived from, their definition and scope note in RiC-CM.</html:p>
-                  <html:p>We have created two annotation properties, subproperties of
-                            rdfs:comment, for handling:</html:p>
+                  <html:p>Each class or property has an English label (rdfs:label) and description
+                     (rdfs:comment). Some have a skos:scopeNote.</html:p>
+                  <html:p>When a RiC-O class or property corresponds in a way to a RiC-CM component,
+                     its description and scope note are, either the same as, or derived from, their
+                     definition and scope note in RiC-CM.</html:p>
+                  <html:p>We have created two annotation properties, subproperties of rdfs:comment,
+                     for handling:</html:p>
                   <html:ul>
-                     <html:li>Information about the corresponding RiC-CM component when
-                                appliable (<html:a href="#rico:RiCCMCorrespondingComponent">rico:RiCCMCorrespondingComponent</html:a>). Various phrasings
-                                are used in this property depending on the rule applied for defining
-                                the RiC-CM component.</html:li>
-                     <html:li>Information, most often in prose text for now, about possible
-                                mappings with other models or ontologies (<html:a href="#rico:closeTo">rico:closeTo</html:a>, rarely used in this
-                                0.1 version)).</html:li>
+                     <html:li>Information about the corresponding RiC-CM component when appliable
+                           (<html:a href="#rico:RiCCMCorrespondingComponent"
+                           >rico:RiCCMCorrespondingComponent</html:a>). Various phrasings are used
+                        in this property depending on the rule applied for defining the RiC-CM
+                        component.</html:li>
+                     <html:li>Information, most often in prose text for now, about possible mappings
+                        with other models or ontologies (<html:a href="#rico:closeTo"
+                           >rico:closeTo</html:a>, rarely used in this 0.1 version)).</html:li>
                   </html:ul>
                </html:div>
             </html:div>
             <html:div id="next-steps">
                <html:h4>Known issues and next steps</html:h4>
-               <html:p>The following is a non exhaustive list of known issues, topics or tasks
-                        on which EGAD will work in the next months:</html:p>
+               <html:p>The following is a non exhaustive list of known issues, topics or tasks on
+                  which EGAD will work in the next months:</html:p>
                <html:ul>
-                  <html:li>providing examples, both as full RDF datasets and in this documentation)</html:li>
+                  <html:li>providing examples, both as full RDF datasets and in this
+                     documentation)</html:li>
                   <html:li>finishing the system of relations (where some subclasses are still
-                            missing)</html:li>
-                  <html:li>assessing, and probably changing in some cases, the tense of the
-                            verbs in some object properties (e.g. for the properties that correspond
-                            to some RiC-CM relations)</html:li>
-                  <html:li>articulating the Event and Activity classes, and the Relation system
-                            of classes</html:li>
+                     missing)</html:li>
+                  <html:li>assessing, and probably changing in some cases, the tense of the verbs in
+                     some object properties (e.g. for the properties that correspond to some RiC-CM
+                     relations)</html:li>
+                  <html:li>articulating the Event and Activity classes, and the Relation system of
+                     classes</html:li>
                   <html:li>improving the names of object properties</html:li>
-                  <html:li>adding suggestions of mappings (in rico:closeTo) and OWL
-                            equivalences between some classes or properties and components in other
-                            models (among which - this is not an exhaustive list- CIDOC-CRM, IFLA-LRM, PREMIS, PROV-O, and Schema.org)</html:li>
+                  <html:li>adding suggestions of mappings (in rico:closeTo) and OWL equivalences
+                     between some classes or properties and components in other models (among which
+                     - this is not an exhaustive list- CIDOC-CRM, IFLA-LRM, PREMIS, PROV-O, and
+                     Schema.org)</html:li>
                   <html:li>documenting RiC-O in French and Spanish</html:li>
-                  <html:li>providing users with some SPARQL constructs for
-                            inferring.</html:li>
+                  <html:li>providing users with some SPARQL constructs for inferring.</html:li>
                </html:ul>
             </html:div>
          </html:div>
       </dcterms:description>
       <dcterms:publisher rdf:resource="http://www.wikidata.org/entity/Q1421986"/>
       <dcterms:title xml:lang="en">International Council on Archives Records in Contexts Ontology
-            (ICA RiC-O) version 0.2</dcterms:title>
-      <rdfs:label xml:lang="en">International Council on Archives Records in Contexts Ontology (ICA RiC-O)
-            version 0.2</rdfs:label>
-      <owl:versionInfo xml:lang="en">Version 0.2 - last update: 2020-03-12.</owl:versionInfo>
+         (ICA RiC-O) version 0.2</dcterms:title>
+      <rdfs:label xml:lang="en">International Council on Archives Records in Contexts Ontology (ICA
+         RiC-O) version 0.2</rdfs:label>
+      <vann:preferredNamespaceUri>https://www.ica.org/standards/RiC/ontology#</vann:preferredNamespaceUri>
+      <vann:preferredNamespacePrefix>rico</vann:preferredNamespacePrefix>
+      <owl:versionInfo xml:lang="en">Version 0.2 - last update: 2020-10-23.</owl:versionInfo>
+      <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+         >2019-12-12</dcterms:issued>
+      <owl:priorVersion rdf:resource="https://www.ica.org/standards/RiC/RiC-O_v0-1.rdf"/>
       <skos:historyNote rdf:parseType="Literal">
          <html:div xml:lang="en">
             <html:p>A first beta version of RiC-O was developed in 2017 and used by the National
-                    Archives of France for building a proof of concept (<html:a href="http://piaaf.demo.logilab.fr">http://piaaf.demo.logilab.fr</html:a>).</html:p>
+               Archives of France for building a proof of concept (<html:a
+                  href="http://piaaf.demo.logilab.fr"
+               >http://piaaf.demo.logilab.fr</html:a>).</html:p>
             <html:p>EGAD then continued to develop the ontology, and this process entered a very
-                    active period in 2019, while RiC-CM v0.2 was being designed and edited. From
-                    December 2018 to November 2019, about 65 persons that had applied to a call for
-                    reviewers, received successive beta versions of RiC-O and sent a few first
-                    comments. While EGAD RiC-O team could not answer to each of these comments, each
-                    was taken into account. In particular, it was decided to prepare and publish,
-                    along with RiC-O v0.1, a preview of RiC-CM v0.2. The goal of the preview release
-                    of RiC-CM v0.2 is to provide context for the classes, properties, and overall
-                    logic of RiC-O in support of the ontology’s first public release.</html:p>
+               active period in 2019, while RiC-CM v0.2 was being designed and edited. From December
+               2018 to November 2019, about 65 persons that had applied to a call for reviewers,
+               received successive beta versions of RiC-O and sent a few first comments. While EGAD
+               RiC-O team could not answer to each of these comments, each was taken into account.
+               In particular, it was decided to prepare and publish, along with RiC-O v0.1, a
+               preview of RiC-CM v0.2. The goal of the preview release of RiC-CM v0.2 is to provide
+               context for the classes, properties, and overall logic of RiC-O in support of the
+               ontology’s first public release.</html:p>
             <html:p>Version 0.1 is a draft, and was released with a public call for
-                    comments.</html:p>
-            <html:p>The Git repository that is used for handling RiC-O will soon be made public,
-                    so that making pull requests will be possible.</html:p>
-            <html:p>The following is a list of the changes made to RiC-O (this current version being RiC-O v0.2)  since the release of RiC-O v0.1 in December 2019.</html:p>
+               comments.</html:p>
+            <html:p>The Git repository that is used for handling RiC-O will soon be made public, so
+               that making pull requests will be possible.</html:p>
+            <html:p>The following is a list of the changes made to RiC-O (this current version being
+               RiC-O v0.2) since the release of RiC-O v0.1 in December 2019. Note that from October 2020 any change on a component is described and dated in the specification of this component, using skos:changeNote.</html:p>
             <html:ul>
-               <html:li>Fixed a bug in the documentation of rico:PerformanceRelation and its object properties.</html:li>
+               <html:li>Fixed a bug in the documentation of rico:PerformanceRelation and its object
+                  properties.</html:li>
                <html:li>Renamed the file and updated the ontology metadata.</html:li>
                <html:li>OccupationType made a subclass of ActivityType.</html:li>
-               <html:li>Changed the domain and range of rico:hasOriginal and rico:hasDraft (it is now Record or Record Part); same for their inverse properties.</html:li>
-               <html:li>Fixed a bug in the definition of rico:provenanceRelationHasTarget (removed the owl:propertyChainAxiom).</html:li>
-               <html:li>Changed the name of rico:leadBy object property (grammatical mistake)  to rico:ledBy. </html:li>
+               <html:li>Changed the domain and range of rico:hasOriginal and rico:hasDraft (it is
+                  now Record or Record Part); same for their inverse properties.</html:li>
+               <html:li>Fixed a bug in the definition of rico:provenanceRelationHasTarget (removed
+                  the owl:propertyChainAxiom).</html:li>
+               <html:li>Changed the name of rico:leadBy object property (grammatical mistake) to
+                  rico:ledBy. </html:li>
+               <html:li>2020, October 19: Added a vann:preferredNamespaceUri and vann:preferredNamespacePrefix
+                  property to the ontology metadata</html:li>
+               <html:li>2020, October 19 : created RuleType and IdentifierType classes, along with
+                  the associated object properties.</html:li>
+               <html:li>2020, October 23: updated the text definition and/or scope note of 33
+                  classes, that correspond to RiC-CM entities or attributes, in order to make them
+                  compliant with RiC-CM v0.2. Added a few owl:disjointWith properties.</html:li>
             </html:ul>
          </html:div>
       </skos:historyNote>
@@ -443,6 +479,10 @@
    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/title"/>
    <!-- http://www.w3.org/2004/02/skos/core#altLabel -->
    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#altLabel"/>
+   <!-- http://www.w3.org/2004/02/skos/core#changeNote -->
+   <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#changeNote">
+      <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2004/02/skos/core#note"/>
+   </owl:AnnotationProperty>
    <!-- http://www.w3.org/2004/02/skos/core#definition -->
    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#definition"/>
    <!-- http://www.w3.org/2004/02/skos/core#historyNote -->
@@ -456,27 +496,20 @@
    <!-- http://www.w3.org/2004/02/skos/core#scopeNote -->
    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#scopeNote"/>
    <!-- https://www.ica.org/standards/RiC/ontology#RiCCMCorrespondingComponent -->
-   <owl:AnnotationProperty rdf:about="https://www.ica.org/standards/RiC/ontology#RiCCMCorrespondingComponent">
+   <owl:AnnotationProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#RiCCMCorrespondingComponent">
       <rdfs:comment xml:lang="en">When it exists, specifies the identifier and name of RiC-CM
-            component that corresponds to the annotated class or property.</rdfs:comment>
+         component that corresponds to the annotated class or property.</rdfs:comment>
       <rdfs:label xml:lang="en">RiC-CM corresponding component</rdfs:label>
       <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
    </owl:AnnotationProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#closeTo -->
    <owl:AnnotationProperty rdf:about="https://www.ica.org/standards/RiC/ontology#closeTo">
       <rdfs:comment xml:lang="en">An annotation property for recording a possible mapping to a
-            component in another model or ontology</rdfs:comment>
+         component in another model or ontology</rdfs:comment>
       <rdfs:label xml:lang="en">close to</rdfs:label>
       <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
    </owl:AnnotationProperty>
-   <!-- skos:altLabel -->
-   <owl:AnnotationProperty rdf:about="skos:altLabel"/>
-   <!-- skos:historyNote -->
-   <owl:AnnotationProperty rdf:about="skos:historyNote"/>
-   <!-- skos:note -->
-   <owl:AnnotationProperty rdf:about="skos:note"/>
-   <!-- skos:scopeNote -->
-   <owl:AnnotationProperty rdf:about="skos:scopeNote"/>
    <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -492,21 +525,24 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAccumulationRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAccumulationRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record Resource or an Instantiation to an Agent, when
-            the Agent accumulates it, be it intentionally (collecting it) or not (receiving it in
-            the course of its activities).</rdfs:comment>
+         the Agent accumulates it, be it intentionally (collecting it) or not (receiving it in the
+         course of its activities).</rdfs:comment>
       <rdfs:label xml:lang="en">accumulated by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R028 ('accumulated by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#accumulates -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#accumulates">
@@ -516,113 +552,142 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAccumulationRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAccumulationRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'accumulates' object
-            property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'accumulates' object property</rdfs:comment>
       <rdfs:label xml:lang="en">accumulates </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R028i ('accumulates'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#accumulatedBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAccumulationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAccumulationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AccumulationRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
-      <rdfs:comment xml:lang="en">Connects an Accumulation Relation to one of the accumulated
-            Record Resources or Instantiations</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects an Accumulation Relation to one of the accumulated Record
+         Resources or Instantiations</rdfs:comment>
       <rdfs:label xml:lang="en">accumulation relation has source </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAccumulationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAccumulationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AccumulationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Accumulation Relation to one of the accumulating
-            Agents</rdfs:comment>
+         Agents</rdfs:comment>
       <rdfs:label xml:lang="en">accumulation relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfActivityDocumentationRelation"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfActivityDocumentationRelation"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <rdfs:comment xml:lang="en">Connects an Activity Documentation Relation to one of the
-            resulting Record Resources or Instantiations</rdfs:comment>
+         resulting Record Resources or Instantiations</rdfs:comment>
       <rdfs:label xml:lang="en">activity documentation relation has source </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#activityIsTargetOfActivityDocumentationRelation"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#activityIsTargetOfActivityDocumentationRelation"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
       <rdfs:comment xml:lang="en">Connects an Activity Documentation Relation to one of the
-            documented Activities</rdfs:comment>
+         documented Activities</rdfs:comment>
       <rdfs:label xml:lang="en">activity documentation relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#activityIsContextOfRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#activityIsContextOfRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#activityIsContextOfRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#asConcernsActivity"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <rdfs:comment xml:lang="en">Connects an Activity to an Agent Temporal Relation (when the
-            Activity is transferred from an Agent to another one) or a Mandate Relation (the Mandate
-            assigns the Activity to the Agent or defines it).</rdfs:comment>
+         Activity is transferred from an Agent to another one) or a Mandate Relation (the Mandate
+         assigns the Activity to the Agent or defines it).</rdfs:comment>
       <rdfs:label xml:lang="en">activity is context of relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#activityIsSourceOfPerformanceRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#activityIsSourceOfPerformanceRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#activityIsSourceOfPerformanceRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PerformanceRelation"/>
       <rdfs:comment xml:lang="en">Connects an Activity that is performed to a Performance
-            Relation</rdfs:comment>
+         Relation</rdfs:comment>
       <rdfs:label xml:lang="en">activity is source of performance relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#activityIsTargetOfActivityDocumentationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#activityIsTargetOfActivityDocumentationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#activityIsTargetOfActivityDocumentationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
-      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation"/>
+      <rdfs:range
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation"/>
       <rdfs:comment xml:lang="en">Connects an Activity to an Activity Documentation
-            Relation</rdfs:comment>
-      <rdfs:label xml:lang="en">activity is target of activity documentation relation
-        </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget"/>
+         Relation</rdfs:comment>
+      <rdfs:label xml:lang="en">activity is target of activity documentation relation </rdfs:label>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#affectedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#affectedBy">
@@ -633,7 +698,7 @@
       <rdfs:comment xml:lang="en">Inverse of 'affects' object property</rdfs:comment>
       <rdfs:label xml:lang="en">affected by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R059i ('affected by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#affects -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#affects">
@@ -641,38 +706,47 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an Event to a Thing that the Event has some significant
-            impact on.</rdfs:comment>
+         impact on.</rdfs:comment>
       <rdfs:label xml:lang="en">affects </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R059 ('affects'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#affectedBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentControlRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent Control Relation to one of the controlling
-            Agents</rdfs:comment>
+         Agents</rdfs:comment>
       <rdfs:label xml:lang="en">agent control relation has source </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentControlRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent Control Relation to one of the controlled
-            Agents</rdfs:comment>
+         Agents</rdfs:comment>
       <rdfs:label xml:lang="en">agent control relation has target </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">s</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentHasWorkRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentHasWorkRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#workRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#WorkRelation"/>
@@ -680,30 +754,42 @@
       <rdfs:label xml:lang="en">agent has work relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent Hierarchical Relation to one of the
-            hierarchically superior Agents</rdfs:comment>
+         hierarchically superior Agents</rdfs:comment>
       <rdfs:label xml:lang="en">agent hierarchical relation has source </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent Hierarchical Relation to one of the
-            hierarchically inferior Agents</rdfs:comment>
+         hierarchically inferior Agents</rdfs:comment>
       <rdfs:label xml:lang="en">agent hierarchical relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
@@ -711,51 +797,70 @@
       <rdfs:label xml:lang="en">agent is connected to agent relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentControlRelation"/>
       <rdfs:comment xml:lang="en">Connects a controlling Agent to an Agent Control
-            Relation</rdfs:comment>
+         Relation</rdfs:comment>
       <rdfs:label xml:lang="en">agent is source of agent control relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
-      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
-      <rdfs:comment xml:lang="en">Connects a hierarchically superior Agent to an Agent
-            Hierarchical Relation</rdfs:comment>
+      <rdfs:range
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
+      <rdfs:comment xml:lang="en">Connects a hierarchically superior Agent to an Agent Hierarchical
+         Relation</rdfs:comment>
       <rdfs:label xml:lang="en">agent is source of agent hierarchical relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
       <rdfs:comment xml:lang="en">Connects a predecessor Agent to an Agent Temporal
-            Relation</rdfs:comment>
+         Relation</rdfs:comment>
       <rdfs:label xml:lang="en">agent is source of agent temporal relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorityRelation"/>
       <rdfs:comment xml:lang="en">Connects an Agent thas has the authority, to an Authority
-            Relation</rdfs:comment>
+         Relation</rdfs:comment>
       <rdfs:label xml:lang="en">agent is source of authority relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsSourceOfIntellectualPropertyRightsRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfIntellectualPropertyRightsRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfIntellectualPropertyRightsRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -765,25 +870,32 @@
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
-      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation"/>
+      <rdfs:range
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation"/>
       <rdfs:comment xml:lang="en">Connects an Agent having the intellectual property rights, to an
-            Intellectual Property Rights Relation</rdfs:comment>
+         Intellectual Property Rights Relation</rdfs:comment>
       <rdfs:label xml:lang="en">agent is source of intellectual property rights relation
-        </rdfs:label>
+      </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ManagementRelation"/>
       <rdfs:comment xml:lang="en">Connects a manager Agent to a Management Relation</rdfs:comment>
       <rdfs:label xml:lang="en">agent is source of management relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsSourceOfOwnershipRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfOwnershipRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfOwnershipRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -798,99 +910,135 @@
       <rdfs:label xml:lang="en">agent is source of ownership relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsSourceOfRecordResourceHoldingRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfRecordResourceHoldingRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfRecordResourceHoldingRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
-      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation"/>
+      <rdfs:range
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation"/>
       <rdfs:comment xml:lang="en">Connects an Agent that holds a Record Resource or Instantiation,
-            to a Record Resource Holding Relation</rdfs:comment>
+         to a Record Resource Holding Relation</rdfs:comment>
       <rdfs:label xml:lang="en">agent is source of record resource holding relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAccumulationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAccumulationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAccumulationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AccumulationRelation"/>
       <rdfs:comment xml:lang="en">Connects one of the accumulating Agents to an Accumulation
-            Relation</rdfs:comment>
+         Relation</rdfs:comment>
       <rdfs:label xml:lang="en">agent is target of accumulation relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentControlRelation"/>
       <rdfs:comment xml:lang="en">Connects one of the controlled Agents to an Agent Control
-            Relation</rdfs:comment>
+         Relation</rdfs:comment>
       <rdfs:label xml:lang="en">agent is target of agent control relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
-      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
+      <rdfs:range
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
       <rdfs:comment xml:lang="en">Connects one of the hierarchically inferior Agents to an Agent
-            Hierarchical Relation</rdfs:comment>
+         Hierarchical Relation</rdfs:comment>
       <rdfs:label xml:lang="en">agent is target of agent hierarchical relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
-      <rdfs:comment xml:lang="en">Connects one of the Agents that created or accumulated the
-            Record resource or Instantiation, to an Agent Origination Relation</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects one of the Agents that created or accumulated the Record
+         resource or Instantiation, to an Agent Origination Relation</rdfs:comment>
       <rdfs:label xml:lang="en">agent is target of agent origination relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
       <rdfs:comment xml:lang="en">Connects a successor Agent to an Agent Temporal
-            Relation</rdfs:comment>
+         Relation</rdfs:comment>
       <rdfs:label xml:lang="en">agent is target of agent temporal relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsTargetOfCreationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfCreationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfCreationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#CreationRelation"/>
       <rdfs:comment xml:lang="en">Connects a creator Agent to a Creation Relation</rdfs:comment>
       <rdfs:label xml:lang="en">agent is target of creation relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsTargetOfMandateRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfMandateRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfMandateRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
       <rdfs:comment xml:lang="en">Connects a mandated Agent to a Mandate Relation</rdfs:comment>
       <rdfs:label xml:lang="en">agent is target of mandate relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsTargetOfPerformanceRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfPerformanceRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfPerformanceRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PerformanceRelation"/>
       <rdfs:comment xml:lang="en">Connects an Agent to a Performance Relation</rdfs:comment>
       <rdfs:label xml:lang="en">agent is target of performance relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -901,35 +1049,45 @@
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ProvenanceRelation"/>
       <rdfs:comment xml:lang="en">Connects an Agent or Activity that is the provenance of a Record
-            resource or Instantiation, to a Provenance Relation</rdfs:comment>
+         resource or Instantiation, to a Provenance Relation</rdfs:comment>
       <rdfs:label xml:lang="en">agent or activity is target of provenance relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <rdfs:comment xml:lang="en">Connects an Agent Origination Relation to one of the resulting
-            Record Resource or Instantiation</rdfs:comment>
+         Record Resource or Instantiation</rdfs:comment>
       <rdfs:label xml:lang="en">agent origination relation has source </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent Origination Relation to one of the creating or
-            accumulating Agents</rdfs:comment>
+         accumulating Agents</rdfs:comment>
       <rdfs:label xml:lang="en">agent origination relation has target </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentRelationConnects -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentRelationConnects">
@@ -937,159 +1095,206 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent Relation to one of the involved
-            Agents</rdfs:comment>
+         Agents</rdfs:comment>
       <rdfs:label xml:lang="en">agent relation connects </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfAgentSubordinationRelation"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentSubordinationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfAgentSubordinationRelation"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentSubordinationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects an Agent Subordination Relation to one of the
-            hierarchically superior Persons</rdfs:comment>
+         hierarchically superior Persons</rdfs:comment>
       <rdfs:label xml:lang="en">agent subordination relation has source </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfAgentSubordinationRelation"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentSubordinationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfAgentSubordinationRelation"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentSubordinationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects an Agent Subordination Relation to one of the
-            hierarchically inferior Persons</rdfs:comment>
+         hierarchically inferior Persons</rdfs:comment>
       <rdfs:label xml:lang="en">agent subordination relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent Temporal Relation to one of the predecessor
-            Agents</rdfs:comment>
+         Agents</rdfs:comment>
       <rdfs:label xml:lang="en">agent temporal relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent Temporal Relation to one of the successor
-            Agents</rdfs:comment>
+         Agents</rdfs:comment>
       <rdfs:label xml:lang="en">agent temporal relation has target </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#appellationIsSourceOfAppellationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#appellationIsSourceOfAppellationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#appellationIsSourceOfAppellationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AppellationRelation"/>
-      <rdfs:comment xml:lang="en">Connects an Appellation to an Appellation
-            Relation</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects an Appellation to an Appellation Relation</rdfs:comment>
       <rdfs:label xml:lang="en">appellation is source of appellation relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AppellationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
       <rdfs:comment xml:lang="en">Connects an Appellation Relation to the concerned
-            Appellation</rdfs:comment>
+         Appellation</rdfs:comment>
       <rdfs:label xml:lang="en">appellation relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationIsSourceOfAppellationRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationIsSourceOfAppellationRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#appellationRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#appellationRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAppellationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#appellationRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAppellationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AppellationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an Appellation Relation to one of the designated
-            Things</rdfs:comment>
+         Things</rdfs:comment>
       <rdfs:label xml:lang="en">appellation relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#asConcernsActivity -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#asConcernsActivity">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
       <rdfs:comment xml:lang="en">Connects an Agent Temporal Relation or Mandate Relation, to an
-            Activity that is, either transferred from an Agent to another one, or assigned by a
-            Mandate to an Agent.</rdfs:comment>
+         Activity that is, either transferred from an Agent to another one, or assigned by a Mandate
+         to an Agent.</rdfs:comment>
       <rdfs:label xml:lang="en">as concerns activity </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#activityIsContextOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#activityIsContextOfRelation"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorityRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Authority Relation to an Agent that has the
-            authority</rdfs:comment>
+         authority</rdfs:comment>
       <rdfs:label xml:lang="en">authority relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorityRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <rdfs:comment xml:lang="en">Connects an Authority Relation to a Thing over which the
-            Authority is performed</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects an Authority Relation to a Thing over which the Authority
+         is performed</rdfs:comment>
       <rdfs:label xml:lang="en">authority relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#authorizedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#authorizedBy">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorizes"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Mandate"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfMandateRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfMandateRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'authorizes' object property</rdfs:comment>
       <rdfs:label xml:lang="en">authorized by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R067i ('authorizedBy'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#authorizes -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#authorizes">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Mandate"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#mandateIsSourceOfMandateRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#mandateIsSourceOfMandateRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Mandate to the Agent that the Mandate gives the
-            authority or competencies to act.</rdfs:comment>
+         authority or competencies to act.</rdfs:comment>
       <rdfs:label xml:lang="en">authorizes </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R067 ('authorizes'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorizedBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#authorizingAgent -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#authorizingAgent">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAuthorizingAgentInMandateRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAuthorizingAgentInMandateRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Mandate Relation to an Agent that assigns the
-            Mandate.</rdfs:comment>
+         Mandate.</rdfs:comment>
       <rdfs:label xml:lang="en">authorizing agent </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#belongsToCategory -->
@@ -1099,26 +1304,32 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTypeRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#typeRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTypeRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#typeRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Thing to a Type that categorizes it</rdfs:comment>
       <rdfs:label xml:lang="en">belongs to category </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#belongsToDemographicGroup -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#belongsToDemographicGroup">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#belongsToDemographicGroup">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDemographicGroupOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#DemographicGroup"/>
       <rdfs:comment xml:lang="en">Connects a Person to a Demographic Group to which it
-            belongs.</rdfs:comment>
+         belongs.</rdfs:comment>
       <rdfs:label xml:lang="en">belongs to demographic group </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#childRelationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#childRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfChildRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfChildRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ChildRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Child Relation to a parent Person</rdfs:comment>
@@ -1126,8 +1337,10 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#childRelationHasTarget -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#childRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfChildRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfChildRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ChildRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Child Relation to a child Person</rdfs:comment>
@@ -1141,16 +1354,17 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource or an Instantiation to the Agent that
-            collects it intentionally (is a collector).</rdfs:comment>
+         collects it intentionally (is a collector).</rdfs:comment>
       <rdfs:label xml:lang="en">collected by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R030 ('collected by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#collects -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#collects">
@@ -1160,84 +1374,97 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
-      <rdfs:comment xml:lang="en">Inverse of 'collected by' object
-            property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'collected by' object property</rdfs:comment>
       <rdfs:label xml:lang="en">collects </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R030i ('collects'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#collectedBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#containedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#containedBy">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOf"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#contains"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
-      <rdfs:comment xml:lang="en">Inverse of 'contained by' object
-            property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'contained by' object property</rdfs:comment>
       <rdfs:label xml:lang="en">contained by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R007i ('contained by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#contains -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#contains">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPart"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:comment xml:lang="en">Connects a Place to a region within.</rdfs:comment>
       <rdfs:label xml:lang="en">contains </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R007 ('contains'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#containedBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#controlledBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#controlledBy">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isHierarchicallyInferiorTo"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isUnderAuthorityOf"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isHierarchicallyInferiorTo"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isUnderAuthorityOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#controls"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'controls' object property</rdfs:comment>
       <rdfs:label xml:lang="en">controlled by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R041i ('controlled by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#controls -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#controls">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasAuthorityOver"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isHierarchicallySuperiorTo"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isHierarchicallySuperiorTo"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Agent to another Agent it controls </rdfs:comment>
       <rdfs:label xml:lang="en">controls </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R041 ('controls'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#controlledBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasCorrespondenceRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasCorrespondenceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#CorrespondenceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Correspondence Relation to one of the Persons
-            involved</rdfs:comment>
+         involved</rdfs:comment>
       <rdfs:label xml:lang="en">correspondence relation connects </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#createdBy -->
@@ -1248,113 +1475,144 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
-      <rdfs:comment xml:lang="en">Connects a Record Resource or an Instantiation to an Agent that
-            is either responsible for all or some of the content of the Record Resource or is a
-            contributor to the genesis or production of an Instantiation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Record Resource or an Instantiation to an Agent that is
+         either responsible for all or some of the content of the Record Resource or is a
+         contributor to the genesis or production of an Instantiation.</rdfs:comment>
       <rdfs:label xml:lang="en">created by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R027 ('created by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#createdByMigrationFromInstantiation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#createdByMigrationFromInstantiation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDerivedFromInstantiation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isMigratedIntoInstantiation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#createdByMigrationFromInstantiation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDerivedFromInstantiation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isMigratedIntoInstantiation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfMigrationRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfMigrationRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is migrated into instantiation' object
-            property</rdfs:comment>
+         property</rdfs:comment>
       <rdfs:label xml:lang="en">created by migration from instantiation </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R015i ('created by migration from
-            instantiation' relation)</RiCCMCorrespondingComponent>
+         instantiation' relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#creationRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfCreationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfCreationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#CreationRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <rdfs:comment xml:lang="en">Connects a Creation Relation to one of the created Record
-            Resources or Instantiations</rdfs:comment>
+         Resources or Instantiations</rdfs:comment>
       <rdfs:label xml:lang="en">creation relation has source </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#creationRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#creationRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#creationRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#CreationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Creation Relation to one of the creator
-            Agents</rdfs:comment>
+         Agents</rdfs:comment>
       <rdfs:label xml:lang="en">creation relation has target </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfCreationRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfCreationRelation"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#creationWithRole -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#creationWithRole">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#roleIsContextOfCreationRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#roleIsContextOfCreationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#CreationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RoleType"/>
       <rdfs:comment xml:lang="en">Connects a Creation Relation to the Role Type that the creator
-            Agent(s) has in the creation process</rdfs:comment>
+         Agent(s) has in the creation process</rdfs:comment>
       <rdfs:label xml:lang="en">creation with role </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#DerivationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-      <rdfs:comment xml:lang="en">Connects a Derivation Relation to the Instantiation from which
-            one or more Instantiations is derived.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Derivation Relation to the Instantiation from which one
+         or more Instantiations is derived.</rdfs:comment>
       <rdfs:label xml:lang="en">derivation relation has source </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfDerivationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfDerivationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#DerivationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects a Derivation Relation to one of the derived
-            Instantiations</rdfs:comment>
+         Instantiations</rdfs:comment>
       <rdfs:label xml:lang="en">derivation relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#DescendanceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Descendance Relation to one of the ancestor
-            Persons</rdfs:comment>
+         Persons</rdfs:comment>
       <rdfs:label xml:lang="en">descendance relation has source </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#DescendanceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Descendance Relation to one of the descendant
-            Persons</rdfs:comment>
+         Persons</rdfs:comment>
       <rdfs:label xml:lang="en">descendance relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#describedBy -->
@@ -1366,7 +1624,7 @@
       <rdfs:comment xml:lang="en">Inverse of 'describes' object property</rdfs:comment>
       <rdfs:label xml:lang="en">described by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R021i (described by
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#describes -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#describes">
@@ -1374,13 +1632,12 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource to a Thing that it
-            describes</rdfs:comment>
+         describes</rdfs:comment>
       <rdfs:label xml:lang="en">describes </rdfs:label>
       <skos:scopeNote xml:lang="en">Can be used, among other situations, for specifying that some
-            finding aid (a Record that has Documentary Form Type Finding Aid) describes some Record
-            Set.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">RiC-R021
-            (describes)</RiCCMCorrespondingComponent>
+         finding aid (a Record that has Documentary Form Type Finding Aid) describes some Record
+         Set.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">RiC-R021 (describes)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#describedBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#documentedBy -->
@@ -1392,32 +1649,36 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
-      <rdfs:comment xml:lang="en">Inverse of 'is documentation of' object
-            property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is documentation of' object property</rdfs:comment>
       <rdfs:label xml:lang="en">documented by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R033i ('documented by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#enforcedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#enforcedBy">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isResponsibleForEnforcing"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isResponsibleForEnforcing"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
-      <rdfs:comment xml:lang="en">Connects a Rule to an Agent that enforces the
-            Rule.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Rule to an Agent that enforces the Rule.</rdfs:comment>
       <rdfs:label xml:lang="en">enforced by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R066 ('enforced by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#eventIsSourceOfEventRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#eventIsSourceOfEventRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#eventRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#eventIsSourceOfEventRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#eventRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#EventRelation"/>
       <rdfs:comment xml:lang="en">Connects an Event to an Event Relation</rdfs:comment>
@@ -1425,17 +1686,21 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#eventRelationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#eventRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#EventRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:comment xml:lang="en">Connects an Event Relation to an Event</rdfs:comment>
       <rdfs:label xml:lang="en">event relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#eventIsSourceOfEventRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#eventIsSourceOfEventRelation"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#eventRelationHasTarget -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#eventRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfEventRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfEventRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#EventRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an Event Relation to an associated Thing</rdfs:comment>
@@ -1443,48 +1708,55 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#existsIn -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#existsIn">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPosition"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsSourceOfPositionToGroupRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsSourceOfPositionToGroupRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget"
+         />
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Position to a Group that position exists in, or is
-            defined by, that Group’s organizational structure.</rdfs:comment>
+         defined by, that Group’s organizational structure.</rdfs:comment>
       <rdfs:label xml:lang="en">exists in </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R056 ('exists in'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#expressedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#expressedBy">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#expresses"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:comment xml:lang="en">Connects a Rule to a Record Resource that expresses the
-            Rule.</rdfs:comment>
+         Rule.</rdfs:comment>
       <rdfs:label xml:lang="en">expressed by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R064 ('expressed by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#expresses -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#expresses">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
-      <rdfs:comment xml:lang="en">Inverse of 'expressed by' object
-            property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'expressed by' object property</rdfs:comment>
       <rdfs:label xml:lang="en">expresses </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R064i ('expresses'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#expressedBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#familyRelationConnects -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#familyRelationConnects">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#FamilyRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Family Relation to a Person.</rdfs:comment>
@@ -1497,13 +1769,15 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'precedes' object property</rdfs:comment>
       <rdfs:label xml:lang="en">follows </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R008i ('follows'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#followsInTime -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#followsInTime">
@@ -1512,109 +1786,146 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'precedes in time' object
-            property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'precedes in time' object property</rdfs:comment>
       <rdfs:label xml:lang="en">follows in time </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R009i ('follows in time'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToFunctionalEquivalenceRelation"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#FunctionalEquivalenceRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToFunctionalEquivalenceRelation"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#FunctionalEquivalenceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects a Functional Equivalence Relation to one of the
-            functionally equivalent Instantiations.</rdfs:comment>
+         functionally equivalent Instantiations.</rdfs:comment>
       <rdfs:label xml:lang="en">functional equivalence relation connects </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#groupIsSourceOfGroupSubdivisionRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfGroupSubdivisionRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfGroupSubdivisionRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#GroupSubdivisionRelation"/>
       <rdfs:comment xml:lang="en">Connects the Group that has at least a subdivision, to a Group
-            Subdivision Relation</rdfs:comment>
+         Subdivision Relation</rdfs:comment>
       <rdfs:label xml:lang="en">group is source of group subdivision relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#groupIsSourceOfMembershipRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfMembershipRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfMembershipRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#MembershipRelation"/>
-      <rdfs:comment xml:lang="en">Connects the Group (that has one to many members) to a
-            Membership Relation</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects the Group (that has one to many members) to a Membership
+         Relation</rdfs:comment>
       <rdfs:label xml:lang="en">group is source of membership relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#groupIsTargetOfGroupSubdivisionRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfGroupSubdivisionRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfGroupSubdivisionRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#GroupSubdivisionRelation"/>
       <rdfs:comment xml:lang="en">Connects a Group that is a subdivision, to a Group Subdivision
-            Relation</rdfs:comment>
+         Relation</rdfs:comment>
       <rdfs:label xml:lang="en">group is target of group subdivision relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#groupIsTargetOfLeadershipRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfLeadershipRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfLeadershipRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#LeadershipRelation"/>
       <rdfs:comment xml:lang="en">Connects a Group (which has a leader) to a Leadership
-            Relation</rdfs:comment>
+         Relation</rdfs:comment>
       <rdfs:label xml:lang="en">group is target of leadership relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#groupIsTargetOfPositionToGroupRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfPositionToGroupRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfPositionToGroupRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PositionToGroupRelation"/>
       <rdfs:comment xml:lang="en">Connects the Group (in which a Position exists) to a Position To
-            Group Relation</rdfs:comment>
+         Group Relation</rdfs:comment>
       <rdfs:label xml:lang="en">group is target of position to group relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#GroupSubdivisionRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#GroupSubdivisionRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:comment xml:lang="en">Connects a Group Subdivision Relation to the Group that has
-            subdivisions</rdfs:comment>
+         subdivisions</rdfs:comment>
       <rdfs:label xml:lang="en">group subdivision relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfGroupSubdivisionRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfGroupSubdivisionRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#GroupSubdivisionRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#GroupSubdivisionRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
-      <rdfs:comment xml:lang="en">Connects a Group Subdivision Relation to one of the Groups that
-            is a subdivision</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Group Subdivision Relation to one of the Groups that is
+         a subdivision</rdfs:comment>
       <rdfs:label xml:lang="en">group subdivision relation has target </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfGroupSubdivisionRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfGroupSubdivisionRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasActivityType -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasActivityType">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isActivityTypeOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityType"/>
       <rdfs:comment xml:lang="en">Connects an Activity to an Activity Type that categorizes
-            it.</rdfs:comment>
+         it.</rdfs:comment>
       <rdfs:label xml:lang="en">has activity type </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasAddressee -->
@@ -1625,16 +1936,17 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource or an Instantiation to the Agent that
-            it is addressed to.</rdfs:comment>
+         it is addressed to.</rdfs:comment>
       <rdfs:label xml:lang="en">has addressee </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R032 ('has addressee'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasAgentName -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasAgentName">
@@ -1647,20 +1959,22 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasAncestor -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasAncestor">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyLinkWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyLinkWith"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isSuccessorOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDescendant"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'has descendant' object
-            property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'has descendant' object property</rdfs:comment>
       <rdfs:label xml:lang="en">has ancestor </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R017i (has ancestor
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasAppellation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasAppellation">
@@ -1669,11 +1983,13 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAppellationRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAppellationRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Thing to an Appellation that is used for designating
-            it.</rdfs:comment>
+         it.</rdfs:comment>
       <rdfs:label xml:lang="en">has appellation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasAuthorityOver -->
@@ -1683,26 +1999,28 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Agent to a Thing the Agent has authority
-            over</rdfs:comment>
+         over</rdfs:comment>
       <rdfs:label xml:lang="en">has authority over </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R036 ('has authority over'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasBeginningDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasBeginningDate">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
-      <rdfs:comment xml:lang="en">Inverse of 'is beginning date of' object
-            property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is beginning date of' object property</rdfs:comment>
       <rdfs:label xml:lang="en">has beginning date </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R069i ('has beginning date'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasBirthDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasBirthDate">
@@ -1710,20 +2028,20 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isBirthDateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
-      <rdfs:comment xml:lang="en">Inverse of 'is birth date of' object
-            property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is birth date of' object property</rdfs:comment>
       <rdfs:label xml:lang="en">has birth date </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R070i ('has birth date'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasCarrierType -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasCarrierType">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isCarrierTypeOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#CarrierType"/>
-      <rdfs:comment xml:lang="en">Connects an Instantiation to a Carrier Type which categorizes
-            its carrier.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects an Instantiation to a Carrier Type which categorizes its
+         carrier.</rdfs:comment>
       <rdfs:label xml:lang="en">has carrier type </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasChild -->
@@ -1733,48 +2051,52 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfChildRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#childRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfChildRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#childRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Person to one of their children.</rdfs:comment>
       <rdfs:label xml:lang="en">has child </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R018 ('has child'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasComponent -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasComponent">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPart"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isComponentOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-      <rdfs:comment xml:lang="en">Connects an Instantiation to one of its
-            components.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects an Instantiation to one of its components.</rdfs:comment>
       <rdfs:label xml:lang="en">has component </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R004 ('has component'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasConstituent -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasConstituent">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPart"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isConstituentOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Record"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordPart"/>
       <rdfs:comment xml:lang="en">Connects a Record to a component part of that
-            Record.</rdfs:comment>
+         Record.</rdfs:comment>
       <rdfs:label xml:lang="en">has constituent </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R003 (has 'constituent'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasContentOfType -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasContentOfType">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isContentTypeOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ContentType"/>
       <rdfs:comment xml:lang="en">Connects a Recourd Resource to a Content Type which categorizes
-            its content.</rdfs:comment>
+         its content.</rdfs:comment>
       <rdfs:label xml:lang="en">has content of type </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasCoordinates -->
@@ -1784,30 +2106,32 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PhysicalLocation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Coordinates"/>
       <rdfs:comment xml:lang="en">Connects a Physical Location to its coordinates in a reference
-            system.</rdfs:comment>
+         system.</rdfs:comment>
       <rdfs:label xml:lang="en">has coordinates </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasCopy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasCopy">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInTime"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isCopyOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource to a copy of that Record
-            Resource.</rdfs:comment>
+         Resource.</rdfs:comment>
       <rdfs:label xml:lang="en">has copy </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R012 ('has copy'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasCorporateBodyType -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasCorporateBodyType">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isCorporateBodyTypeOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#CorporateBody"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#CorporateBodyType"/>
       <rdfs:comment xml:lang="en">Connects a Corporate Body to a Corporate Body Type which
-            categorizes it.</rdfs:comment>
+         categorizes it.</rdfs:comment>
       <rdfs:label xml:lang="en">has corporate body type </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasCorrespondent -->
@@ -1817,14 +2141,16 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personHasCorrespondenceRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#personHasCorrespondenceRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Persons that correspond or have corresponded with
-            each other. This relation is symmetric.</rdfs:comment>
+         each other. This relation is symmetric.</rdfs:comment>
       <rdfs:label xml:lang="en">has correspondent </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R052 ('has correspondent'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasDeathDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasDeathDate">
@@ -1832,49 +2158,58 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDeathDateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
-      <rdfs:comment xml:lang="en">Inverse of 'is death date of' object
-            property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is death date of' object property</rdfs:comment>
       <rdfs:label xml:lang="en">has death date </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R072i ('has death date'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasDerivedInstantiation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasDerivedInstantiation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#hasDerivedInstantiation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInTime"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDerivedFromInstantiation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDerivedFromInstantiation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Connects an Instantiation to an Instantiation that is derived
-            from it.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects an Instantiation to an Instantiation that is derived from
+         it.</rdfs:comment>
       <rdfs:label xml:lang="en">has derived instantiation </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R014 ('has derived instantiation'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasDescendant -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasDescendant">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyLinkWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyLinkWith"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAntecedentOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Person to one of their descendants.</rdfs:comment>
       <rdfs:label xml:lang="en">has descendant </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R017 ('has descendant'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasAncestor"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasDocumentaryFormType -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasDocumentaryFormType">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDocumentaryFormTypeOf"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDocumentaryFormTypeOf"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -1885,13 +2220,14 @@
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#DocumentaryFormType"/>
       <rdfs:comment xml:lang="en">Connects a Record or Record Part to its Documentary Form
-            Type.</rdfs:comment>
+         Type.</rdfs:comment>
       <rdfs:label xml:lang="en">has documentary form type </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasDraft -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasDraft">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInTime"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDraftOf"/>
       <rdfs:domain>
          <owl:Class>
@@ -1909,75 +2245,97 @@
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
-      <rdfs:comment xml:lang="en">Inverse of 'is draft of' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is draft of' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">has draft </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-011i ('has draft'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasEndDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasEndDate">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isEndDateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
-      <rdfs:comment xml:lang="en">Inverse of 'is end date of' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is end date of' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">has end date </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R071i ('has end date'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasEventType -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasEventType">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventTypeOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#EventType"/>
       <rdfs:comment xml:lang="en">Connects an Event to an Event Type which categorizes
-            it.</rdfs:comment>
+         it.</rdfs:comment>
       <rdfs:label xml:lang="en">has event type </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasFamilyLinkWith -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasFamilyLinkWith">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Persons that have some type of family link, i.e.
-            belong to the same family. This relation is symmetric.</rdfs:comment>
+         belong to the same family. This relation is symmetric.</rdfs:comment>
       <rdfs:label xml:lang="en">has family link with </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R047 ('has family link with'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasFamilyType -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasFamilyType">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isFamilyTypeOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Family"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#FamilyType"/>
       <rdfs:comment xml:lang="en">Connects a Family to a Family Type that categorizes
-            it.</rdfs:comment>
+         it.</rdfs:comment>
       <rdfs:label xml:lang="en">has family type </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-      <rdfs:comment xml:lang="en">Connects two Record Resources when there is a genetic link
-            between them. Genetic in this sense is as defined by diplomatics, i.e. the process by
-            which a Record Resource is developed. This relation is symmetric.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects two Record Resources when there is a genetic link between
+         them. Genetic in this sense is as defined by diplomatics, i.e. the process by which a
+         Record Resource is developed. This relation is symmetric.</rdfs:comment>
       <rdfs:label xml:lang="en">has genetic link to record resource </rdfs:label>
       <skos:scopeNote xml:lang="en">Use to connect two Record Resources only if it is not possible
-            to be more accurate and specify a narrower, asymmetric relation, e.g. ‘is original
-            of’.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">RiC-R023 ('has genetic link to record
-            resource' relation)</RiCCMCorrespondingComponent>
+         to be more accurate and specify a narrower, asymmetric relation, e.g. ‘is original
+         of’.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">RiC-R023 ('has genetic link to record resource'
+         relation)</RiCCMCorrespondingComponent>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#hasIdentifierType -->
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasIdentifierType">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isIdentifierTypeOf"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Identifier"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#IdentifierType"/>
+      <rdfs:comment xml:lang="en">Connects an Identifier and an Identifier Type that categorizes
+         it.</rdfs:comment>
+      <rdfs:label xml:lang="en">has identifier type</rdfs:label>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Object property added along with IdentifierType class and isIdentifierTypeOf
+            object property.</rdf:value>
+         <dc:date>2020-10-19</dc:date>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasInstantiation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasInstantiation">
@@ -1986,19 +2344,24 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsSourceOfRecordResourceToInstantiationRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsSourceOfRecordResourceToInstantiationRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget"
+         />
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record Resource to one of its
-            Instantiations.</rdfs:comment>
+         Instantiations.</rdfs:comment>
       <rdfs:label xml:lang="en">has instantiation </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R025 ('has instantiation'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasIntellectualPropertyRightsOn -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasIntellectualPropertyRightsOn">
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#hasIntellectualPropertyRightsOn">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasAuthorityOver"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsHeldBy"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsHeldBy"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -2012,31 +2375,35 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfIntellectualPropertyRightsRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfIntellectualPropertyRightsRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget"
+         />
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Person, Group or Position to a Record Resource or
-            Instantiation on which the Agent has some intellectual property rights</rdfs:comment>
+         Instantiation on which the Agent has some intellectual property rights</rdfs:comment>
       <rdfs:label xml:lang="en">has intellectual property rights on </rdfs:label>
-      <RiCCMCorrespondingComponent xml:lang="en">RiC-R040 ('has intellectual property rights
-            on' relation)</RiCCMCorrespondingComponent>
+      <RiCCMCorrespondingComponent xml:lang="en">RiC-R040 ('has intellectual property rights on'
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasJurisdiction -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasJurisdiction">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isJurisdictionOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
-      <rdfs:comment xml:lang="en">Inverse of 'is jurisdiction of' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is jurisdiction of' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">has jurisdiction </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R076i ('has jurisdiction'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasLanguage -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasLanguage">
@@ -2046,43 +2413,46 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Agent"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Language"/>
       <rdfs:comment xml:lang="en">Connects an Agent or Record Resource to a Language that it
-            uses.</rdfs:comment>
+         uses.</rdfs:comment>
       <rdfs:label xml:lang="en">has language </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasLegalStatus -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasLegalStatus">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isLegalStatusOf"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Agent"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#LegalStatus"/>
       <rdfs:comment xml:lang="en">Connects an Agent or Record Resource to a Legal Status which
-            categorizes it.</rdfs:comment>
+         categorizes it.</rdfs:comment>
       <rdfs:label xml:lang="en">has legal status </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasLocation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasLocation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isLocationOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
-      <rdfs:comment xml:lang="en">Inverse of 'is location of' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is location of' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">has location </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R075i ('has location'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasMainSubject -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasMainSubject">
@@ -2091,41 +2461,45 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource to a Thing that is its main
-            subject.</rdfs:comment>
+         subject.</rdfs:comment>
       <rdfs:label xml:lang="en">has main subject </rdfs:label>
       <skos:scopeNote xml:lang="en">Use for specifying, for example, that a Record Set of type
-            personal file has main subject some person, which would help end users to retrieve the
-            main archival resources about this person.</skos:scopeNote>
+         personal file has main subject some person, which would help end users to retrieve the main
+         archival resources about this person.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R020 ('has main subject'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasMember -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasMember">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isMemberOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfMembershipRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfMembershipRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Group to a Person that is a member of that
-            Group.</rdfs:comment>
+         Group.</rdfs:comment>
       <rdfs:label xml:lang="en">has member </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R055 ('has member'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasModificationDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasModificationDate">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isModificationDateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:comment xml:lang="en">Inverse of 'is modification date of' object
-            property.</rdfs:comment>
+         property.</rdfs:comment>
       <rdfs:label xml:lang="en">has modification date </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R073i ('has modification date'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasName -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasName">
@@ -2138,18 +2512,20 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOccupationOfType -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOccupationOfType">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToDemographicGroup"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToDemographicGroup"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOccupationTypeOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#OccupationType"/>
       <rdfs:comment xml:lang="en">Connects a Person to an Occupation Type that categorizes his/her
-            occupation (profession, trade or craft).</rdfs:comment>
+         occupation (profession, trade or craft).</rdfs:comment>
       <rdfs:label xml:lang="en">has occupation of type </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOriginal -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOriginal">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInTime"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOriginalOf"/>
       <rdfs:domain>
          <owl:Class>
@@ -2167,22 +2543,20 @@
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
-      <rdfs:comment xml:lang="en">Inverse of 'is original of' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is original of' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">has original </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R010i (is original of
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasParent -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasParent">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasAncestor"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
-      <rdfs:comment xml:lang="en">Inverse of 'is parent of' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is parent of' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">has parent </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R018i (has parent
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasChild"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasPart -->
@@ -2192,16 +2566,18 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Thing to a constitutive or component part of that
-            Thing.</rdfs:comment>
+         Thing.</rdfs:comment>
       <rdfs:label xml:lang="en">has part </rdfs:label>
       <skos:scopeNote xml:lang="en">The end of existence of a whole/part relation may affect the
-            integrity or nature of the domain entity</skos:scopeNote>
+         integrity or nature of the domain entity</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R002 (has part
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasPhysicalLocation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasPhysicalLocation">
@@ -2223,33 +2599,38 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasPlaceType -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasPlaceType">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceTypeOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PlaceType"/>
       <rdfs:comment xml:lang="en">Connects a Place to a Place Type that categorizes
-            it.</rdfs:comment>
+         it.</rdfs:comment>
       <rdfs:label xml:lang="en">has place type </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasPosition -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasPosition">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:comment xml:lang="en">Inverse of 'exists in' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">has position </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R056i ('has position'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#existsIn"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasProductionTechniqueType -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasProductionTechniqueType">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isProductionTechniqueTypeOf"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#hasProductionTechniqueType">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isProductionTechniqueTypeOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ProductionTechniqueType"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation to a Production Technique Type that
-            categorizes its production technique.</rdfs:comment>
+         categorizes its production technique.</rdfs:comment>
       <rdfs:label xml:lang="en">has production technique type </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasProvenance -->
@@ -2260,50 +2641,74 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"
+         />
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record Resource or an Instantiation to an Agent that
-            creates or accumulates the Record Resource, receives it, or sends it.</rdfs:comment>
+         creates or accumulates the Record Resource, receives it, or sends it.</rdfs:comment>
       <rdfs:label xml:lang="en">has provenance </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R026 ('has provenance'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasRecordResourceState -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasRecordResourceState">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceStateOf"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceStateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceState"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource to a Record Resource State that
-            categorizes its state.</rdfs:comment>
+         categorizes its state.</rdfs:comment>
       <rdfs:label xml:lang="en">has record resource state </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasRecordSetType -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasRecordSetType">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordSetTypeOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSetType"/>
       <rdfs:comment xml:lang="en">Connects a Record Set to a Record Set Type that categorizes
-            it.</rdfs:comment>
+         it.</rdfs:comment>
       <rdfs:label xml:lang="en">has record set type </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasRepresentationType -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasRepresentationType">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRepresentationTypeOf"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRepresentationTypeOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RepresentationType"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation to a Representation Type that
-            categorizes its representation type.</rdfs:comment>
+         categorizes its representation type.</rdfs:comment>
       <rdfs:label xml:lang="en">has representation type </rdfs:label>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#hasRuleType -->
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasRuleType">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleTypeOf"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RuleType"/>
+      <rdfs:comment xml:lang="en">Connects a Rule to a Rule Type that categorizes it.</rdfs:comment>
+      <rdfs:label xml:lang="en">has rule type</rdfs:label>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Object property added along with RuleType class and isRuleTypeOf object
+            property.</rdf:value>
+         <dc:date>2020-10-19</dc:date>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasSender -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasSender">
@@ -2313,32 +2718,36 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource or an Instantiation to the Agent that
-            sends it</rdfs:comment>
+         sends it</rdfs:comment>
       <rdfs:label xml:lang="en">has sender </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R031 ('has sender'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasSibling -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasSibling">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyLinkWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyLinkWith"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSiblingRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#siblingRelationConnects"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSiblingRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#siblingRelationConnects"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Persons that are siblings. This relation is
-            symmetric.</rdfs:comment>
+         symmetric.</rdfs:comment>
       <rdfs:label xml:lang="en">has sibling </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R048 ('has sibling'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasSource">
@@ -2347,7 +2756,8 @@
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Relation"/>
             </owl:unionOf>
          </owl:Class>
@@ -2356,30 +2766,34 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Agent"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <rdfs:comment xml:lang="en">Connects a Record Resource or Relation to a Record Resource or
-            Agent that is used as a source of information for identifying or describing
-            it.</rdfs:comment>
+         Agent that is used as a source of information for identifying or describing
+         it.</rdfs:comment>
       <rdfs:label xml:lang="en">has source </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasSpouse -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasSpouse">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyLinkWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyLinkWith"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSpouseRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#spouseRelationConnects"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSpouseRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#spouseRelationConnects"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Persons that are or were married. This relation is
-            symmetric.</rdfs:comment>
+         symmetric.</rdfs:comment>
       <rdfs:label xml:lang="en">has spouse </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R049 ('has spouse'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasStudent -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasStudent">
@@ -2388,46 +2802,53 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfTeachingRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfTeachingRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'has teacher' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'has teacher' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">has student </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R053i ('has student'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasSubEvent -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasSubEvent">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPart"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isSubEventOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
-      <rdfs:comment xml:lang="en">Connects an Event to one of a series of Events that constitute
-            the original, broader Event.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects an Event to one of a series of Events that constitute the
+         original, broader Event.</rdfs:comment>
       <rdfs:label xml:lang="en">has sub event </rdfs:label>
-      <skos:scopeNote xml:lang="en">Since an Activity is a kind of Event, this Relation can also
-            be used for Activity.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Since an Activity is a kind of Event, this Relation can also be
+         used for Activity.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R006 ('has subevent'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasSubdivision -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasSubdivision">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPart"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isHierarchicallySuperiorTo"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isHierarchicallySuperiorTo"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isSubdivisionOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfGroupSubdivisionRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfGroupSubdivisionRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget"
+         />
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Group to one of its subdivisions.</rdfs:comment>
       <rdfs:label xml:lang="en">has subdivision </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R005 ('has subdivision'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasSubject -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasSubject">
@@ -2436,10 +2857,10 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource to a Thing that is its
-            subject.</rdfs:comment>
+         subject.</rdfs:comment>
       <rdfs:label xml:lang="en">has subject </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R019 ('has subject'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasTeacher -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasTeacher">
@@ -2447,14 +2868,16 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfTeachingRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfTeachingRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Person to another Person who is their
-            student.</rdfs:comment>
+         student.</rdfs:comment>
       <rdfs:label xml:lang="en">has teacher </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R053 ('has teacher'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasStudent"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasTitle -->
@@ -2465,31 +2888,35 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Rule"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Title"/>
-      <rdfs:comment xml:lang="en">Connects a Record Resource, Instantiation or Rule to a title
-            that is used for designating it.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Record Resource, Instantiation or Rule to a title that
+         is used for designating it.</rdfs:comment>
       <rdfs:label xml:lang="en">has title </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasWorkRelationWith -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasWorkRelationWith">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentHasWorkRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#workRelationConnects"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentHasWorkRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#workRelationConnects"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Agents that have some type of work relation in the
-            course of their activities. This relation is symmetric.</rdfs:comment>
+         course of their activities. This relation is symmetric.</rdfs:comment>
       <rdfs:label xml:lang="en">has work relation with </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R046 ('has work relation with'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#heldBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#heldBy">
@@ -2499,20 +2926,23 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfRecordResourceHoldingRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfRecordResourceHoldingRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource"
+         />
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'is holder of' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is holder of' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">held by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R039i ('held by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#identifiedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#identifiedBy">
@@ -2529,13 +2959,14 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Identifier"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an Identifier to a Thing that it
-            identifies.</rdfs:comment>
+         identifies.</rdfs:comment>
       <rdfs:label xml:lang="en">identifies </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#identifiedBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#includedIn -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#includedIn">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#includes"/>
       <rdfs:domain>
          <owl:Class>
@@ -2549,11 +2980,12 @@
       <rdfs:comment xml:lang="en">Inverse of 'includes' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">included in </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R024i ('included in'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#includes -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#includes">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range>
          <owl:Class>
@@ -2564,12 +2996,12 @@
          </owl:Class>
       </rdfs:range>
       <rdfs:comment xml:lang="en">Connects a Record Set to a Record or Record Set it aggregates or
-            contains</rdfs:comment>
+         contains</rdfs:comment>
       <rdfs:label xml:lang="en">includes </rdfs:label>
       <skos:scopeNote xml:lang="en">A Record or Record Set can be aggregated in one or many Record
-            Sets simultaneously or through time</skos:scopeNote>
+         Sets simultaneously or through time</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R024 ('includes'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#includedIn"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiates -->
@@ -2578,110 +3010,147 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfRecordResourceToInstantiationRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfRecordResourceToInstantiationRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource"
+         />
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'has instantiation' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'has instantiation' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">instantiates </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R025i (instantiates
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasInstantiation"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToFunctionalEquivalenceRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToFunctionalEquivalenceRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToFunctionalEquivalenceRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#FunctionalEquivalenceRelation"/>
+      <rdfs:range
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#FunctionalEquivalenceRelation"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation to a Functional Equivalence
-            Relation</rdfs:comment>
-      <rdfs:label xml:lang="en">instantiation is connected to functional equivalence relation
-        </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects"/>
+         Relation</rdfs:comment>
+      <rdfs:label xml:lang="en">instantiation is connected to functional equivalence relation </rdfs:label>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation"/>
+      <rdfs:range
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation to an Instantiation to Instantiation
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">instantiation is connected to instantiation relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#DerivationRelation"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation (from which at least one Instantiation
-            is derived) to a Derivation Relation.</rdfs:comment>
+         is derived) to a Derivation Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">instantiation is source of derivation relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfMigrationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfMigrationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfMigrationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#MigrationRelation"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation (from which at least one Instantiation
-            is migrated) to a Migration Relation.</rdfs:comment>
+         is migrated) to a Migration Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">instantiation is source of migration relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfDerivationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfDerivationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfDerivationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#DerivationRelation"/>
       <rdfs:comment xml:lang="en">Connects a derived Instantiation to a Derivation
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">instantiation is target of derivation relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfMigrationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfMigrationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfDerivationRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfMigrationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfDerivationRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#MigrationRelation"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation which results from a migration, to a
-            Migration Relation.</rdfs:comment>
+         Migration Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">instantiation is target of migration relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfRecordResourceToInstantiationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfRecordResourceToInstantiationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfRecordResourceToInstantiationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation"/>
+      <rdfs:range
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation of a Record Resource to the Record
-            Resource to Instantiation Relation.</rdfs:comment>
-      <rdfs:label xml:lang="en">instantiation is target of record resource to instantiation
-            relation </rdfs:label>
+         Resource to Instantiation Relation.</rdfs:comment>
+      <rdfs:label xml:lang="en">instantiation is target of record resource to instantiation relation
+      </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects">
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationConnects"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-      <rdfs:comment xml:lang="en">Connects an Instantiation to Instantiation Relation to one of
-            the related Instantiations.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects an Instantiation to Instantiation Relation to one of the
+         related Instantiations.</rdfs:comment>
       <rdfs:label xml:lang="en">instantiation to instantiation relation connects </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsHeldBy -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsHeldBy">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isUnderAuthorityOf"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsHeldBy">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isUnderAuthorityOf"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -2695,20 +3164,27 @@
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfIntellectualPropertyRightsRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfIntellectualPropertyRightsRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource"
+         />
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'has intellectual property rights on'
-            object property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'has intellectual property rights on' object
+         property</rdfs:comment>
       <rdfs:label xml:lang="en">intellectual property rights held by </rdfs:label>
-      <RiCCMCorrespondingComponent xml:lang="en">RiC-R040i ('intellectual property rights
-            held by' relation)</RiCCMCorrespondingComponent>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasIntellectualPropertyRightsOn"/>
+      <RiCCMCorrespondingComponent xml:lang="en">RiC-R040i ('intellectual property rights held by'
+         relation)</RiCCMCorrespondingComponent>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasIntellectualPropertyRightsOn"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -2719,48 +3195,57 @@
          </owl:Class>
       </rdfs:range>
       <rdfs:comment xml:lang="en">Connects an IntellectualPropertyRightsRelation to one of the
-            Group, Person or Position that holds the rights.</rdfs:comment>
+         Group, Person or Position that holds the rights.</rdfs:comment>
       <rdfs:label xml:lang="en">intellectual property rights relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfIntellectualPropertyRightsRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfIntellectualPropertyRightsRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfIntellectualPropertyRightsRelation"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfIntellectualPropertyRightsRelation"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <rdfs:comment xml:lang="en">Connects an IintellectualPropertyRightsRelation to one of the
-            Record Resource or Instantiation on which the rights are held.</rdfs:comment>
+         Record Resource or Instantiation on which the rights are held.</rdfs:comment>
       <rdfs:label xml:lang="en">intellectual property rights relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#involvedIn -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#involvedIn">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#involves"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:comment xml:lang="en">Inverse of 'involves' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">involved in </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R058i ('involvedIn'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#involves -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#involves">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <rdfs:comment xml:lang="en">Connects an Event to a Thing that the Event actively or
-            passively involves in. </rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects an Event to a Thing that the Event actively or passively
+         involves in. </rdfs:comment>
       <rdfs:label xml:lang="en">involves </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R058 ('involves'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#involvedIn"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isActivityTypeOf -->
@@ -2769,7 +3254,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
       <rdfs:comment xml:lang="en">Connects an Activity Type to an Activity that it
-            categorizes.</rdfs:comment>
+         categorizes.</rdfs:comment>
       <rdfs:label xml:lang="en">is activity type of </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasActivityType"/>
    </owl:ObjectProperty>
@@ -2781,48 +3266,53 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
-      <rdfs:comment xml:lang="en">Inverse of 'has addressee' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'has addressee' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is addressee of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-032i ('is addressee of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasAddressee"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isAdjacentTo -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isAdjacentTo">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:comment xml:lang="en">Connects two Places that are geographically adjacent. This is a
-            symmetric object property.</rdfs:comment>
+         symmetric object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is adjacent to </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R077 ('is adjacent to'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent">
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Agents. This object property is
-            symmetric.</rdfs:comment>
+         symmetric.</rdfs:comment>
       <rdfs:label xml:lang="en">is agent associated with agent </rdfs:label>
-      <skos:scopeNote xml:lang="en">Use to connect two Agents only if it is not possible to be
-            more accurate and use a narrower Agent to Agent relation, e.g. ‘has work relation
-            with’.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">RiC-R044 ('is agent associated with
-            agent' relation)</RiCCMCorrespondingComponent>
+      <skos:scopeNote xml:lang="en">Use to connect two Agents only if it is not possible to be more
+         accurate and use a narrower Agent to Agent relation, e.g. ‘has work relation
+         with’.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">RiC-R044 ('is agent associated with agent'
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isAgentNameOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isAgentNameOf">
@@ -2835,23 +3325,26 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isAntecedentOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isAntecedentOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInTime"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isSuccessorOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Agent to another Agent that succeeds it
-            chronologically.</rdfs:comment>
+         chronologically.</rdfs:comment>
       <rdfs:label xml:lang="en">is antecedent of </rdfs:label>
       <skos:scopeNote xml:lang="en">There may be zero to many intermediate Agents , ignored or
-            unknown,between the two connected Agents. Can be used when there is a transfer of
-            function from the first Agent to the second Agent.</skos:scopeNote>
+         unknown,between the two connected Agents. Can be used when there is a transfer of function
+         from the first Agent to the second Agent.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">RIC-R016 (is antecedent of
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isAppellationOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isAppellationOf">
@@ -2859,7 +3352,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an Appellation to a Thing that it
-            designates.</rdfs:comment>
+         designates.</rdfs:comment>
       <rdfs:label xml:lang="en">is appellation of </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasAppellation"/>
    </owl:ObjectProperty>
@@ -2870,10 +3363,10 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:comment xml:lang="en">Inverse of 'is date associated with' object
-            property.</rdfs:comment>
+         property.</rdfs:comment>
       <rdfs:label xml:lang="en">is associated with date </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R068i ('is associated with date'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent">
@@ -2882,14 +3375,16 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfEventRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#eventRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfEventRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#eventRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is event associated with' object
-            property.</rdfs:comment>
+         property.</rdfs:comment>
       <rdfs:label xml:lang="en">is associated with event </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R057i ('is associated with event'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace">
@@ -2898,14 +3393,16 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfPlaceRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#placeRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfPlaceRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#placeRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is place associated with' object
-            property.</rdfs:comment>
+         property.</rdfs:comment>
       <rdfs:label xml:lang="en">is associated with place </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R074i ('is associated with place'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule">
@@ -2914,47 +3411,53 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is rule associated with' object
-            property.</rdfs:comment>
+         property.</rdfs:comment>
       <rdfs:label xml:lang="en">is associated with rule </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R062i ('is associated with rule'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isAuthorizingAgentInMandateRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isAuthorizingAgentInMandateRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isAuthorizingAgentInMandateRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
       <rdfs:comment xml:lang="en">Connects an Agent that assigns the Mandate, to a Mandate
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">is authorizing agent in mandate relation </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorizingAgent"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isBeginningDateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Date to a Thing that came into existence on that
-            Date.</rdfs:comment>
+         Date.</rdfs:comment>
       <rdfs:label xml:lang="en">is beginning date of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R069 ('is beginning date of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasBeginningDate"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isBirthDateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isBirthDateOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Date to a Person that was born on that
-            Date.</rdfs:comment>
+         Date.</rdfs:comment>
       <rdfs:label xml:lang="en">is birth date of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R070 ('is birth date of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasBirthDate"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isCarrierTypeOf -->
@@ -2963,7 +3466,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#CarrierType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects a Carrier Type to an Instantiation whose carrier it
-            categorizes.</rdfs:comment>
+         categorizes.</rdfs:comment>
       <rdfs:label xml:lang="en">is carrier type of </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasCarrierType"/>
    </owl:ObjectProperty>
@@ -2973,38 +3476,40 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#typeIsSourceOfTypeRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#typeRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#typeIsSourceOfTypeRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#typeRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Type (a category) to a Thing that it
-            categorizes.</rdfs:comment>
+         categorizes.</rdfs:comment>
       <rdfs:label xml:lang="en">is category of </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToCategory"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isComponentOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isComponentOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-      <rdfs:comment xml:lang="en">Inverse of 'has component' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'has component' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is component of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R004i (is component of
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasComponent"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isConstituentOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isConstituentOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOf"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordPart"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Record"/>
-      <rdfs:comment xml:lang="en">Inverse of 'has constituent' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'has constituent' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is constituent of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R003i (is constituent of
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasConstituent"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isContentTypeOf -->
@@ -3013,7 +3518,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ContentType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:comment xml:lang="en">Connects a Content Type to a Record Resource whose content it
-            categorizes.</rdfs:comment>
+         categorizes.</rdfs:comment>
       <rdfs:label xml:lang="en">is content type of </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasContentOfType"/>
    </owl:ObjectProperty>
@@ -3023,20 +3528,21 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Coordinates"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PhysicalLocation"/>
       <rdfs:comment xml:lang="en">Connects an instance of Coordinates to a Physical Location it
-            locates on earth, according to some reference system.</rdfs:comment>
+         locates on earth, according to some reference system.</rdfs:comment>
       <rdfs:label xml:lang="en">is coordinates of </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasCoordinates"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isCopyOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isCopyOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInTime"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:comment xml:lang="en">Inverse of 'has copy' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is copy of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R012i (is copy of
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasCopy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isCorporateBodyTypeOf -->
@@ -3045,9 +3551,10 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#CorporateBodyType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#CorporateBody"/>
       <rdfs:comment xml:lang="en">Connects a Corporate Body Type to a Corporate Body that it
-            categorizes.</rdfs:comment>
+         categorizes.</rdfs:comment>
       <rdfs:label xml:lang="en">is corporate body type of </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasCorporateBodyType"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasCorporateBodyType"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isCreatorOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isCreatorOf">
@@ -3057,19 +3564,21 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfCreationRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfCreationRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'created by' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'created by' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is creator of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R027i ('is creator of
-            'relation')</RiCCMCorrespondingComponent>
+         'relation')</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#createdBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith -->
@@ -3078,22 +3587,22 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Date to a Thing that the Date is associated with the
-            existence and lifecycle of.</rdfs:comment>
+         existence and lifecycle of.</rdfs:comment>
       <rdfs:label xml:lang="en">is date associated with </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R068 ('is date associated with'
-            relation)</RiCCMCorrespondingComponent>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
+         relation)</RiCCMCorrespondingComponent>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDeathDateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDeathDateOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isEndDateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
-      <rdfs:comment xml:lang="en">Connects a Date to a Person who died on that
-            Date.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Date to a Person who died on that Date.</rdfs:comment>
       <rdfs:label xml:lang="en">is death date of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R072 ('is death date of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDeathDate"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDemographicGroupOf -->
@@ -3102,25 +3611,30 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#DemographicGroup"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Demographic Group to a Person who belongs to
-            it.</rdfs:comment>
+         it.</rdfs:comment>
       <rdfs:label xml:lang="en">is demographic group of </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToDemographicGroup"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToDemographicGroup"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDerivedFromInstantiation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDerivedFromInstantiation">
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isDerivedFromInstantiation">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInTime"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Inverse of 'has derived instantiation' object
-            property.</rdfs:comment>
+         property.</rdfs:comment>
       <rdfs:label xml:lang="en">is derived from instantiation </rdfs:label>
-      <RiCCMCorrespondingComponent xml:lang="en">RiC-R014i ('is derived from
-            instantiation' relation)</RiCCMCorrespondingComponent>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDerivedInstantiation"/>
+      <RiCCMCorrespondingComponent xml:lang="en">RiC-R014i ('is derived from instantiation'
+         relation)</RiCCMCorrespondingComponent>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDerivedInstantiation"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDocumentaryFormTypeOf -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDocumentaryFormTypeOf">
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isDocumentaryFormTypeOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isCategoryOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#DocumentaryFormType"/>
       <rdfs:range>
@@ -3132,9 +3646,10 @@
          </owl:Class>
       </rdfs:range>
       <rdfs:comment xml:lang="en">Connects a Documentary Form Type to a Record or Record Part that
-            it categorizes.</rdfs:comment>
+         it categorizes.</rdfs:comment>
       <rdfs:label xml:lang="en">is documentary form type of </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDocumentaryFormType"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDocumentaryFormType"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDocumentationOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDocumentationOf">
@@ -3143,25 +3658,30 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfActivityDocumentationRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfActivityDocumentationRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget"
+         />
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record Resource or an Instantiation to the Activity
-            that generates the Record Resource or Instantiation.</rdfs:comment>
+         that generates the Record Resource or Instantiation.</rdfs:comment>
       <rdfs:label xml:lang="en">is documentation of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R033 ('is documentation of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#documentedBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDraftOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDraftOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInTime"/>
       <rdfs:domain>
          <owl:Class>
@@ -3179,23 +3699,23 @@
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
-      <rdfs:comment xml:lang="en">Connects a draft to the final version of a
-            Record.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a draft to the final version of a Record.</rdfs:comment>
       <rdfs:label xml:lang="en">is draft of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R011 (is draft of
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDraft"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isEndDateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isEndDateOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Date to a Thing whose existence ended on that
-            Date.</rdfs:comment>
+         Date.</rdfs:comment>
       <rdfs:label xml:lang="en">is end date of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R071 ('is end date
-            of')</RiCCMCorrespondingComponent>
+         of')</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasEndDate"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isEquivalentTo -->
@@ -3204,8 +3724,7 @@
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <rdfs:comment xml:lang="en">Connects two Things that are considered
-            equivalent.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects two Things that are considered equivalent.</rdfs:comment>
       <rdfs:label xml:lang="en">is equivalent to </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith -->
@@ -3214,15 +3733,18 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#eventIsSourceOfEventRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#eventRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#eventIsSourceOfEventRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#eventRelationHasTarget"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Connects an Event to a Thing that is associated with the
-            existence and lifecycle of the Event.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects an Event to a Thing that is associated with the existence
+         and lifecycle of the Event.</rdfs:comment>
       <rdfs:label xml:lang="en">is event associated with </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R057 ('is event associated with'
-            relation)</RiCCMCorrespondingComponent>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
+         relation)</RiCCMCorrespondingComponent>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isEventTypeOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isEventTypeOf">
@@ -3230,7 +3752,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#EventType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:comment xml:lang="en">Connects an Event Type to an Event that is
-            categorizes.</rdfs:comment>
+         categorizes.</rdfs:comment>
       <rdfs:label xml:lang="en">is event type of </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasEventType"/>
    </owl:ObjectProperty>
@@ -3240,74 +3762,92 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#FamilyType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Family"/>
       <rdfs:comment xml:lang="en">Connects a Family Type to a Family that is
-            categorizes.</rdfs:comment>
+         categorizes.</rdfs:comment>
       <rdfs:label xml:lang="en">is family type of </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyType"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isFromUseDateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isFromUseDateOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasUsedFromDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
       <rdfs:comment xml:lang="en">Connects a Date to an Appellation, when it is the date at which
-            the Appellation was first used.</rdfs:comment>
+         the Appellation was first used.</rdfs:comment>
       <rdfs:label xml:lang="en">is from use date of </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isFunctionallyEquivalentTo -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isFunctionallyEquivalentTo">
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isFunctionallyEquivalentTo">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isEquivalentTo"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToFunctionalEquivalenceRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToFunctionalEquivalenceRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects"
+         />
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Connects two Instantiations which may be considered as
-            equivalent. This relation is symmetric.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects two Instantiations which may be considered as equivalent.
+         This relation is symmetric.</rdfs:comment>
       <rdfs:label xml:lang="en">is functionally equivalent to </rdfs:label>
       <skos:scopeNote xml:lang="en">Use for Instantiations which, from some point of view, may be
-            considered as equivalent. This equivalence is usually based upon the fact that the
-            Instantiations have at least the same intellectual content (they instantiate the same
-            Record Resource).</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">RiC-R035 ('is functionally equivalent
-            to' relation)</RiCCMCorrespondingComponent>
+         considered as equivalent. This equivalence is usually based upon the fact that the
+         Instantiations have at least the same intellectual content (they instantiate the same
+         Record Resource).</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">RiC-R035 ('is functionally equivalent to'
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isHierarchicallyInferiorTo -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isHierarchicallyInferiorTo">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isHierarchicallySuperiorTo"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isHierarchicallyInferiorTo">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isHierarchicallySuperiorTo"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"
+         />
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is hierarchically superior to' object
-            property.</rdfs:comment>
+         property.</rdfs:comment>
       <rdfs:label xml:lang="en">is hierarchically inferior to </rdfs:label>
-      <RiCCMCorrespondingComponent xml:lang="en">RiC-R045i ('is hierarchically inferior
-            to' relation)</RiCCMCorrespondingComponent>
+      <RiCCMCorrespondingComponent xml:lang="en">RiC-R045i ('is hierarchically inferior to'
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isHierarchicallySuperiorTo -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isHierarchicallySuperiorTo">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isHierarchicallySuperiorTo">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"
+         />
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Agent to an Agent that is hierarchically
-            inferior.</rdfs:comment>
+         inferior.</rdfs:comment>
       <rdfs:label xml:lang="en">is hierarchically superior to </rdfs:label>
       <skos:scopeNote xml:lang="en">The hierarchical relation can be an authority relation, or a
-            whole/part relation between two Groups</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">RiC-R045 ('is hierarchically superior
-            to' relation)</RiCCMCorrespondingComponent>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isHierarchicallyInferiorTo"/>
+         whole/part relation between two Groups</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">RiC-R045 ('is hierarchically superior to'
+         relation)</RiCCMCorrespondingComponent>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isHierarchicallyInferiorTo"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isHolderOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isHolderOf">
@@ -3317,20 +3857,39 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfRecordResourceHoldingRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfRecordResourceHoldingRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget"
+         />
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Agent to a Record Resource or Instantiation that the
-            Agent holds.</rdfs:comment>
+         Agent holds.</rdfs:comment>
       <rdfs:label xml:lang="en">is holder of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R039 ('is holder of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#heldBy"/>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#isIdentifierTypeOf -->
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isIdentifierTypeOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isCategoryOf"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#IdentifierType"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Identifier"/>
+      <rdfs:comment xml:lang="en">Connects an Identifier Type and an Identifier that it
+         categorizes.</rdfs:comment>
+      <rdfs:label xml:lang="en">is identifier type of</rdfs:label>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Object property added along with IdentifierType class and hasIdentifierType
+            object property.</rdf:value>
+         <dc:date>2020-10-19</dc:date>
+      </skos:changeNote>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasIdentifierType"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isInferiorTo -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isInferiorTo">
@@ -3339,41 +3898,48 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfAgentSubordinationRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfAgentSubordinationRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasSource"
+         />
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'is superior to' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is superior to' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is inferior to </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R043i ('is inferior to'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation">
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"
+         />
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Instantiations. This object property is
-            symmetric.</rdfs:comment>
+         symmetric.</rdfs:comment>
       <rdfs:label xml:lang="en">is instantiation associated with instantiation </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R034 ('is instantiation associated with
-            instantiation' relation)</RiCCMCorrespondingComponent>
+         instantiation' relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isJurisdictionOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isJurisdictionOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Place to an Agent that has jurisdiction over the
-            Place.</rdfs:comment>
+         Place.</rdfs:comment>
       <rdfs:label xml:lang="en">is jurisdiction of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R076 ('is jurisdiction of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasJurisdiction"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isLanguageOf -->
@@ -3384,23 +3950,25 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Agent"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <rdfs:comment xml:lang="en">Connects a Language to An Agent or Record Resource that uses
-            it.</rdfs:comment>
+         it.</rdfs:comment>
       <rdfs:label xml:lang="en">is language of </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasLanguage"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isLastUpdateDateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isLastUpdateDateOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isModificationDateOf"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isModificationDateOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasLastUpdatedAtDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Date and a Thing that was last modified at this
-            Date.</rdfs:comment>
+         Date.</rdfs:comment>
       <rdfs:label xml:lang="en">is last update date of </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isLeaderOf -->
@@ -3410,13 +3978,15 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfLeadershipRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfLeadershipRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Person to the Group that Person leads.</rdfs:comment>
       <rdfs:label xml:lang="en">is leader of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R042 ('is leader of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isLegalStatusOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isLegalStatusOf">
@@ -3426,25 +3996,27 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Agent"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <rdfs:comment xml:lang="en">Connects a Legal Status to an Agent or Record Resource that it
-            categorizes.</rdfs:comment>
+         categorizes.</rdfs:comment>
       <rdfs:label xml:lang="en">is legal status of </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasLegalStatus"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isLocationOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isLocationOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Place to a Thing that is located in the
-            Place.</rdfs:comment>
+         Place.</rdfs:comment>
       <rdfs:label xml:lang="en">is location of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R075 ('is location of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasLocation"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isMainSubjectOf -->
@@ -3452,11 +4024,10 @@
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isSubjectOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-      <rdfs:comment xml:lang="en">Inverse of 'has main subject' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'has main subject' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is main subject of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R020i (is main subject
-            of)</RiCCMCorrespondingComponent>
+         of)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasMainSubject"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isManagerOf -->
@@ -3468,62 +4039,74 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Agent to a Record Resource or Instantiation that the
-            Agent manages.</rdfs:comment>
+         Agent manages.</rdfs:comment>
       <rdfs:label xml:lang="en">is manager of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R038 ('is manager of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isMemberOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isMemberOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfMembershipRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfMembershipRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'has member' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'has member' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is member of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R055i ('is member of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasMember"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isMigratedIntoInstantiation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isMigratedIntoInstantiation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDerivedInstantiation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isMigratedIntoInstantiation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDerivedInstantiation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfMigrationRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfMigrationRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Instantiation to a version it has been migrated
-            to.</rdfs:comment>
+         to.</rdfs:comment>
       <rdfs:label xml:lang="en">is migrated into instantiation </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R015 (is migrated into instantiation
-            relation)</RiCCMCorrespondingComponent>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#createdByMigrationFromInstantiation"/>
+         relation)</RiCCMCorrespondingComponent>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#createdByMigrationFromInstantiation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isModificationDateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isModificationDateOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Date to a Thing that was modified on that
-            Date.</rdfs:comment>
+         Date.</rdfs:comment>
       <rdfs:label xml:lang="en">is modification date of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R073 ('is modification date of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasModificationDate"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isNameOf -->
@@ -3537,17 +4120,19 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOccupationTypeOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOccupationTypeOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDemographicGroupOf"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDemographicGroupOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#OccupationType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects an Occupation Type to a Person whose occupation is
-            categorized by it.</rdfs:comment>
+         categorized by it.</rdfs:comment>
       <rdfs:label xml:lang="en">is occupation type of </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOccupationOfType"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOriginalOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOriginalOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInTime"/>
       <rdfs:domain>
          <owl:Class>
@@ -3566,12 +4151,12 @@
          </owl:Class>
       </rdfs:range>
       <rdfs:comment xml:lang="en">Connects the original version of a Record to a copy or a later
-            version.</rdfs:comment>
+         version.</rdfs:comment>
       <rdfs:label xml:lang="en">is original of </rdfs:label>
       <skos:scopeNote xml:lang="en">There may be zero to many intermediate Records, ignored or
-            unknown, between the two connected Records</skos:scopeNote>
+         unknown, between the two connected Records</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R010 (is original of
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOriginal"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOwnerOf -->
@@ -3589,14 +4174,16 @@
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfOwnershipRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfOwnershipRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Group, Person or Position to a Thing that this Agent
-            owns.</rdfs:comment>
+         owns.</rdfs:comment>
       <rdfs:label xml:lang="en">is owner of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R037 ('is owner of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isPartOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isPartOf">
@@ -3604,13 +4191,15 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'has part' relation.</rdfs:comment>
       <rdfs:label xml:lang="en">is part of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R002i (is part of
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPart"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isPhysicalLocationOf -->
@@ -3619,7 +4208,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PhysicalLocation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:comment xml:lang="en">Connects a Physical Location to a Place, when it is its
-            location.</rdfs:comment>
+         location.</rdfs:comment>
       <rdfs:label xml:lang="en">is physical location of </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPhysicalLocation"/>
    </owl:ObjectProperty>
@@ -3629,15 +4218,18 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#placeIsSourceOfPlaceRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#placeRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#placeIsSourceOfPlaceRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#placeRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Place to a Thing that Place is associated with the
-            existence and lifecycle of.</rdfs:comment>
+         existence and lifecycle of.</rdfs:comment>
       <rdfs:label xml:lang="en">is place associated with </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R074 ('is place associated with'
-            relation)</RiCCMCorrespondingComponent>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
+         relation)</RiCCMCorrespondingComponent>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isPlaceNameOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isPlaceNameOf">
@@ -3645,7 +4237,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PlaceName"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:comment xml:lang="en">Connects a Place Name to a Place that is designated by
-            it.</rdfs:comment>
+         it.</rdfs:comment>
       <rdfs:label xml:lang="en">is place name of </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPlaceName"/>
    </owl:ObjectProperty>
@@ -3655,19 +4247,21 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PlaceType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:comment xml:lang="en">Connects a Place Type to a Place that is categorized by
-            it.</rdfs:comment>
+         it.</rdfs:comment>
       <rdfs:label xml:lang="en">is place type of </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPlaceType"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isProductionTechniqueTypeOf -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isProductionTechniqueTypeOf">
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isProductionTechniqueTypeOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isCategoryOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ProductionTechniqueType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects a Production Technique Type to an Instantiation whose
-            production technique is categorized by it.</rdfs:comment>
+         production technique is categorized by it.</rdfs:comment>
       <rdfs:label xml:lang="en">is production technique type of </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasProductionTechniqueType"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasProductionTechniqueType"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isProvenanceOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isProvenanceOf">
@@ -3677,46 +4271,54 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"
+         />
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">inverse of 'has provenance' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">inverse of 'has provenance' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is provenance of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R026i ('is provenance of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasProvenance"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource">
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Record Resources. This object property is
-            symmetric.</rdfs:comment>
+         symmetric.</rdfs:comment>
       <rdfs:label xml:lang="en">is record resource associated with record resource </rdfs:label>
-      <RiCCMCorrespondingComponent xml:lang="en">RiC-R022 ('is record resource associated
-            with record resource' relation)</RiCCMCorrespondingComponent>
+      <RiCCMCorrespondingComponent xml:lang="en">RiC-R022 ('is record resource associated with
+         record resource' relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isRecordResourceStateOf -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isRecordResourceStateOf">
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isRecordResourceStateOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isCategoryOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceState"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-      <rdfs:comment xml:lang="en">Connects a Record Resource State to a Record Resource whose
-            state it categorizes.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Record Resource State to a Record Resource whose state
+         it categorizes.</rdfs:comment>
       <rdfs:label xml:lang="en">is record resource state of </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasRecordResourceState"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasRecordResourceState"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isRecordSetTypeOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isRecordSetTypeOf">
@@ -3724,7 +4326,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSetType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a Record Set Type to a Record Set that it
-            categorizes.</rdfs:comment>
+         categorizes.</rdfs:comment>
       <rdfs:label xml:lang="en">is record set type of </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasRecordSetType"/>
    </owl:ObjectProperty>
@@ -3734,14 +4336,15 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">The most generic object property. Connects an Thing to any other
-            Thing This is a symmetric object property.</rdfs:comment>
+         Thing This is a symmetric object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is related to </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R001 (is related to
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isRepliedToBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isRepliedToBy">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInTime"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#repliesTo"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
@@ -3749,7 +4352,7 @@
       <rdfs:comment xml:lang="en">Connects a Record Resource to a reply.</rdfs:comment>
       <rdfs:label xml:lang="en">is replied to by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R013 (is replied to by
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isRepresentationTypeOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isRepresentationTypeOf">
@@ -3757,32 +4360,36 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RepresentationType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects a Representation Type to an Instantiation that it
-            categorizes.</rdfs:comment>
+         categorizes.</rdfs:comment>
       <rdfs:label xml:lang="en">is representation type of </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasRepresentationType"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasRepresentationType"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isResponsibleForEnforcing -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isResponsibleForEnforcing">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isResponsibleForEnforcing">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
-      <rdfs:comment xml:lang="en">Inverse of 'enforced by' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'enforced by' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is responsible for enforcing </rdfs:label>
-      <RiCCMCorrespondingComponent xml:lang="en">RiC-R066i ('is responsible for
-            enforcing' relation)</RiCCMCorrespondingComponent>
+      <RiCCMCorrespondingComponent xml:lang="en">RiC-R066i ('is responsible for enforcing'
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#enforcedBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isResponsibleForIssuing -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isResponsibleForIssuing">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isResponsibleForIssuing">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#issuedBy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <rdfs:comment xml:lang="en">Inverse of 'issued by' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is responsible for issuing </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R065i ('is responsible for issuing'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith">
@@ -3790,15 +4397,32 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Rule to a Thing that is associated with the existence
-            and lifecycle of the Rule.</rdfs:comment>
+         and lifecycle of the Rule.</rdfs:comment>
       <rdfs:label xml:lang="en">is rule associated with </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R062 ('is rule associated with'
-            relation)</RiCCMCorrespondingComponent>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
+         relation)</RiCCMCorrespondingComponent>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"
+      />
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#isRuleTypeOf -->
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isRuleTypeOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isCategoryOf"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RuleType"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
+      <rdfs:comment xml:lang="en">connects a Rule Type to a Rule that it categorizes.</rdfs:comment>
+      <rdfs:label xml:lang="en">is rule type of</rdfs:label>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Object property added along with RuleType class and hasRuleType object
+            property.</rdf:value>
+         <dc:date>2020-10-19</dc:date>
+      </skos:changeNote>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasRuleType"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isSenderOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isSenderOf">
@@ -3808,15 +4432,15 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
-      <rdfs:comment xml:lang="en">Inverse of 'has sender' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'has sender' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is sender of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R031i ('is sender of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSender"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isSourceOf -->
@@ -3826,53 +4450,59 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Agent"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Relation"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <rdfs:comment xml:lang="en">Connects a Record Resource or an Agent to a Record Resource or
-            Relation, when the first is used as a source of information for identifying or
-            describing the second one.</rdfs:comment>
+         Relation, when the first is used as a source of information for identifying or describing
+         the second one.</rdfs:comment>
       <rdfs:label xml:lang="en">is source of </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSource"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isSubEventOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isSubEventOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
-      <rdfs:comment xml:lang="en">Inverse of 'has subevent' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'has subevent' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is sub event of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R006i ('is subevent of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSubEvent"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isSubdivisionOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isSubdivisionOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isHierarchicallyInferiorTo"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isHierarchicallyInferiorTo"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfGroupSubdivisionRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfGroupSubdivisionRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource"
+         />
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'has subdivision' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'has subdivision' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is subdivision of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R005i ('is subdivision'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSubdivision"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isSubjectOf -->
@@ -3880,28 +4510,29 @@
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-      <rdfs:comment xml:lang="en">Inverse of 'has subject' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'has subject' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is subject of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RIc-R019i ('is subject of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSubject"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isSuccessorOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isSuccessorOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInTime"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'is antecedent of' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is antecedent of' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is successor of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R016i (is successor
-            of)</RiCCMCorrespondingComponent>
+         of)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAntecedentOf"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isSuperiorTo -->
@@ -3910,14 +4541,16 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfAgentSubordinationRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfAgentSubordinationRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasTarget"
+         />
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Connects a Person to a Person they are superior
-            to.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Person to a Person they are superior to.</rdfs:comment>
       <rdfs:label xml:lang="en">is superior to </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R043 ('is superior to'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isInferiorTo"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isTitleOf -->
@@ -3928,24 +4561,26 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Rule"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
-      <rdfs:comment xml:lang="en">Connects a Title to a Record Resource, Instantiation or Rule
-            that it designates.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Title to a Record Resource, Instantiation or Rule that
+         it designates.</rdfs:comment>
       <rdfs:label xml:lang="en">is title of </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasTitle"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isToUseDateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isToUseDateOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasUsedToDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
-      <rdfs:comment xml:lang="en">Connects a Date to an Appellation, when it is the date till
-            which the Appellation was used.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Date to an Appellation, when it is the date till which
+         the Appellation was used.</rdfs:comment>
       <rdfs:label xml:lang="en">is to use date of </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isUnderAuthorityOf -->
@@ -3954,134 +4589,166 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'has authority over' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'has authority over' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">is under authority of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R036i ('is under authority of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasAuthorityOver"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#issuedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#issuedBy">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Rule to the Agent that issued or published the
-            Rule.</rdfs:comment>
+         Rule.</rdfs:comment>
       <rdfs:label xml:lang="en">issued by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R065 ('issued by'
-            relation)</RiCCMCorrespondingComponent>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isResponsibleForIssuing"/>
+         relation)</RiCCMCorrespondingComponent>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isResponsibleForIssuing"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfKnowingOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfKnowingOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#KnowingOfRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
-      <rdfs:comment xml:lang="en">Connects a Knowing Of Relation to a 'knowing of'
-            Person (a Person who has some knowledge of another one.)</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Knowing Of Relation to a 'knowing of' Person (a Person
+         who has some knowledge of another one.)</rdfs:comment>
       <rdfs:label xml:lang="en">knowing of relation has source </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfKnowingOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfKnowingOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#KnowingOfRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
-      <rdfs:comment xml:lang="en">Connects a Knowing Of Relation to a 'known by' Person
-            (a Person on which another one has some has some knowledge.)</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Knowing Of Relation to a 'known by' Person (a Person on
+         which another one has some has some knowledge.)</rdfs:comment>
       <rdfs:label xml:lang="en">knowing of relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#knowingRelationConnects -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#KnowingRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects Knowing Relation to any known Person
-            involved.</rdfs:comment>
+         involved.</rdfs:comment>
       <rdfs:label xml:lang="en">knowing relation connects </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#knownBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#knownBy">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#knowsOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfKnowingOfRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfKnowingOfRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'knows of' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">known by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R050i ('known by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#knows -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#knows">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Persons that directly know each other during their
-            existence. This object property is symmetric.</rdfs:comment>
+         existence. This object property is symmetric.</rdfs:comment>
       <rdfs:label xml:lang="en">knows </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R051 ('knows'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#knowsOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#knowsOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfKnowingOfRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfKnowingOfRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Person to another Person they have some knowledge of
-            through time or space.</rdfs:comment>
+         through time or space.</rdfs:comment>
       <rdfs:label xml:lang="en">knows of </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R050 ('knows of'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#knownBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfLeadershipRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfLeadershipRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#LeadershipRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Leadership Relation to a Person who is involved as a
-            leader.</rdfs:comment>
+         leader.</rdfs:comment>
       <rdfs:label xml:lang="en">leadership relation has source </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#LeadershipRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:comment xml:lang="en">Connects a Leadership Relation to a lead Group.</rdfs:comment>
       <rdfs:label xml:lang="en">leadership relation has target </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfLeadershipRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfLeadershipRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#leadershipWithPosition -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipWithPosition">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#positionIsContextOfLeadershipRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#positionIsContextOfLeadershipRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#LeadershipRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:comment xml:lang="en">Connects a Leadership Relation to the Position occupied by the
-            leading Person.</rdfs:comment>
+         leading Person.</rdfs:comment>
       <rdfs:label xml:lang="en">leadership with position </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#ledBy -->
@@ -4090,192 +4757,244 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfLeadershipRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfLeadershipRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'is leader of' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is leader of' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">led by</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R042i ('led by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isLeaderOf"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#managedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#managedBy">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isUnderAuthorityOf"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isUnderAuthorityOf"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'is manager of' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is manager of' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">managed by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R038i ('managed by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isManagerOf"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#managementRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ManagementRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Management Relation to an Agent who is involved as a
-            manager.</rdfs:comment>
+         manager.</rdfs:comment>
       <rdfs:label xml:lang="en">management relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ManagementRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <rdfs:comment xml:lang="en">Connects a Management Relation to a Record Resource or
-            Instantiation that is involved as a managed thing.</rdfs:comment>
+         Instantiation that is involved as a managed thing.</rdfs:comment>
       <rdfs:label xml:lang="en">management relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#mandateIsSourceOfMandateRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#mandateIsSourceOfMandateRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#mandateIsSourceOfMandateRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Mandate"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
       <rdfs:comment xml:lang="en">Connects a Mandate to a Mandate Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">mandate is source of mandate relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Mandate"/>
       <rdfs:comment xml:lang="en">Connects a Mandate Relation to a Mandate.</rdfs:comment>
       <rdfs:label xml:lang="en">mandate relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateIsSourceOfMandateRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateIsSourceOfMandateRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
-      <rdfs:comment xml:lang="en">Connects a Mandate Relation to an Agent who is given the
-            authority or competencies to act.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Mandate Relation to an Agent who is given the authority
+         or competencies to act.</rdfs:comment>
       <rdfs:label xml:lang="en">mandate relation has target </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfMandateRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfMandateRelation"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#MembershipRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:comment xml:lang="en">Connects a Membership Relation to the Group that has
-            member(s).</rdfs:comment>
+         member(s).</rdfs:comment>
       <rdfs:label xml:lang="en">membership relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfMembershipRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfMembershipRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfMembershipRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfMembershipRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#MembershipRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Membership Relation to a Person who is involved as a
-            member.</rdfs:comment>
+         member.</rdfs:comment>
       <rdfs:label xml:lang="en">membership relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#membershipWithPosition -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#membershipWithPosition">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#positionIsContextOfMembershipRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#positionIsContextOfMembershipRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#MembershipRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:comment xml:lang="en">Connects a Membership Relation to the Position occupied by the
-            member Person(s).</rdfs:comment>
+         member Person(s).</rdfs:comment>
       <rdfs:label xml:lang="en">membership with position </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#MigrationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects a Migration Relation to the migrated
-            Instantiation.</rdfs:comment>
+         Instantiation.</rdfs:comment>
       <rdfs:label xml:lang="en">migration relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfMigrationRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfMigrationRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#MigrationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects a Migration Relation to a resulting
-            Instantiation.</rdfs:comment>
+         Instantiation.</rdfs:comment>
       <rdfs:label xml:lang="en">migration relation has target </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfMigrationRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfMigrationRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#occupiedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#occupiedBy">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#occupies"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsTargetOfPositionHoldingRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsTargetOfPositionHoldingRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource"
+         />
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'occupies' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">occupied by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R054i ('occupied by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#occupies -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#occupies">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfPositionHoldingRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfPositionHoldingRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget"
+         />
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Person to a Position they occupy.</rdfs:comment>
       <rdfs:label xml:lang="en">occupies </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R054 ('occupies'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#occupiedBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#overlaps -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#overlaps">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:comment xml:lang="en">Connects two Places that geographically overlap. This object
-            property is symmetric.</rdfs:comment>
+         property is symmetric.</rdfs:comment>
       <rdfs:label xml:lang="en">overlaps </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R078 ('overlaps'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#ownedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#ownedBy">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isUnderAuthorityOf"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isUnderAuthorityOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range>
          <owl:Class>
@@ -4287,19 +5006,22 @@
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfOwnershipRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfOwnershipRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'is owner of' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is owner of' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">owned by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R037i ('owned by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOwnerOf"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#OwnershipRelation"/>
       <rdfs:range>
          <owl:Class>
@@ -4310,38 +5032,53 @@
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
-      <rdfs:comment xml:lang="en">Connects an Ownership Relation to a Person, Group or Position
-            that is involved as an owner.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects an Ownership Relation to a Person, Group or Position that
+         is involved as an owner.</rdfs:comment>
       <rdfs:label xml:lang="en">ownership relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfOwnershipRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfOwnershipRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfOwnershipRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfOwnershipRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#OwnershipRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an Ownership Relation to a Thing that is
-            owned.</rdfs:comment>
+         owned.</rdfs:comment>
       <rdfs:label xml:lang="en">owner ship relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PerformanceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
-      <rdfs:comment xml:lang="en">Connects a Performance Relation to a performed Activity.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Performance Relation to a performed
+         Activity.</rdfs:comment>
       <rdfs:label xml:lang="en">performance relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#activityIsSourceOfPerformanceRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#activityIsSourceOfPerformanceRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PerformanceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
-      <rdfs:comment xml:lang="en">Connects a Performance Relation to a performing Agent.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Performance Relation to a performing
+         Agent.</rdfs:comment>
       <rdfs:label xml:lang="en">performance relation has target </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfPerformanceRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfPerformanceRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#performedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#performedBy">
@@ -4350,14 +5087,16 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#activityIsSourceOfPerformanceRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#activityIsSourceOfPerformanceRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Activity to an Agent that performs the
-            Activity.</rdfs:comment>
+         Activity.</rdfs:comment>
       <rdfs:label xml:lang="en">performed by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R060 ('performed by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#performs -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#performs">
@@ -4365,313 +5104,420 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfPerformanceRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfPerformanceRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'performed by' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'performed by' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">performs </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R060i ('performs'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#performedBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personHasCorrespondenceRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personHasCorrespondenceRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personHasCorrespondenceRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#CorrespondenceRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person to a Correspondence Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person has correspondence relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#FamilyRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person to a Family Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person has family relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#KnowingRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person to a Knowing Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person has knowing relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personHasSiblingRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSiblingRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#siblingRelationConnects"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSiblingRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#siblingRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#SiblingRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person to a Sibling Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person has sibling relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personHasSpouseRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSpouseRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#spouseRelationConnects"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSpouseRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#spouseRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#SpouseRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person to a Spouse Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person has spouse relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsSourceOfAgentSubordinationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfAgentSubordinationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfAgentSubordinationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
-      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentSubordinationRelation"/>
+      <rdfs:range
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentSubordinationRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (who is hierarchically superior) to an Agent
-            Subordination Relation.</rdfs:comment>
+         Subordination Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person is source of agent subordination relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasSource"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsSourceOfChildRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfChildRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfChildRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ChildRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (as a parent) to a Child
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person is source of child relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#childRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#childRelationHasSource"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#DescendanceRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (as an ancestor) to a Descendance
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person is source of descendance relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsSourceOfKnowingOfRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfKnowingOfRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfKnowingOfRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#KnowingOfRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (who has some knowledge of another one) to a
-            Knowing Of Relation.</rdfs:comment>
+         Knowing Of Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person is source of knowing of relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsSourceOfLeadershipRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfLeadershipRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfLeadershipRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#LeadershipRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (as a leader) to a Leadership
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person is source of leadership relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsSourceOfPositionHoldingRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfPositionHoldingRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfPositionHoldingRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PositionHoldingRelation"/>
-      <rdfs:comment xml:lang="en">Connects a Person (who occupies a Position) to a Position
-            Holding Relation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Person (who occupies a Position) to a Position Holding
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person is source of position holding relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsSourceOfTeachingRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfTeachingRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfTeachingRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#TeachingRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (as a teacher) to a Teaching
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person is source of teaching relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsTargetOfAgentSubordinationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfAgentSubordinationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfAgentSubordinationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
-      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentSubordinationRelation"/>
+      <rdfs:range
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentSubordinationRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (who is hierarchically inferior) to an Agent
-            Subordination Relation.</rdfs:comment>
+         Subordination Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person is target of agent subordination relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasTarget"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsTargetOfChildRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfChildRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfChildRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ChildRelation"/>
-      <rdfs:comment xml:lang="en">Connects a Person (as a child) to a Child
-            Relation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Person (as a child) to a Child Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person is target of child relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#childRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#childRelationHasTarget"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#DescendanceRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (as a descendant) to a Descendance
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person is target of descendance relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsTargetOfKnowingOfRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfKnowingOfRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfKnowingOfRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#KnowingOfRelation"/>
-      <rdfs:comment xml:lang="en">Connects a Person (of which another Person has some knowledge)
-            to a Knowing Of Relation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Person (of which another Person has some knowledge) to
+         a Knowing Of Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person is target of knowing of relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsTargetOfMembershipRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfMembershipRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfMembershipRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#MembershipRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (as a member of a Group) to a Membership
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person is target of membership relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsTargetOfTeachingRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfTeachingRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfTeachingRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#TeachingRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (as a student) to a Teaching
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">person is target of teaching relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#placeIsSourceOfPlaceRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#placeIsSourceOfPlaceRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#placeRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#placeIsSourceOfPlaceRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#placeRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PlaceRelation"/>
       <rdfs:comment xml:lang="en">Connects a Place (as associated to a Thing) to a Place
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">place is source of place relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#placeRelationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#placeRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PlaceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:comment xml:lang="en">Connects a Place Relation to the Place concerned.</rdfs:comment>
       <rdfs:label xml:lang="en">place relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#placeIsSourceOfPlaceRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#placeIsSourceOfPlaceRelation"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#placeRelationHasTarget -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#placeRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfPlaceRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfPlaceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PlaceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Place Relation to a Thing that is associated to the
-            Place.</rdfs:comment>
+         Place.</rdfs:comment>
       <rdfs:label xml:lang="en">place relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PositionHoldingRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Position Holding Relation to a Person (who occupies a
-            Position).</rdfs:comment>
+         Position).</rdfs:comment>
       <rdfs:label xml:lang="en">position holding relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfPositionHoldingRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfPositionHoldingRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#positionIsTargetOfPositionHoldingRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#positionIsTargetOfPositionHoldingRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PositionHoldingRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:comment xml:lang="en">Connects a Position Holding Relation to a Position (that is
-            occupied).</rdfs:comment>
+         occupied).</rdfs:comment>
       <rdfs:label xml:lang="en">position holding relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionIsContextOfLeadershipRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsContextOfLeadershipRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsContextOfLeadershipRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#LeadershipRelation"/>
       <rdfs:comment xml:lang="en">Connects a Position to a Leadership Relation (the leading Person
-            occupies that Position).</rdfs:comment>
+         occupies that Position).</rdfs:comment>
       <rdfs:label xml:lang="en">position is context of leadership relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipWithPosition"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipWithPosition"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionIsContextOfMembershipRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsContextOfMembershipRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsContextOfMembershipRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#MembershipRelation"/>
       <rdfs:comment xml:lang="en">Connects a Position to a Membership Relation (the member Person
-            occupies that Position).</rdfs:comment>
+         occupies that Position).</rdfs:comment>
       <rdfs:label xml:lang="en">position is context of membership relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipWithPosition"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipWithPosition"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionIsSourceOfPositionToGroupRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsSourceOfPositionToGroupRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsSourceOfPositionToGroupRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PositionToGroupRelation"/>
-      <rdfs:comment xml:lang="en">Connects a Position (that exists within a Group) to a Position
-            to Group Relation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Position (that exists within a Group) to a Position to
+         Group Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">position is source of position to group relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionIsTargetOfPositionHoldingRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsTargetOfPositionHoldingRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsTargetOfPositionHoldingRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PositionHoldingRelation"/>
       <rdfs:comment xml:lang="en">Connects a Position (that is occupied by a Person) to a Position
-            Holding Relation.</rdfs:comment>
+         Holding Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">position is target of position holding relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PositionToGroupRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:comment xml:lang="en">Connects a Position to Group Relation to a Position (that exists
-            in a Group).</rdfs:comment>
+         in a Group).</rdfs:comment>
       <rdfs:label xml:lang="en">position to group relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#positionIsSourceOfPositionToGroupRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#positionIsSourceOfPositionToGroupRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PositionToGroupRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:comment xml:lang="en">Connects a Position to Group Relation to a Group (in which a
-            Position exists).</rdfs:comment>
+         Position exists).</rdfs:comment>
       <rdfs:label xml:lang="en">position to group relation has target </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfPositionToGroupRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfPositionToGroupRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#precedes -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#precedes">
@@ -4679,19 +5525,21 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Thing to a Thing that follows it in some
-            sequence.</rdfs:comment>
+         sequence.</rdfs:comment>
       <rdfs:label xml:lang="en">precedes </rdfs:label>
       <skos:scopeNote xml:lang="en">The relation does not specify by itself what criteria are used
-            for ordering the sequence. There may actually be zero to many intermediate Entities,
-            ignored or unkown, in the sequence between the two connected Things. Can be used, for
-            example, for specifying that some Record 'precedes' (has next) some Record
-            within a Record Set.</skos:scopeNote>
+         for ordering the sequence. There may actually be zero to many intermediate Entities,
+         ignored or unkown, in the sequence between the two connected Things. Can be used, for
+         example, for specifying that some Record 'precedes' (has next) some Record within a Record
+         Set.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R008 ('precedes'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#follows"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#precedesInTime -->
@@ -4700,39 +5548,47 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Thing to a Thing that follows it in chronological
-            order.</rdfs:comment>
+         order.</rdfs:comment>
       <rdfs:label xml:lang="en">precedes in time </rdfs:label>
       <skos:scopeNote xml:lang="en">There may actually be zero to many intermediate Entities,
-            ignored or unknown, in the chronological sequence between the two connected
-            Entities.</skos:scopeNote>
+         ignored or unknown, in the chronological sequence between the two connected
+         Entities.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R009 ('precedes in time'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInTime"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ProvenanceRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <rdfs:comment xml:lang="en">Connects a Provenance Relation to a Record Resource or
-            Instantiation.</rdfs:comment>
+         Instantiation.</rdfs:comment>
       <rdfs:label xml:lang="en">provenance relation has source </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ProvenanceRelation"/>
       <rdfs:range>
          <owl:Class>
@@ -4743,9 +5599,11 @@
          </owl:Class>
       </rdfs:range>
       <rdfs:comment xml:lang="en">Connects a Provenance Relation to an Agent or
-            Activity.</rdfs:comment>
+         Activity.</rdfs:comment>
       <rdfs:label xml:lang="en">provenance relation has target </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#proxyFor -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor">
@@ -4753,7 +5611,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:comment xml:lang="en">Connects a Proxy to the Record Resource it stands for in the
-            specific context of a Record Set.</rdfs:comment>
+         specific context of a Record Set.</rdfs:comment>
       <rdfs:label xml:lang="en">proxy for </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#proxyIn -->
@@ -4762,7 +5620,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a Proxy to the Record Set in which it stands for
-            (represents) another Record Resource.</rdfs:comment>
+         (represents) another Record Resource.</rdfs:comment>
       <rdfs:label xml:lang="en">proxy in </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#publishedBy -->
@@ -4772,7 +5630,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Record resource to an Agent who published
-            it.</rdfs:comment>
+         it.</rdfs:comment>
       <rdfs:label xml:lang="en">published by </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#publishes -->
@@ -4781,7 +5639,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:comment xml:lang="en">Connects an Agent to a Record Resource that it
-            published.</rdfs:comment>
+         published.</rdfs:comment>
       <rdfs:label xml:lang="en">publishes </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#publishedBy"/>
    </owl:ObjectProperty>
@@ -4793,16 +5651,17 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource or an Instantiation to the Agent that
-            receives it in the course of its activities.</rdfs:comment>
+         receives it in the course of its activities.</rdfs:comment>
       <rdfs:label xml:lang="en">received by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R029 ('received by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#receives -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#receives">
@@ -4812,379 +5671,463 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
-      <rdfs:comment xml:lang="en">Inverse of 'received by' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'received by' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">receives </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R029i (receives
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#receivedBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceGeneticRelationConnects -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceGeneticRelationConnects">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceGeneticRelation"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceGeneticRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceGeneticRelationConnects">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceGeneticRelation"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceGeneticRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource Genetic Relation to one of the
-            associated Record Resources.</rdfs:comment>
+         associated Record Resources.</rdfs:comment>
       <rdfs:label xml:lang="en">record resource genetic relation connects </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource Holding Relation to an Agent (as the
-            holder of a Record Resource or Instantiation).</rdfs:comment>
+         holder of a Record Resource or Instantiation).</rdfs:comment>
       <rdfs:label xml:lang="en">record resource holding relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfRecordResourceHoldingRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfRecordResourceHoldingRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfRecordResourceHoldingRelation"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfRecordResourceHoldingRelation"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <rdfs:comment xml:lang="en">Connects a Record Resource Holding Relation to a Record Resource
-            or Instantiation (that is held by an Agent).</rdfs:comment>
+         or Instantiation (that is held by an Agent).</rdfs:comment>
       <rdfs:label xml:lang="en">record resource holding relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceGeneticRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceGeneticRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceGeneticRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceGeneticRelation"/>
+      <rdfs:range
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceGeneticRelation"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource to a Record Resource Genetic
-            Relation.</rdfs:comment>
-      <rdfs:label xml:lang="en">record resource is connected to record resource genetic relation
-        </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceGeneticRelationConnects"/>
+         Relation.</rdfs:comment>
+      <rdfs:label xml:lang="en">record resource is connected to record resource genetic relation </rdfs:label>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceGeneticRelationConnects"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation"/>
+      <rdfs:range
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource to a Record Resource
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">record resource is connected to record resource relation
-        </rdfs:label>
+      </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceIsSourceOfRecordResourceToInstantiationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsSourceOfRecordResourceToInstantiationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsSourceOfRecordResourceToInstantiationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation"/>
+      <rdfs:range
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource (that was instantiated) to a Record
-            Resource To Instantiation Relation</rdfs:comment>
+         Resource To Instantiation Relation</rdfs:comment>
       <rdfs:label xml:lang="en">record resource is source of record resource to instantiation
-            relation </rdfs:label>
+         relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAccumulationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAccumulationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAccumulationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AccumulationRelation"/>
-      <rdfs:comment xml:lang="en">Connects a Record Resource or Instantiation (that is
-            accumulated) to an Accumulation Relation.</rdfs:comment>
-      <rdfs:label xml:lang="en">record resource or instantiation is source of accumulation
-            relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource"/>
+      <rdfs:comment xml:lang="en">Connects a Record Resource or Instantiation (that is accumulated)
+         to an Accumulation Relation.</rdfs:comment>
+      <rdfs:label xml:lang="en">record resource or instantiation is source of accumulation relation </rdfs:label>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfActivityDocumentationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfActivityDocumentationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfActivityDocumentationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
-      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation"/>
+      <rdfs:range
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource or Instantiation (that documents an
-            Activity) to an Activity Documentation Relation.</rdfs:comment>
-      <rdfs:label xml:lang="en">record resource or instantiation is source of activity
-            documentation relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasSource"/>
+         Activity) to an Activity Documentation Relation.</rdfs:comment>
+      <rdfs:label xml:lang="en">record resource or instantiation is source of activity documentation
+         relation </rdfs:label>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasSource"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
-      <rdfs:comment xml:lang="en">Connects a Record Resource or Instantiation (that is created,
-            sent or accumulated) to an Agent Origination Relation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Record Resource or Instantiation (that is created, sent
+         or accumulated) to an Agent Origination Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">record resource or instantiation is source of agent origination
-            relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"/>
+         relation </rdfs:label>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfCreationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfCreationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfCreationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#CreationRelation"/>
-      <rdfs:comment xml:lang="en">Connects a Record Resource or Instantiation (that is created) to
-            a Creation Relation.</rdfs:comment>
-      <rdfs:label xml:lang="en">record resource or instantiation is source of creation relation
-        </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource"/>
+      <rdfs:comment xml:lang="en">Connects a Record Resource or Instantiation (that is created) to a
+         Creation Relation.</rdfs:comment>
+      <rdfs:label xml:lang="en">record resource or instantiation is source of creation relation </rdfs:label>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ProvenanceRelation"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource or Instantiation (that is created or
-            accumulated by an Agent, or documents an Activity) to a Provenance
-            Relation.</rdfs:comment>
-      <rdfs:label xml:lang="en">record resource or instantiation is source of provenance relation
-        </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource"/>
+         accumulated by an Agent, or documents an Activity) to a Provenance Relation.</rdfs:comment>
+      <rdfs:label xml:lang="en">record resource or instantiation is source of provenance relation </rdfs:label>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfIntellectualPropertyRightsRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfIntellectualPropertyRightsRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfIntellectualPropertyRightsRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
-      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation"/>
+      <rdfs:range
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource or Instantiation (on which some
-            intellectual property rights are held) to an Intellectual Property Rights
-            Relation.</rdfs:comment>
-      <rdfs:label xml:lang="en">record resource or instantiation is target of intellectual
-            property rights relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget"/>
+         intellectual property rights are held) to an Intellectual Property Rights
+         Relation.</rdfs:comment>
+      <rdfs:label xml:lang="en">record resource or instantiation is target of intellectual property
+         rights relation </rdfs:label>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ManagementRelation"/>
-      <rdfs:comment xml:lang="en">Connects a Record Resource or Instantiation (that is managed by
-            an Agent) to a Management Relation.</rdfs:comment>
-      <rdfs:label xml:lang="en">record resource or instantiation is target of management relation
-        </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget"/>
+      <rdfs:comment xml:lang="en">Connects a Record Resource or Instantiation (that is managed by an
+         Agent) to a Management Relation.</rdfs:comment>
+      <rdfs:label xml:lang="en">record resource or instantiation is target of management relation </rdfs:label>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfRecordResourceHoldingRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfRecordResourceHoldingRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfRecordResourceHoldingRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
-      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation"/>
+      <rdfs:range
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource or Instantiation (that is held by an
-            Agent) to a Record Resource Holding Relation.</rdfs:comment>
+         Agent) to a Record Resource Holding Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">record resource or instantiation is target of record resource
-            holding relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget"/>
+         holding relation </rdfs:label>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects">
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationConnects"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource relation to one of the related Record
-            Resources.</rdfs:comment>
+         Resources.</rdfs:comment>
       <rdfs:label xml:lang="en">record resource relation connects </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-      <rdfs:comment xml:lang="en">Connects a Record Resource To Instantiation Relation to the
-            Record Resource (that was instantiated). </rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Record Resource To Instantiation Relation to the Record
+         Resource (that was instantiated). </rdfs:comment>
       <rdfs:label xml:lang="en">record resource to instantiation relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceIsSourceOfRecordResourceToInstantiationRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceIsSourceOfRecordResourceToInstantiationRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <rdfs:domain
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource To Instantiation Relation to an
-            Instantiation of the involved Record Resource. </rdfs:comment>
+         Instantiation of the involved Record Resource. </rdfs:comment>
       <rdfs:label xml:lang="en">record resource to instantiation relation has target </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfRecordResourceToInstantiationRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfRecordResourceToInstantiationRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#regulatedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#regulatedBy">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#regulates"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
-      <rdfs:comment xml:lang="en">Inverse of the 'regulates' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of the 'regulates' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">regulated by </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R063i ('regulated by'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#regulates -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#regulates">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Rule to a Thing that it regulates</rdfs:comment>
       <rdfs:label xml:lang="en">regulates </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R063 ('regulates'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#regulatedBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#relationConnects -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#relationConnects">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an n-ary Relation to any of the Things
-            involved.</rdfs:comment>
+         involved.</rdfs:comment>
       <rdfs:label xml:lang="en">relation connects </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#relationHasContext -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasContext">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationConnects"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an n-ary Relation to a Thing that is a secondary,
-            contextual entity during the existence of the Relation.</rdfs:comment>
+         contextual entity during the existence of the Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">relation has context </rdfs:label>
-      <skos:scopeNote xml:lang="en">The secondary entity may be, for instance, a Position or a
-            Role Type.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">The secondary entity may be, for instance, a Position or a Role
+         Type.</skos:scopeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#relationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasSource">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationConnects"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an n-ary Relation to a Thing that is its
-            source.</rdfs:comment>
+         source.</rdfs:comment>
       <rdfs:label xml:lang="en">relation has source </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#relationHasTarget -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasTarget">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationConnects"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an n-ary Relation to a Thing that is its
-            target.</rdfs:comment>
+         target.</rdfs:comment>
       <rdfs:label xml:lang="en">relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#repliesTo -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#repliesTo">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInTime"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-      <rdfs:comment xml:lang="en">Inverse of 'is replied to by' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is replied to by' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">replies to </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R013i ('replies' to
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRepliedToBy"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#resultsFrom -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#resultsFrom">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#resultsIn"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
-      <rdfs:comment xml:lang="en">Inverse of 'results in' object
-            property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'results in' object property.</rdfs:comment>
       <rdfs:label xml:lang="en">results from </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R061i ('results from'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#resultsIn -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#resultsIn">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an Event to a Thing that results from the
-            Event.</rdfs:comment>
+         Event.</rdfs:comment>
       <rdfs:label xml:lang="en">results in </rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R061 ('results in'
-            relation)</RiCCMCorrespondingComponent>
+         relation)</RiCCMCorrespondingComponent>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#resultsFrom"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#roleIsContextOfCreationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#roleIsContextOfCreationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#roleIsContextOfCreationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RoleType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#CreationRelation"/>
-      <rdfs:comment xml:lang="en">Connects a Role Type to a Creation Relation (this Role Type
-            being the specific role played by the creating Person in the context of this
-            Relation).</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Role Type to a Creation Relation (this Role Type being
+         the specific role played by the creating Person in the context of this
+         Relation).</rdfs:comment>
       <rdfs:label xml:lang="en">role is context of creation relation </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#creationWithRole"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RuleRelation"/>
@@ -5193,107 +6136,139 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RuleRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <rdfs:comment xml:lang="en">Connects a Rule Relation to a Rule.</rdfs:comment>
       <rdfs:label xml:lang="en">rule relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RuleRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Rule Relation to a Thing (that is associated to a
-            Rule).</rdfs:comment>
+         Rule).</rdfs:comment>
       <rdfs:label xml:lang="en">rule relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#SequentialRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Sequential Relation to a Thing that precedes other
-            Thing(s) in the sequence.</rdfs:comment>
+         Thing(s) in the sequence.</rdfs:comment>
       <rdfs:label xml:lang="en">sequential relation has source </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#SequentialRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Sequential Relation to a Thing that follows other
-            Thing(s) in the sequence.</rdfs:comment>
+         Thing(s) in the sequence.</rdfs:comment>
       <rdfs:label xml:lang="en">sequential relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#siblingRelationConnects -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#siblingRelationConnects">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#siblingRelationConnects">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#SiblingRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Sibling Relation to one of the siblings
-            involved.</rdfs:comment>
+         involved.</rdfs:comment>
       <rdfs:label xml:lang="en">sibling relation connects </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasSiblingRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasSiblingRelation"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#spouseRelationConnects -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#spouseRelationConnects">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#SpouseRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Sibling Relation to one of the spouses
-            involved.</rdfs:comment>
+         involved.</rdfs:comment>
       <rdfs:label xml:lang="en">spouse relation connects </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasSpouseRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasSpouseRelation"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#TeachingRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Teaching Relation to a Person (who is a
-            teacher).</rdfs:comment>
+         teacher).</rdfs:comment>
       <rdfs:label xml:lang="en">teaching relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfTeachingRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfTeachingRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#TeachingRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Teaching Relation to a Person (who is a
-            student).</rdfs:comment>
+         student).</rdfs:comment>
       <rdfs:label xml:lang="en">teaching relation has target </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfTeachingRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfTeachingRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#TemporalRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Temporal Relation to a Thing that precedes other
-            Thing(s) in time.</rdfs:comment>
+         Thing(s) in time.</rdfs:comment>
       <rdfs:label xml:lang="en">temporal relation has source </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#TemporalRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Temporal Relation to a Thing that follows other
-            Thing(s) in time.</rdfs:comment>
+         Thing(s) in time.</rdfs:comment>
       <rdfs:label xml:lang="en">temporal relation has target </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation">
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
@@ -5302,108 +6277,138 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationConnects"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:comment xml:lang="en">Connects a Thing (that is a secondary, contextual entity during
-            the existence of the Relation) to a n-ary Relation.</rdfs:comment>
+         the existence of the Relation) to a n-ary Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">thing is context of relation </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:comment xml:lang="en">Connects a Thing (that is the source of a Relation) to a
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">thing is source of relation </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#SequentialRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing to a Sequential Relation, when this Thing
-            precedes other Thing(s) in the sequence.</rdfs:comment>
+         precedes other Thing(s) in the sequence.</rdfs:comment>
       <rdfs:label xml:lang="en">thing is source of sequential relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#TemporalRelation"/>
-      <rdfs:comment xml:lang="en">Connects a Thing to a Temporal Relation, when this Thing
-            precedes other Thing(s) in time.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Thing to a Temporal Relation, when this Thing precedes
+         other Thing(s) in time.</rdfs:comment>
       <rdfs:label xml:lang="en">thing is source of temporal relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#WholePartRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing to a Whole Part Relation, when this Thing has
-            Part other Thing(s).</rdfs:comment>
+         Part other Thing(s).</rdfs:comment>
       <rdfs:label xml:lang="en">thing is source of whole part relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAppellationRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAppellationRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAppellationRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AppellationRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing (that is designated by an Appellation) to an
-            Appellation Relation.</rdfs:comment>
+         Appellation Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">thing is target of appellation relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationRelationHasTarget"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorityRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing (that is under authority of an Agent) to an
-            Authority Relation.</rdfs:comment>
+         Authority Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">thing is target of authority relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfEventRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfEventRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfEventRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#EventRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing (that is associated with an Event) to an Event
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">thing is target of event relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#eventRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#eventRelationHasTarget"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfOwnershipRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfOwnershipRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfOwnershipRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#OwnershipRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing (that is owned by a Group, a Person or a
-            Position) to an Ownership Relation.</rdfs:comment>
+         Position) to an Ownership Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">thing is target of ownership relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfPlaceRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfPlaceRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfPlaceRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PlaceRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing (that is associated with a Place) to a Place
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">thing is target of place relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#placeRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#placeRelationHasTarget"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:comment xml:lang="en">Connects a Thing to a n-ary Relation.</rdfs:comment>
@@ -5411,58 +6416,74 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RuleRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing (that is associated with a Rule) to a Rule
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">thing is target of rule relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#SequentialRelation"/>
-      <rdfs:comment xml:lang="en">Connects a Thing (that follows other Thing(s) in a sequence) to
-            a Sequential Relation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Thing (that follows other Thing(s) in a sequence) to a
+         Sequential Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">thing is target of sequential relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#TemporalRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing (that follows other Thing(s) in time) to a
-            Temporal Relation.</rdfs:comment>
+         Temporal Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">thing is target of temporal relation </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTypeRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTypeRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTypeRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#typeRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#TypeRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing (that is categorized by a Type) to a Type
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">thing is target of type relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#WholePartRelation"/>
-      <rdfs:comment xml:lang="en">Connects a Thing to a Whole Part Relation, when this Thing is
-            Part of another Thing.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Thing to a Whole Part Relation, when this Thing is Part
+         of another Thing.</rdfs:comment>
       <rdfs:label xml:lang="en">thing is target of whole part relation </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#typeIsSourceOfTypeRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#typeIsSourceOfTypeRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#typeIsSourceOfTypeRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#typeRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#TypeRelation"/>
@@ -5471,82 +6492,99 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#typeRelationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#typeRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#TypeRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:comment xml:lang="en">Connects a Type Relation to the Type (that categorizes the
-            involved Thing(s)).</rdfs:comment>
+         involved Thing(s)).</rdfs:comment>
       <rdfs:label xml:lang="en">type relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#typeIsSourceOfTypeRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#typeIsSourceOfTypeRelation"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#typeRelationHasTarget -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#typeRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#TypeRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Type Relation to a Thing (that is categorized by the
-            involved Type).</rdfs:comment>
+         involved Type).</rdfs:comment>
       <rdfs:label xml:lang="en">type relation has target </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTypeRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTypeRelation"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#wasLastUpdatedAtDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#wasLastUpdatedAtDate">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasModificationDate"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasModificationDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:comment xml:lang="en">Connects a Thing to the Date when it was last
-            modified.</rdfs:comment>
+         modified.</rdfs:comment>
       <rdfs:label xml:lang="en">was last updated at date </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isLastUpdateDateOf"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#wasUsedFromDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#wasUsedFromDate">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:comment xml:lang="en">Connects an Appellation to the Date from which it was
-            used.</rdfs:comment>
+         used.</rdfs:comment>
       <rdfs:label xml:lang="en">was used from date </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isFromUseDateOf"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#wasUsedToDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#wasUsedToDate">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:comment xml:lang="en">Connects an Appellation to the Date till when it was
-            used.</rdfs:comment>
+         used.</rdfs:comment>
       <rdfs:label xml:lang="en">was used to date </rdfs:label>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isToUseDateOf"/>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#WholePartRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Whole Part Relation to the Thing that has some
-            parts.</rdfs:comment>
+         parts.</rdfs:comment>
       <rdfs:label xml:lang="en">whole part relation has source </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#WholePartRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Whole Part Relation to a Thing that is a
-            part.</rdfs:comment>
+         part.</rdfs:comment>
       <rdfs:label xml:lang="en">whole part relation has target </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation"
+      />
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#workRelationConnects -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#workRelationConnects">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#WorkRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Work Relation to an Agent.</rdfs:comment>
       <rdfs:label xml:lang="en">work relation connects </rdfs:label>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHasWorkRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHasWorkRelation"
+      />
    </owl:ObjectProperty>
    <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -5560,11 +6598,11 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Information on the anticipated accession(s) to the Record
-            Set.</rdfs:comment>
+         Set.</rdfs:comment>
       <rdfs:label xml:lang="en">accrual</rdfs:label>
       <skos:scopeNote xml:lang="en">See also accrualStatus</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">corresponds to RiC-A01 (Accrual
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#accrualStatus -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#accrualStatus">
@@ -5574,7 +6612,7 @@
       <rdfs:label xml:lang="en">accrual status</rdfs:label>
       <skos:scopeNote xml:lang="en">See also accrual</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">corresponds to RiC-A01 (Accrual
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#altimetricSystem -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#altimetricSystem">
@@ -5590,10 +6628,10 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Coordinates"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">The height of a Place above a reference level, especially above
-            sea level.</rdfs:comment>
+         sea level.</rdfs:comment>
       <rdfs:label xml:lang="en">altitude</rdfs:label>
-      <skos:scopeNote xml:lang="en">Property of the Coordinates class. If you don't use this
-            class, use geographicalCoordinates property, a property of Place class.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Property of the Coordinates class. If you don't use this class,
+         use geographicalCoordinates property, a property of Place class.</skos:scopeNote>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#authenticityNote -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#authenticityNote">
@@ -5601,19 +6639,20 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Description of evidences that the Record Resource or
-            Instantiation is what it purports to be, was created or sent by the said Agent, at the
-            said time and has not been tampered or corrupted. </rdfs:comment>
+      <rdfs:comment xml:lang="en">Description of evidences that the Record Resource or Instantiation
+         is what it purports to be, was created or sent by the said Agent, at the said time and has
+         not been tampered or corrupted. </rdfs:comment>
       <rdfs:label xml:lang="en">authenticity note</rdfs:label>
       <skos:scopeNote xml:lang="en">For electronic records, it may include results from automated
-            means of checking the validity of signatures and timestamp.</skos:scopeNote>
+         means of checking the validity of signatures and timestamp.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A03 (Authenticity Note
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#authorizingMandate -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#authorizingMandate">
@@ -5621,11 +6660,11 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Information on a Mandate that authorizes an Agent to perform an
-            Activity.</rdfs:comment>
+         Activity.</rdfs:comment>
       <rdfs:label xml:lang="en">authorizing mandate</rdfs:label>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
-            later on. Use only if you don't use the Mandate class for handling
-            mandates.</skos:scopeNote>
+         later on. Use only if you don't use the Mandate class for handling
+         mandates.</skos:scopeNote>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#beginningDate -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#beginningDate">
@@ -5635,10 +6674,9 @@
       <rdfs:comment xml:lang="en">Date at which something began.</rdfs:comment>
       <rdfs:label xml:lang="en">beginning date</rdfs:label>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
-            later on. Use only if you don't use Date classes for handling
-            dates.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of
-            RiC-E18 (Date entity)</RiCCMCorrespondingComponent>
+         later on. Use only if you don't use Date classes for handling dates.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of RiC-E18
+         (Date entity)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#birthDate -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#birthDate">
@@ -5648,37 +6686,36 @@
       <rdfs:comment xml:lang="en">Date at which a Person was born.</rdfs:comment>
       <rdfs:label xml:lang="en">birth date</rdfs:label>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
-            later on. Use only if you don't use Date classes for handling
-            dates.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of
-            RiC-E18 (Date entity)</RiCCMCorrespondingComponent>
+         later on. Use only if you don't use Date classes for handling dates.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of RiC-E18
+         (Date entity)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#calendar -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#calendar">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#dateStandard"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Used system of reckoning time in which the beginning, length,
-            and divisions of a year are defined, sometimes along with multiyear
-            cycles.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Used system of reckoning time in which the beginning, length, and
+         divisions of a year are defined, sometimes along with multiyear cycles.</rdfs:comment>
       <rdfs:label xml:lang="en">calendar</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Specialization of RiC-A14 (Date Standard
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#carrierExtent -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#carrierExtent">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Number of physical units and/or physical dimensions of Record
-            Resource carriers.</rdfs:comment>
+         Resource carriers.</rdfs:comment>
       <rdfs:label xml:lang="en">carrier extent</rdfs:label>
       <skos:scopeNote xml:lang="en">For electronic resources, it indicates the size of storage
-            capacity (disk, tape, film etc.). The attribute may be different from the Instantiation
-            Extent data ropertyy. For example, the Carrier Extent of a movie may be 4 GB (as DVD),
-            while Instantiation Extent may be 2 GB.</skos:scopeNote>
+         capacity (disk, tape, film etc.). The attribute may be different from the Instantiation
+         Extent data ropertyy. For example, the Carrier Extent of a movie may be 4 GB (as DVD),
+         while Instantiation Extent may be 2 GB.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A04 (Carrier Extent
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#certainty -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#certainty">
@@ -5693,20 +6730,20 @@
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Used to express the degree of certitude of a Date, an Event or a
-            Relation.</rdfs:comment>
+         Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">certainty</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A06 (Certainty
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#classification -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#classification">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Information on the criterion or criteria that may be used to
-            identify a Record as a member of a Record Set.</rdfs:comment>
+         identify a Record as a member of a Record Set.</rdfs:comment>
       <rdfs:label xml:lang="en">classification</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A07 (Classification
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#conditionsOfAccess -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#conditionsOfAccess">
@@ -5714,16 +6751,17 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Terms and circumstances affecting the availability of a Record
-            for consultation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Terms and circumstances affecting the availability of a Record for
+         consultation.</rdfs:comment>
       <rdfs:label xml:lang="en">conditions of access</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A08 (Conditions of Access
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#conditionsOfUse -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#conditionsOfUse">
@@ -5731,16 +6769,17 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Terms and circumstances affecting the availability for use after
-            access has been provided.</rdfs:comment>
+         access has been provided.</rdfs:comment>
       <rdfs:label xml:lang="en">conditions of use</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A09 (Conditions of Use
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#creationDate -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#creationDate">
@@ -5750,44 +6789,42 @@
       <rdfs:comment xml:lang="en">Date at which an entity was created.</rdfs:comment>
       <rdfs:label xml:lang="en">creation date</rdfs:label>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
-            later on. Use only if you don't use Date classes for handling
-            dates.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of
-            RiC-E18 (Date entity)</RiCCMCorrespondingComponent>
+         later on. Use only if you don't use Date classes for handling dates.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of RiC-E18
+         (Date entity)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#date -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#date">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Chronological information associated with an entity that
-            contributes to its identification and contextualization.</rdfs:comment>
+         contributes to its identification and contextualization.</rdfs:comment>
       <rdfs:label xml:lang="en">date</rdfs:label>
       <skos:scopeNote xml:lang="en">Provided for usability reasons, like its subproperties. May be
-            deprecated and removed later on. Use only if you don't use Date classes for
-            handling dates.</skos:scopeNote>
+         deprecated and removed later on. Use only if you don't use Date classes for handling
+         dates.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Data property implementation of RiC-E18 (Date
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#dateQualifier -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#dateQualifier">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Indicates the precision of a date. It specifies if, and to what
-            extent, the value is an estimation.</rdfs:comment>
+         extent, the value is an estimation.</rdfs:comment>
       <rdfs:label xml:lang="en">date qualifier</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A13 (Date Qualifier
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#dateStandard -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#dateStandard">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#referenceSystem"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Identifier of the standard of the Normalized
-            date.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Identifier of the standard of the Normalized date.</rdfs:comment>
       <rdfs:label xml:lang="en">date standard</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A14 (Date Standard
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#deathDate -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#deathDate">
@@ -5797,10 +6834,9 @@
       <rdfs:comment xml:lang="en">Date at which a Person died.</rdfs:comment>
       <rdfs:label xml:lang="en">death date</rdfs:label>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
-            later on. Use only if you don't use Date classes for handling
-            dates.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of
-            RiC-E18 (Date entity)</RiCCMCorrespondingComponent>
+         later on. Use only if you don't use Date classes for handling dates.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of RiC-E18
+         (Date entity)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#deletionDate -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#deletionDate">
@@ -5810,20 +6846,19 @@
       <rdfs:comment xml:lang="en">Date at which an entity was deleted.</rdfs:comment>
       <rdfs:label xml:lang="en">deletion date</rdfs:label>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
-            later on. Use only if you don't use Date classes for handling
-            dates.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of
-            RiC-E18 (Date entity)</RiCCMCorrespondingComponent>
+         later on. Use only if you don't use Date classes for handling dates.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of RiC-E18
+         (Date entity)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#descriptiveNote -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#descriptiveNote">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Descriptive information about an entity that is not otherwise
-            addressed.</rdfs:comment>
+         addressed.</rdfs:comment>
       <rdfs:label xml:lang="en">descriptive note</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A16 (Descriptive Note
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#endDate -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#endDate">
@@ -5833,10 +6868,9 @@
       <rdfs:comment xml:lang="en">Date at which something ended.</rdfs:comment>
       <rdfs:label xml:lang="en">end date</rdfs:label>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
-            later on. Use only if you don't use Date classes for handling
-            dates.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of
-            RiC-E18 (Date entity)</RiCCMCorrespondingComponent>
+         later on. Use only if you don't use Date classes for handling dates.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of RiC-E18
+         (Date entity)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#expressedDate -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#expressedDate">
@@ -5846,29 +6880,29 @@
       <rdfs:comment xml:lang="en">Natural language expression of a Date.</rdfs:comment>
       <rdfs:label xml:lang="en">expressed date</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A19 (Expressed Date
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#geodesicSystem -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#geodesicSystem">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#referenceSystem"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Coordinates"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Reference system used for geographical
-            coordinates.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Reference system used for geographical coordinates.</rdfs:comment>
       <rdfs:label xml:lang="en">geodesic system</rdfs:label>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#geographicalCoordinates -->
-   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#geographicalCoordinates">
+   <owl:DatatypeProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#geographicalCoordinates">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Longitudinal and latitudinal information of an
-            entity.</rdfs:comment>
+         entity.</rdfs:comment>
       <rdfs:label xml:lang="en">geographical coordinates</rdfs:label>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
-            later on. Use only if you don't use PhysicalLocation and Coordinates classes with
-            Place.</skos:scopeNote>
+         later on. Use only if you don't use PhysicalLocation and Coordinates classes with
+         Place.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A11 (Coordinates
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#height -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#height">
@@ -5887,54 +6921,57 @@
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Agent"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Place"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Rule"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Summary of the evolution of an entity, since its origin until
-            present time. </rdfs:comment>
+         present time. </rdfs:comment>
       <rdfs:label xml:lang="en">history</rdfs:label>
-      <skos:scopeNote xml:lang="en">History can alternatively be represented by a series of
-            related Events.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">History can alternatively be represented by a series of related
+         Events.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A21 (History
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#identifier -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#identifier">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">A word, number, letter, symbol, or any combination of these used
-            to uniquely identify or reference an individual instance of an entity within a specific
-            information domain.</rdfs:comment>
+         to uniquely identify or reference an individual instance of an entity within a specific
+         information domain.</rdfs:comment>
       <rdfs:label xml:lang="en">identifier</rdfs:label>
       <skos:scopeNote xml:lang="en">Use only if you don't use Identifier class for handling
-            identifiers.</skos:scopeNote>
+         identifiers.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A22 (Identifier
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationExtent -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationExtent">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Countable characteristics of the Instantiation expressed as a
-            quantity.</rdfs:comment>
+         quantity.</rdfs:comment>
       <rdfs:label xml:lang="en">Instantiation extent</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A23 (Instantiation Extent
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationStructure -->
-   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationStructure">
+   <owl:DatatypeProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationStructure">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#structure"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Information about the physical and intellectual arrangement and
-            composition of an Instantiation.</rdfs:comment>
+         composition of an Instantiation.</rdfs:comment>
       <rdfs:label xml:lang="en">Instantiation structure</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Specialization of RiC-A40 (Structure
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#integrity -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#integrity">
@@ -5942,16 +6979,17 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Information about the completeness of the Record Resource or the
-            Instantiation.</rdfs:comment>
+         Instantiation.</rdfs:comment>
       <rdfs:label xml:lang="en">integrity</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A24 (Integrity
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#lastModificationDate -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#lastModificationDate">
@@ -5961,33 +6999,31 @@
       <rdfs:comment xml:lang="en">Date at which an entity was last updated.</rdfs:comment>
       <rdfs:label xml:lang="en">last modification date</rdfs:label>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
-            later on. Use only if you don't use Date classes for handling
-            dates.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of
-            RiC-E18 (Date entity)</RiCCMCorrespondingComponent>
+         later on. Use only if you don't use Date classes for handling dates.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of RiC-E18
+         (Date entity)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#latitude -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#latitude">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#measure"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Coordinates"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Distance in degrees north or south of the
-            equator.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Distance in degrees north or south of the equator.</rdfs:comment>
       <rdfs:label xml:lang="en">latitude</rdfs:label>
-      <skos:scopeNote xml:lang="en">Property of the Coordinates class. If you don't use this
-            class, use geographicalCoordinates property, a property of Place class.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Property of the Coordinates class. If you don't use this class,
+         use geographicalCoordinates property, a property of Place class.</skos:scopeNote>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#location -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#location">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">A delimitation of the physical territory of a
-            place.</rdfs:comment>
+         place.</rdfs:comment>
       <rdfs:label xml:lang="en">location</rdfs:label>
       <skos:scopeNote xml:lang="en">Use only if you don't use PhysicalLocation class with
-            Place.</skos:scopeNote>
+         Place.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A27 (Location
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#longitude -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#longitude">
@@ -5995,17 +7031,17 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Coordinates"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Distance in degrees east or west of a prime
-            meridian.</rdfs:comment>
+         meridian.</rdfs:comment>
       <rdfs:label xml:lang="en">longitude</rdfs:label>
-      <skos:scopeNote xml:lang="en">Property of the Coordinates class. If you don't use this
-            class, use geographicalCoordinates property, a property of Place class.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Property of the Coordinates class. If you don't use this class,
+         use geographicalCoordinates property, a property of Place class.</skos:scopeNote>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#measure -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#measure">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">The extent, quantity, amount, or degree of an entity, as
-            determined by measurement or calculation.</rdfs:comment>
+         determined by measurement or calculation.</rdfs:comment>
       <rdfs:label xml:lang="en">measure</rdfs:label>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#modificationDate -->
@@ -6016,22 +7052,21 @@
       <rdfs:comment xml:lang="en">Date of the modification of an entity.</rdfs:comment>
       <rdfs:label xml:lang="en">modification date</rdfs:label>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
-            later on. Use only if you don't use Date classes for handling
-            dates.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of
-            RiC-E18 (Date entity)</RiCCMCorrespondingComponent>
+         later on. Use only if you don't use Date classes for handling dates.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of RiC-E18
+         (Date entity)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#name -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#name">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">A label, title or term designating the entity in order to make
-            it distinguishable from other similar entities.</rdfs:comment>
+      <rdfs:comment xml:lang="en">A label, title or term designating the entity in order to make it
+         distinguishable from other similar entities.</rdfs:comment>
       <rdfs:label xml:lang="en">name</rdfs:label>
       <skos:scopeNote xml:lang="en">Use only if you don't use Name class for handling
-            names.</skos:scopeNote>
+         names.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corrresponds to RiC-A28 (Name
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#normalizedDateValue -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#normalizedDateValue">
@@ -6039,10 +7074,10 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Date representation based on a standard, preferably
-            machine-readable.</rdfs:comment>
+         machine-readable.</rdfs:comment>
       <rdfs:label xml:lang="en">normalized date value</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A29 (Normalized Date
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#normalizedValue -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#normalizedValue">
@@ -6057,49 +7092,52 @@
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Value representation based on a standard, preferably
-            machine-readable.</rdfs:comment>
+         machine-readable.</rdfs:comment>
       <rdfs:label xml:lang="en">normalized value</rdfs:label>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#physicalCharacteristics -->
-   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#physicalCharacteristics">
+   <owl:DatatypeProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#physicalCharacteristics">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Information about the physical features of the
-            Instantiation.</rdfs:comment>
+         Instantiation.</rdfs:comment>
       <rdfs:label xml:lang="en">physical characteristics</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A31 (Physical Characteristics
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent -->
-   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent">
+   <owl:DatatypeProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent">
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Countable characteristics of the content of an entity expressed
-            as a quantity.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Countable characteristics of the content of an entity expressed as
+         a quantity.</rdfs:comment>
       <rdfs:label xml:lang="en">physical or logical extent</rdfs:label>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. Use only if you cannot use the
-            subproperties (particularly if the same free text is being used in your current metadata
-            for describing the record resource, carrier and instantiation extent).</skos:scopeNote>
+         subproperties (particularly if the same free text is being used in your current metadata
+         for describing the record resource, carrier and instantiation extent).</skos:scopeNote>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#productionTechnique -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#productionTechnique">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Method used in the representation of information on the
-            Instantiation.</rdfs:comment>
+         Instantiation.</rdfs:comment>
       <rdfs:label xml:lang="en">production technique</rdfs:label>
       <skos:scopeNote xml:lang="en">Use only if you have free text or don't have a controlled
-            vocabulary for production techniques (in this case, use the ProductionTechniqueType
-            class)</skos:scopeNote>
+         vocabulary for production techniques (in this case, use the ProductionTechniqueType
+         class)</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A33 (Production Technique
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#publicationDate -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#publicationDate">
@@ -6109,49 +7147,51 @@
       <rdfs:comment xml:lang="en">Date of the publication of a Record Resource.</rdfs:comment>
       <rdfs:label xml:lang="en">publication date</rdfs:label>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
-            later on. Use only if you don't use Date classes for handling
-            dates.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of
-            RiC-E18 (Date entity)</RiCCMCorrespondingComponent>
+         later on. Use only if you don't use Date classes for handling dates.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of RiC-E18
+         (Date entity)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#qualityOfRepresentation -->
-   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#qualityOfRepresentation">
+   <owl:DatatypeProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#qualityOfRepresentation">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Conditions of an Instantiation that impact the legibility or
-            completeness of Record Resource, and thus the viability of its use.</rdfs:comment>
+         completeness of Record Resource, and thus the viability of its use.</rdfs:comment>
       <rdfs:label xml:lang="en">quality of representation</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A34 (Quality of Representation
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceExtent -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceExtent">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Countable characteristics of the content of the Record Resource
-            expressed as a quantity.</rdfs:comment>
+         expressed as a quantity.</rdfs:comment>
       <rdfs:label xml:lang="en">Record Resource extent</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A35 (Record Resource extent
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceStructure -->
-   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceStructure">
+   <owl:DatatypeProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceStructure">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#structure"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Information about the physical and intellectual arrangement and
-            composition of a Record Resource.</rdfs:comment>
+         composition of a Record Resource.</rdfs:comment>
       <rdfs:label xml:lang="en">Record Resource structure</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Specialization of RiC-A40 (Structure
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#referenceSystem -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#referenceSystem">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Framework or standard used to represent an
-            information.</rdfs:comment>
+         information.</rdfs:comment>
       <rdfs:label xml:lang="en">reference system</rdfs:label>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#relationState -->
@@ -6159,47 +7199,47 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Used to qualify the state of a Relation (e. g. present, past,
-            ongoing, unknown).</rdfs:comment>
+         ongoing, unknown).</rdfs:comment>
       <rdfs:label xml:lang="en">Relation state</rdfs:label>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#ruleFollowed -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#ruleFollowed">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">The rule or conditions that govern the existence or lifecycle of
-            a Thing.</rdfs:comment>
+      <rdfs:comment xml:lang="en">The rule or conditions that govern the existence or lifecycle of a
+         Thing.</rdfs:comment>
       <rdfs:label xml:lang="en">rule followed</rdfs:label>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
-            later on. Use only if you don't use the Rule class for handling
-            rules.</skos:scopeNote>
+         later on. Use only if you don't use the Rule class for handling rules.</skos:scopeNote>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#scopeAndContent -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#scopeAndContent">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Summary of the scope (such as time periods, geography) and
-            content (such as subject matter, administrative processes) of the Record Resource. </rdfs:comment>
+      <rdfs:comment xml:lang="en">Summary of the scope (such as time periods, geography) and content
+         (such as subject matter, administrative processes) of the Record Resource. </rdfs:comment>
       <rdfs:label xml:lang="en">scope and content</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A38 (Scope and Content
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#source -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#source">
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Relation"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Information about a source used to identify or describe an
-            entity.</rdfs:comment>
+         entity.</rdfs:comment>
       <rdfs:label xml:lang="en">source</rdfs:label>
-      <skos:scopeNote xml:lang="en">Can be used, in particular, for Records having documentary
-            form type Finding Aid or Authority Record, or for Relations. Use only if you don't
-            use the hasSource object property.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Can be used, in particular, for Records having documentary form
+         type Finding Aid or Authority Record, or for Relations. Use only if you don't use the
+         hasSource object property.</skos:scopeNote>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#structure -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#structure">
@@ -6207,29 +7247,31 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Information about the physical and intellectual arrangement and
-            composition of a Record Resource or Instantiation.</rdfs:comment>
+         composition of a Record Resource or Instantiation.</rdfs:comment>
       <rdfs:label xml:lang="en">structure</rdfs:label>
       <skos:scopeNote xml:lang="en">Use only if you cannot use the subproperties (particularly if
-            the same free text is being used in your current metadata for describing the record
-            resource and the instantiation structure).</skos:scopeNote>
+         the same free text is being used in your current metadata for describing the record
+         resource and the instantiation structure).</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A40 (Structure
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#technicalCharacteristics -->
-   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#technicalCharacteristics">
+   <owl:DatatypeProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#technicalCharacteristics">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Mechanism"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Describes any relevant physical or software feature of any
-            device involved in the creation or management of a Record Resource.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Describes any relevant physical or software feature of any device
+         involved in the creation or management of a Record Resource.</rdfs:comment>
       <rdfs:label xml:lang="en">technical characteristics</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A41 (Technical Characteristics
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#textualValue -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#textualValue">
@@ -6252,19 +7294,20 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Rule"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">An identifying name of a Record Resource, Instantiation or
-            Rule.</rdfs:comment>
+         Rule.</rdfs:comment>
       <rdfs:label xml:lang="en">title</rdfs:label>
       <skos:scopeNote xml:lang="en">Use only if you don't use Title class for handling
-            titles.</skos:scopeNote>
+         titles.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Specialization of RiC-A28 (Name
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#type -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#type">
@@ -6273,8 +7316,8 @@
       <rdfs:comment xml:lang="en">A term used to characterize an entity.</rdfs:comment>
       <rdfs:label xml:lang="en">type</rdfs:label>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
-            later on. Use only if you don't use Type subclasses for handling
-            categories.</skos:scopeNote>
+         later on. Use only if you don't use Type subclasses for handling
+         categories.</skos:scopeNote>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#usedFromDate -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#usedFromDate">
@@ -6284,10 +7327,9 @@
       <rdfs:comment xml:lang="en">Date at which an Appellation was first used.</rdfs:comment>
       <rdfs:label xml:lang="en">used from date</rdfs:label>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
-            later on. Use only if you don't use Date classes for handling
-            dates.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of
-            RiC-E18 (Date entity)</RiCCMCorrespondingComponent>
+         later on. Use only if you don't use Date classes for handling dates.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of RiC-E18
+         (Date entity)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#usedToDate -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#usedToDate">
@@ -6297,10 +7339,9 @@
       <rdfs:comment xml:lang="en">Date until an Appellation was used.</rdfs:comment>
       <rdfs:label xml:lang="en">used to date</rdfs:label>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
-            later on. Use only if you don't use Date classes for handling
-            dates.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of
-            RiC-E18 (Date entity)</RiCCMCorrespondingComponent>
+         later on. Use only if you don't use Date classes for handling dates.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Data property specialized implementation of RiC-E18
+         (Date entity)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#width -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#width">
@@ -6318,27 +7359,28 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
    <!-- http://www.w3.org/2004/02/skos/core#Concept -->
-   <owl:Class rdf:about="http://www.w3.org/2004/02/skos/core#Concept">
-      <rdfs:comment xml:lang="en"/>
-      <rdfs:label xml:lang="en"/>
-   </owl:Class>
+   <owl:Class rdf:about="http://www.w3.org/2004/02/skos/core#Concept"> </owl:Class>
    <!-- http://www.w3.org/2004/02/skos/core#ConceptScheme -->
-   <owl:Class rdf:about="http://www.w3.org/2004/02/skos/core#ConceptScheme">
-      <rdfs:comment xml:lang="en"/>
-      <rdfs:label xml:lang="en"/>
-   </owl:Class>
+   <owl:Class rdf:about="http://www.w3.org/2004/02/skos/core#ConceptScheme"> </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#AccumulationRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#AccumulationRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
+      <rdfs:label xml:lang="en">Accumulation Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -6346,25 +7388,30 @@
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least one Record Resource or Instantiation to at
-            least one Agent, when the Agent accumulates it, be it intentionally (collecting it) or
-            not (receiving it in the course of its activities).</rdfs:comment>
-      <rdfs:label xml:lang="en">Accumulation Relation</rdfs:label>
+      <rdfs:comment xml:lang="en">Connects at least one Record Resource or Instantiation to at least
+         one Agent, when the Agent accumulates it, be it intentionally (collecting it) or not
+         (receiving it in the course of its activities).</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R028 and RiC-R028i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Activity -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Activity">
+      <rdfs:label xml:lang="en">Activity</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasActivityType"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityType"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#hasActivityType"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityType"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
@@ -6374,35 +7421,45 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">The doing of something for some human purpose.</rdfs:comment>
-      <rdfs:label xml:lang="en">Activity</rdfs:label>
-      <skos:scopeNote xml:lang="en">Activity is a kind of Event. Activity is specifically used to
-            designate purposeful human activity. Activity may be understood from two perspectives.
-            First it can be understood as leading to an end. The end is the purpose of the Activity,
-            or why the Activity is performed. Second, it can be understood in terms of the processes
-            that lead to achieving the end, how the end is realized through coordinated actions.
-            Purpose and process are complementary understandings of Activity. Together the two
-            perspectives address why the Activity is performed, the expected ends or outcomes; and
-            how the Activity fulfills the purpose. While activity has an intended end, there are
-            also unintended consequences, results not intended, or side-effects. By and large, these
-            may not be the focus of the description, but they are, unquestionably, context. In a
-            corporate or government context an Activity may also be called a function. An Activity
-            exists in a specific social and cultural context, and within that context is subject to
-            change over time. An Activity may be composed of other Activities.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Activity is a kind of Event.&#xD; Activity is specifically used
+         to designate purposeful human activity.&#xD; Activity may be understood from two
+         perspectives. First it can be understood as leading to an end. The end is the purpose of
+         the Activity, or why the Activity is performed. Second, it can be understood in terms of
+         the processes that lead to achieving the end, how the end is realized through coordinated
+         actions.&#xD; Purpose and process are complementary understandings of Activity. Together
+         the two perspectives address why the Activity is performed, the expected ends or outcomes;
+         and how the Activity fulfills the purpose. &#xD; While activity has an intended end, it
+         also has unintended consequences and results, or side-effects. By and large, these may not
+         be the focus of the description, but they are, unquestionably, context. |In a corporate or
+         government context an Activity may also be called a 'function'.&#xD; An Activity exists in
+         a specific social and cultural context, and within that context is subject to change over
+         time. &#xD; An Activity may be composed of other Activities.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E15 (Activity
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Scope note: made separate paragraphs and updated. Objective: to make RiC-O
+            compliant with RiC-CM v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation">
+      <rdfs:label xml:lang="en">Activity Documentation Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ProvenanceRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -6410,37 +7467,48 @@
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least one Record Resource or Instantiation to at
-            least one Activity, when the Record Resource or Instantiation results from the
-            activity.</rdfs:comment>
-      <rdfs:label xml:lang="en">Activity Documentation Relation</rdfs:label>
+      <rdfs:comment xml:lang="en">Connects at least one Record Resource or Instantiation to at least
+         one Activity, when the Record Resource or Instantiation results from the
+         activity.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R033 and RiC-R033
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#ActivityType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#ActivityType">
+      <rdfs:label xml:lang="en">Activity Type</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#isActivityTypeOf"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#isActivityTypeOf"/>
             <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Categorization of an Activity.</rdfs:comment>
-      <rdfs:label xml:lang="en">Activity Type</rdfs:label>
-      <skos:scopeNote xml:lang="en">Activity Category includes domains of Activity. An Activity
-            Category may be defined globally, or be specific to a particular activity
-            domain.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Can be extended with any number of subclasses, e.g.
+         “function/action” and “activity domain”. This allows for a faceted approach that enables an
+         Activity to be categorized using a combination of components, general or more specific. For
+         example, “monitoring” can be used in combination with “election polls” or “water
+         resources”.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A02 (Activity Type
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Scope note: updated (different from RiC-CM scope note). Objective: to make RiC-O
+            compliant with RiC-CM v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Agent -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Agent">
+      <rdfs:label xml:lang="en">Agent</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:subClassOf>
          <owl:Restriction>
@@ -6451,97 +7519,121 @@
       <rdfs:subClassOf>
          <owl:Restriction>
             <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasLegalStatus"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#LegalStatus"/>
+            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#LegalStatus"
+            />
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">A Person, or Group, or an entity created by a Person or Group
-            (Delegate Agent), or a Position, that acts in the world.</rdfs:comment>
-      <rdfs:label xml:lang="en">Agent</rdfs:label>
+         (Mechanism), or a Position, that acts in the world.</rdfs:comment>
       <skos:scopeNote xml:lang="en">An Agent may have one or more identities; an identity is a
-            constellation of properties or relations that together “identify” the Agent. A Person or
-            Group commonly has one identity, though each also may have one or more alternative
-            identities. Such alternative identities may be shared by more than one Person or Group.
-            Alternative identities include but are not limited to pseudonyms, heteronyms, DBA (Doing
-            Business As), and trade identities. An alternative identity should not be confused with
-            a Position in a Group, for example, presidents, prime ministers, governors, popes,
-            royalty, or bishops. Nor should an alternative identity be confused with a variant name
-            or identifier of the same identity. Agent also includes entities created by a Person or
-            Group that act on behalf of the creating Agent in an autonomous or semi-autonomous
-            manner. Examples of such Mechanisms are software agents, robots, and space and
-            underwater probes that generate data (records) in the course of Activity assigned to and
-            in conformance with the instructions given to them by the creating Person or
-            Group.</skos:scopeNote>
+         constellation of properties or relations that together “identify” the Agent. A Person or
+         Group commonly has one identity, though each also may have one or more alternative
+         identities. Such alternative identities may be shared by more than one Person or Group.
+         Alternative identities include but are not limited to pseudonyms, heteronyms, DBA (Doing
+         Business As), and trade identities. &#xD; An alternative identity should not be confused
+         with a Position in a Group, for example, presidents, prime ministers, governors, popes,
+         royalty, or bishops. Nor should an alternative identity be confused with a variant name or
+         identifier of the same identity.&#xD; Agent also includes entities created by a Person or
+         Group that act on behalf of the creating Agent in an autonomous or semi-autonomous manner.
+         Examples of a Mechanism include software agents, robots, and space and underwater probes
+         that generate data (records) in the course of Activity assigned to and in conformance with
+         the instructions given to them by the creating Person or Group.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E07 (Agent
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Comment: updated. Scope note: updated and made several paragraphs. Objective: to
+            make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#AgentControlRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#AgentControlRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
+      <rdfs:label xml:lang="en">Agent Control Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorityRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Agent, to at least another Agent, when the
-            first one(s) control(s) in a way the activities of the second one(s).</rdfs:comment>
-      <rdfs:label xml:lang="en">Agent Control Relation</rdfs:label>
+         first one(s) control(s) in a way the activities of the second one(s).</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R041 and RiC-R041i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:label xml:lang="en">Agent Hierarchical Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Agent to at least another Agent, when the
-            first one is hierarchically superior to the second one.</rdfs:comment>
-      <rdfs:label xml:lang="en">Agent Hierarchical Relation</rdfs:label>
+         first one is hierarchically superior to the second one.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R045 and RiC-R045i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#AgentName -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#AgentName">
+      <rdfs:label xml:lang="en">Agent Name</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Name"/>
       <rdfs:comment xml:lang="en">A label, title or term designating an Agent in order to make it
-            distinguishable from other similar entities.</rdfs:comment>
-      <rdfs:label xml:lang="en">Agent Name</rdfs:label>
-      <RiCCMCorrespondingComponent xml:lang="en">Class implementation of a specialization of
-            RiC-A28 (Name attribute)</RiCCMCorrespondingComponent>
+         distinguishable from other similar entities.</rdfs:comment>
+      <RiCCMCorrespondingComponent xml:lang="en">Class implementation of a specialization of RiC-A28
+         (Name attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation">
+      <rdfs:label xml:lang="en">Agent Origination Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ProvenanceRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -6549,320 +7641,392 @@
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Record Resource or an Instantiation to at
-            least one Agent that creates or accumulates the Record Resource, receives it, or sends
-            it.</rdfs:comment>
-      <rdfs:label xml:lang="en">Agent Origination Relation</rdfs:label>
+         least one Agent that creates or accumulates the Record Resource, receives it, or sends
+         it.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R026 and RiC-R026i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#AgentSubordinationRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#AgentSubordinationRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentControlRelation"/>
-      <rdfs:subClassOf>
-         <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
-            <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
-         </owl:Restriction>
-      </rdfs:subClassOf>
-      <rdfs:subClassOf>
-         <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
-            <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
-         </owl:Restriction>
-      </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least one Person to at least another Person, when
-            the first one is hierarchically superior to the second one.</rdfs:comment>
       <rdfs:label xml:lang="en">Agent Subordination Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentControlRelation"/>
+      <rdfs:subClassOf>
+         <owl:Restriction>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
+            <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
+         </owl:Restriction>
+      </rdfs:subClassOf>
+      <rdfs:subClassOf>
+         <owl:Restriction>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentSubordinationRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
+            <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
+         </owl:Restriction>
+      </rdfs:subClassOf>
+      <rdfs:comment xml:lang="en">Connects at least one Person to at least another Person, when the
+         first one is hierarchically superior to the second one.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R043 and RiC-R043i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:label xml:lang="en">Agent Temporal Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#TemporalRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#asConcernsActivity"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#asConcernsActivity"/>
             <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Agent, to at least another Agent, that
-            succeeds it chronologically for, for instance, fullfilling some functions or performing
-            some activities.</rdfs:comment>
-      <rdfs:label xml:lang="en">Agent Temporal Relation</rdfs:label>
+         succeeds it chronologically for, for instance, fullfilling some functions or performing
+         some activities.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R016 and RiC-016i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation">
+      <rdfs:label xml:lang="en">Agent Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least two Agents.</rdfs:comment>
-      <rdfs:label xml:lang="en">Agent Relation</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R044 and RiC-044i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Appellation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Appellation">
+      <rdfs:label xml:lang="en">Appellation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Concept"/>
       <rdfs:comment xml:lang="en">A concept of any kind that is used for designating an Entity and
-            referring to it.</rdfs:comment>
-      <rdfs:label xml:lang="en">Appellation</rdfs:label>
+         referring to it.</rdfs:comment>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#AppellationRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#AppellationRelation">
+      <rdfs:label xml:lang="en">Appellation Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource"/>
-            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource"/>
+            <owl:qualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">The relation between an Appellation and at least one Thing that
-            the Appellation designates.</rdfs:comment>
-      <rdfs:label xml:lang="en">Appellation Relation</rdfs:label>
+         the Appellation designates.</rdfs:comment>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#AuthorityRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#AuthorityRelation">
+      <rdfs:label xml:lang="en">Authority Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least one Agent, and at least one Thing over which
-            the Agent has some authority.</rdfs:comment>
-      <rdfs:label xml:lang="en">Authority Relation</rdfs:label>
+      <rdfs:comment xml:lang="en">Connects at least one Agent, and at least one Thing over which the
+         Agent has some authority.</rdfs:comment>
       <skos:scopeNote xml:lang="en">Would probably rarely be used as such (use its
-            sub-categories)</skos:scopeNote>
+         sub-categories)</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R036 and RiC-R036i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#CarrierType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#CarrierType">
+      <rdfs:label xml:lang="en">Carrier Type</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#isCarrierTypeOf"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#isCarrierTypeOf"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Categorization of physical material in or on which information
-            is represented.</rdfs:comment>
-      <rdfs:label xml:lang="en">Carrier Type</rdfs:label>
-      <skos:scopeNote xml:lang="en">Carrier Type is essential for assessing authenticity,
-            conservation needs and the availability, access and use of Record Resources. Carrier
-            Type determines the environmental conditions of storage and the prerequisites and
-            possible ways to access and use of the records.</skos:scopeNote>
+      <rdfs:comment xml:lang="en">Categorization of physical material in or on which information is
+         represented.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Carrier Type information is essential for assessing
+         authenticity, conservation needs and the availability, access and use of Record Resources.
+         Carrier Type determines the environmental conditions of storage and the prerequisites and
+         possible ways to access and use of the records.&#xD; Should not be confused with Content
+         Type, that categorizes a Record Resource, nor with Representation Type that categorizes an
+         Instantiation. The Carrier Type depends on the media type that is required to access the
+         records and is independent of its content</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A05 (Carrier Type
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Scope note: updated (quite the same as RiC-CM definition). Objective: to make
+            RiC-O compliant with RiC-CM v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#ChildRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#ChildRelation">
+      <rdfs:label xml:lang="en">Child Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#DescendanceRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#childRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#childRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#childRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#childRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at lest one Person, to at least another Person, when
-            the first has child the second one.</rdfs:comment>
-      <rdfs:label xml:lang="en">Child Relation</rdfs:label>
+      <rdfs:comment xml:lang="en">Connects at lest one Person, to at least another Person, when the
+         first has child the second one.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R018 and RiC-R018i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Concept -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Concept">
+      <rdfs:label xml:lang="en">Concept</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">An idea, unit of thought, abstract cultural object or
-            category</rdfs:comment>
-      <rdfs:label xml:lang="en">Concept</rdfs:label>
+         category</rdfs:comment>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#ContentType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#ContentType">
+      <rdfs:label xml:lang="en">Content Type</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#isContentTypeOf"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#isContentTypeOf"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">The fundamental form of communication in which a Record is
-            expressed and the human sense through which it is intended to be
-            perceived.</rdfs:comment>
-      <rdfs:label xml:lang="en">Content Type</rdfs:label>
+         expressed and the human sense through which it is intended to be perceived.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Should not be confused with Representation Type or Carrier Type
+         of a related Instantiation since the form of communication can be independent of the
+         representation or carrier, for example, a map (Content Type: cartographic image) can be
+         represented as a sketch (Representation Type: graphic) or as a GIS-coded elements
+         (Representation Type: computer).</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A10 (Content Type
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Scope note: added (quite the same as RiC-CM definition).</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Coordinates -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Coordinates">
+      <rdfs:label xml:lang="en">Coordinates</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#isCoordinatesOf"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#PhysicalLocation"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#isCoordinatesOf"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#PhysicalLocation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
             <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#geodesicSystem"/>
-            <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:cardinality>
+            <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:cardinality>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
             <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#latitude"/>
-            <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:cardinality>
+            <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:cardinality>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
             <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#longitude"/>
-            <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:cardinality>
+            <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:cardinality>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#altimetricSystem"/>
-            <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#altimetricSystem"/>
+            <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:maxCardinality>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
             <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#altitude"/>
-            <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
+            <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:maxCardinality>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Longitudinal and latitudinal information of a
-            Place.</rdfs:comment>
-      <rdfs:label xml:lang="en">Coordinates</rdfs:label>
+         Place.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-A11 (Coordinates
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#CorporateBody -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#CorporateBody">
+      <rdfs:label xml:lang="en">Corporate Body</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:comment xml:lang="en">An organized group of persons that act together as an Agent, and
-            that has a recognized legal or social status. || Corporate Body is a kind of
-            Group.</rdfs:comment>
-      <rdfs:label xml:lang="en">Corporate Body</rdfs:label>
-      <skos:scopeNote xml:lang="en">This entity includes: - Any organization or group of people
-            who acts, or may act, as a unit. - Corporate bodies with legal status or not. -
-            Corporate bodies subordinated to another one. - International organization and NGO -
-            Corporate bodies with public power (legislative, executive or judicial) or corporate
-            bodies with a jurisdiction over a population or a space. - Military organizations,
-            regular or not. - Associations, political parties, trade unions, businessmen
-            associations, companies, societies, foundations, cooperative institutions… -
-            Institutions associated to religious communities. - Nobiliary institutions. - Temporary
-            institutions. - Set of people that acts according to a plan, a Project, etc. - Set of
-            people or groups that can act as a unit inside a ship or a set of ships. - Music bands,
-            artistic groups, intellectual groups. - Historical and current corporate bodies. -
-            Institutions that manage and preserve archival records.</skos:scopeNote>
+         that has a recognized legal or social status.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Corporate Body is a kind of Group.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E11 (Corporate Body
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>scope note: updated. Objective: to make RiC-O compliant with RiC-CM
+            v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#CorporateBodyType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#CorporateBodyType">
+      <rdfs:label xml:lang="en">Corporate Body Type</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#isCorporateBodyTypeOf"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#CorporateBody"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#isCorporateBodyTypeOf"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#CorporateBody"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Categorization of a Corporate Body.</rdfs:comment>
-      <rdfs:label xml:lang="en">Corporate Body Type</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A12 (Corporate Body Type
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#CorrespondenceRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#CorrespondenceRelation">
+      <rdfs:label xml:lang="en">Correspondence Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#KnowingRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least two Persons, when they correspond to each
-            other.</rdfs:comment>
-      <rdfs:label xml:lang="en">Correspondence Relation</rdfs:label>
+         other.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R052 and Ri052i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#CreationRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#CreationRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
+      <rdfs:label xml:lang="en">Creation Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#creationWithRole"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#creationWithRole"/>
             <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#RoleType"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -6870,164 +8034,206 @@
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least one Record Resource or Instantiation to at
-            least one Agent, when the Agent is either responsible for all or some of the content of
-            the Record Resource, or is a contributor to the genesis or production of the
-            Instantiation.</rdfs:comment>
-      <rdfs:label xml:lang="en">Creation Relation</rdfs:label>
+      <rdfs:comment xml:lang="en">Connects at least one Record Resource or Instantiation to at least
+         one Agent, when the Agent is either responsible for all or some of the content of the
+         Record Resource, or is a contributor to the genesis or production of the
+         Instantiation.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R027 and RiC-R027i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Date -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Date">
+      <rdfs:label xml:lang="en">Date</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Chronological information associated with an entity that
-            contributes to its identification and contextualization.</rdfs:comment>
-      <rdfs:label xml:lang="en">Date</rdfs:label>
+         contributes to its identification and contextualization.</rdfs:comment>
       <skos:scopeNote xml:lang="en">Date includes both single dates, a date range, or a set of
-            non-contiguous single dates or date ranges. A date may be represented in natural
-            language, based on a digital standard, or both. Digital standard dates will typically be
-            based on ISO 8601, or Extended Date-Time Format (EDTF).</skos:scopeNote>
+         non-contiguous single dates or date ranges. &#xD; A date may be represented in natural
+         language, based on a digital standard, or both. &#xD; Digital standard dates will typically
+         be based on ISO 8601, or Extended Date-Time Format (EDTF).</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E18 (Date
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Scope note: made separate paragraphs.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#DateRange -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#DateRange">
+      <rdfs:label xml:lang="en">Date Range</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasBeginningDate"/>
-            <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#hasBeginningDate"/>
+            <owl:maxQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:maxQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#SingleDate"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
             <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasEndDate"/>
-            <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
+            <owl:maxQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:maxQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#SingleDate"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Chronological information associated with an entity that
-            contributes to its identification and contextualization that implies or explicitly
-            states a start date and end date.</rdfs:comment>
-      <rdfs:label xml:lang="en">Date Range</rdfs:label>
+         contributes to its identification and contextualization, that implies or explicitly states
+         a start date and end date.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E20 (Date Range
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#DateSet -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#DateSet">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
-      <rdfs:comment xml:lang="en">Non-contiguous dates or date ranges.</rdfs:comment>
       <rdfs:label xml:lang="en">Date Set</rdfs:label>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
+      <rdfs:comment xml:lang="en">Non-contiguous single dates or date ranges.</rdfs:comment>
       <skos:scopeNote xml:lang="en">Primarily used in the description of Record Sets to describe
-            dates of member Records</skos:scopeNote>
+         dates of member Records</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E21 (Date Set
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Comment: updated. Objective: to make RiC-O compliant with RiC-CM
+            v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#DemographicGroup -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#DemographicGroup">
+      <rdfs:label xml:lang="en">Demographic Group</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#isDemographicGroupOf"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#isDemographicGroupOf"/>
             <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Categorization of a person according to quantifiable
-            socio-economic characteristics such as age, education, nationality, ethnic/cultural
-            identification, religion, etc.</rdfs:comment>
-      <rdfs:label xml:lang="en">Demographic Group</rdfs:label>
-      <skos:scopeNote xml:lang="en">Identifying Agents as members of particular demographic groups
-            may provide identifying context relevant to understanding Record Resources associated
-            with the Agent, particularly when membership in the group is explicitly related to the
-            Record Resource content. A Demographic group may be defined as a subset of the general
-            population. Individuals may belong to several demographic groups.</skos:scopeNote>
+      <rdfs:comment xml:lang="en">Categorization of a person according to characteristics such as
+         age, gender, education, place of origin, ethnic/cultural identification, religion,
+         etc.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Can be extended with any number of subclasses, e.g. Age or
+         Religion.&#xD; A demographic group may be defined as a subset of the general
+         population.&#xD; Individuals may belong to several demographic groups</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A15 (Demographic Group
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Comment: updated. Scope note: updated and made several paragraphs. Objective: to
+            make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#DerivationRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#DerivationRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation"/>
+      <rdfs:label xml:lang="en">Derivation Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation"/>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#TemporalRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource"/>
-            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource"/>
+            <owl:qualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects an Instantiation to at least one Instantiation that is
-            derived from it.</rdfs:comment>
-      <rdfs:label xml:lang="en">Derivation Relation</rdfs:label>
+         derived from it.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R014 and RiR014i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#DescendanceRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#DescendanceRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
+      <rdfs:label xml:lang="en">Descendance Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#FamilyRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least one Person to at least another Person, when
-            the first has/have descendant the second one(s).</rdfs:comment>
-      <rdfs:label xml:lang="en">Descendance Relation</rdfs:label>
+      <rdfs:comment xml:lang="en">Connects at least one Person to at least another Person, when the
+         first has/have descendant the second one(s).</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R017 and RiC-R017i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#DocumentaryFormType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#DocumentaryFormType">
+      <rdfs:label xml:lang="en">Documentary Form Type</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#isDocumentaryFormTypeOf"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#isDocumentaryFormTypeOf"/>
             <owl:allValuesFrom>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
                      <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Record"/>
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordPart"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordPart"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:allValuesFrom>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Categorization of the documentary form of a
-            Record</rdfs:comment>
-      <rdfs:label xml:lang="en">Documentary Form Type</rdfs:label>
-      <skos:scopeNote xml:lang="en">Documentary Form Type plays an important role in determining
-            the type of information a Record may comprise, its status of perfection, and its
-            authenticity and reliability. Documentary Form Types exist in a specific social and
-            cultural context, and within that context, are subject to change over
-            time.</skos:scopeNote>
+      <rdfs:comment xml:lang="en">Categorization of the document with respect to its extrinsic and
+         intrinsic elements that together communicate its content, administrative and documentary
+         context, and authority</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Documentary Form Type plays an important role in determining the
+         type of information a Record may comprise, its status of perfection, and its authenticity
+         and reliability.&#xD; Documentary form types exist in a specific social and cultural
+         context, and within that context, are subject to change over time</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A17 (Documentary Form Type
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Comment: updated. Scope note: made several paragraphs. Objective: to make RiC-O
+            compliant with RiC-CM v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Event -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Event">
+      <rdfs:label xml:lang="en">Event</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:subClassOf>
          <owl:Restriction>
@@ -7036,60 +8242,53 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Something that happens in time and space.</rdfs:comment>
-      <rdfs:label xml:lang="en">Event</rdfs:label>
-      <skos:scopeNote xml:lang="en">An event may be natural, human, or a combination of natural
-            and human. Events have temporal and spatial boundaries. It may actively involve some
-            agent(s) and affect any primary entity. An event may be discrete, happening at a
-            specific moment in time, or may occur over an extended period of time. Events may have
-            events as parts, and events may precede or follow one another. Multiple agents may
-            participate in the same event, and in different roles. It may be useful or necessary to
-            use Event entity: - when the history of an entity has to be accurately taken into
-            account. One may thus decide to pick out some of the events of that history, for example
-            those who affect the entity and change its state or environment, and to describe them so
-            that this description can be processed. In such a case the Event entity will connect
-            several entities. For example, a creation Event may connect a Record, a DateRange, a
-            Place, an Agent. - in order to specify that a Record, Record Set or Record Part has an
-            Event as subject. Some things that happen and that actively involve agents may be
-            considered either Events or Actions, depending whether they are viewed as contextual
-            entities or whether the focus is on the records that may result from it, in short
-            depending on the perspective adopted when describing them. An Event may be categorized
-            using an Event Type entity. In particular, archivists, records managers and end users
-            may need to use some main event categories concerning either the history of record
-            resources, either the life of agents, for classifying, thus grouping and searching
-            events. Examples include curation events (creation, accumulation, acquisition, transfer,
-            arrangement, description, digitization, deletion…) and biographical events (birth,
-            marriage, death…), or events in the existence of corporate bodies (creation,
-            merger…).</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">An event may be natural, human, or a combination of natural and
+         human. Events have temporal and spatial boundaries. An event may actively involve some
+         agent(s) and affect any entity. &#xD; An event may be discrete, happening at a specific
+         moment in time, or may occur over an extended period of time. Events may have events as
+         parts, and events may precede or follow one another. Multiple agents may participate in the
+         same event, and in different roles. &#xD; </skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E14 (Event
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
       <closeTo xml:lang="en">LODE Event class
-            (http://linkedevents.org/ontology/#term-Event)</closeTo>
+         (http://linkedevents.org/ontology/#term-Event)</closeTo>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Scope note: made separate paragraphs and some changes.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#EventRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#EventRelation">
+      <rdfs:label xml:lang="en">Event Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#eventRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#eventRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#eventRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#eventRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least one Event to at least one Thing, when the
-            first is associated with the existence and lifecycle of the second one.</rdfs:comment>
-      <rdfs:label xml:lang="en">Event Relation</rdfs:label>
+      <rdfs:comment xml:lang="en">Connects at least one Event to at least one Thing, when the first
+         is associated with the existence and lifecycle of the second one.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R057 and RiC-R057i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#EventType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#EventType">
+      <rdfs:label xml:lang="en">Event Type</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:subClassOf>
          <owl:Restriction>
@@ -7098,53 +8297,63 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Categorization of an Event.</rdfs:comment>
-      <rdfs:label xml:lang="en">Event Type</rdfs:label>
-      <skos:scopeNote xml:lang="en">Curation event types include creation; acquisition; transfer;
-            arrangement; description; digitization, etc. Biographical event types include birth,
-            marriage, death, etc.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Events of all kinds can be categorized.&#xD; Curation event
+         types include creation; acquisition; transfer; arrangement; description; digitization, etc.
+         Biographical event types include birth, marriage, death, etc.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A18 (Event Type
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Scope note: updated and made several paragraphs. Objective: to make RiC-O
+            compliant with RiC-CM v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Family -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Family">
+      <rdfs:label xml:lang="en">Family</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:comment xml:lang="en">Two or more persons related by birth, or through marriage,
-            adoption, civil union, or other social conventions that bind them together as a socially
-            recognized familial group.</rdfs:comment>
-      <rdfs:label xml:lang="en">Family</rdfs:label>
-      <skos:scopeNote xml:lang="en">Family is a kind of Group. “Family” is used here as a general
-            term that encompasses a wide variety of familial groups. Other types of familial groups
-            include Dynasty, Clan, House, Tribe and others. Though family may be a recognized legal
-            group in specific contexts, the term may also be used for groups that are socially
-            recognized as families. A family may be a group of persons related either by
-            consanguinity or affinity or cohabitation or other social conventions. In some context,
-            a Family may be a legally recognized as Corporate Body. For example, certain North
-            American peoples (tribes) retain self-government rights and have jurisdiction over
-            defined tribal lands. This entity includes: - Familiar units, clans, houses… -
-            Dynasties, lineages, royal houses, nobiliary houses… - Owners or holders of a title of
-            nobility. - Historical or current families. - Families that manage
-            records.</skos:scopeNote>
+         adoption, civil union, or other social conventions that bind them together as a socially
+         recognized familial group.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Family is a kind of Group. &#xD; “Family” is used here as a
+         general term that encompasses a wide variety of familial groups. Other types of familial
+         groups include Dynasty, Clan, House, Tribe and others.&#xD; Though family may be a
+         recognized legal group in specific contexts, the term may also be used for groups that are
+         socially recognized as families. A family may be a group of persons related either by
+         consanguinity or affinity or cohabitation or other social conventions.&#xD; In some
+         context, a Family may be legally recognized as Corporate Body. For example, certain North
+         American peoples (tribes) retain self-government rights and have jurisdiction over defined
+         tribal lands.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E10 (Family
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Scope note: made separate paragraphs and some changes.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#FamilyRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#FamilyRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:label xml:lang="en">Family Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least two Persons, when they have some family link,
-            i.e. belong to the same family.</rdfs:comment>
-      <rdfs:label xml:lang="en">Family Relation</rdfs:label>
+         i.e. belong to the same family.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R047 and RiC-R047i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#FamilyType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#FamilyType">
+      <rdfs:label xml:lang="en">Family Type</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:subClassOf>
          <owl:Restriction>
@@ -7152,176 +8361,246 @@
             <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Family"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Categorization of family.</rdfs:comment>
-      <rdfs:label xml:lang="en">Family Type</rdfs:label>
+      <rdfs:comment xml:lang="en">Categorization of a Family.</rdfs:comment>
       <skos:scopeNote xml:lang="en">Family Type encompasses a wide variety of familial groups
-            related by consanguinity, affinity, cohabitation or other social
-            conventions.</skos:scopeNote>
+         related by consanguinity, affinity, cohabitation or other social conventions. </skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A20 (Family Type
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Comment: slighty changed.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#FunctionalEquivalenceRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#FunctionalEquivalenceRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation"/>
+      <rdfs:label xml:lang="en">Functional Equivalence Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least two Instantiations which may be considered as
-            equivalent.</rdfs:comment>
-      <rdfs:label xml:lang="en">Functional Equivalence Relation</rdfs:label>
+         equivalent.</rdfs:comment>
       <skos:scopeNote xml:lang="en">Use for Instantiations which, from some point of view, in some
-            context and for some users at least, may be considered as equivalent. This equivalence
-            is usually based upon the fact that the Instantiations have at least the same
-            intellectual content (they instantiate the same Record Resource).</skos:scopeNote>
+         context and for some users at least, may be considered as equivalent. This equivalence is
+         usually based upon the fact that the Instantiations have at least the same intellectual
+         content (they instantiate the same Record Resource).</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R035 and RiC-R035i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Group -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Group">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
-      <owl:disjointWith rdf:resource="https://www.ica.org/standards/RiC/ontology#Mechanism"/>
-      <rdfs:comment xml:lang="en">Two or more Agents that act together as an Agent.</rdfs:comment>
       <rdfs:label xml:lang="en">Group</rdfs:label>
-      <skos:scopeNote xml:lang="en">Group is a kind of Agent. A Group has a socially recognized
-            identity. Each member of the group plays a particular role or roles in the coordinated
-            activity of the group (Position). Corporate Bodies and Families are kinds of groups,
-            though other kinds of groups are possible. For example, the “electorate,” that is all of
-            the voters in a given election. Complex, large groups may be subdivided into other
-            groups</skos:scopeNote>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
+      <rdfs:comment xml:lang="en">Two or more Agents that act together as an Agent.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Group is a kind of Agent.&#xD; A Group has a socially recognized
+         identity. Each member of the Group plays a particular role or roles (that is has a
+         particular Position) in the coordinated activity of the Group.&#xD; Corporate bodies and
+         families are kinds of groups, though other kinds of groups are possible. For example, the
+         “electorate” -- all of the voters in a given election.&#xD; Complex, large groups may be
+         subdivided into other groups.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E09 (Group
-            Entity)</RiCCMCorrespondingComponent>
+         Entity)</RiCCMCorrespondingComponent>
+      <owl:disjointWith rdf:resource="https://www.ica.org/standards/RiC/ontology#Mechanism"/>
+      <owl:disjointWith rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
+      <owl:disjointWith rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Scope note: made separate paragraphs plus very few changes. Disjoint with:
+            enriched.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#GroupSubdivisionRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#GroupSubdivisionRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
+      <rdfs:label xml:lang="en">Group Subdivision Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#WholePartRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource"/>
-            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource"/>
+            <owl:qualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects a Group and at least another Group, when the first one
-            as the second one(s) among its subdivisions.</rdfs:comment>
-      <rdfs:label xml:lang="en">Group Subdivision Relation</rdfs:label>
+      <rdfs:comment xml:lang="en">Connects a Group and at least another Group, when the first one as
+         the second one(s) among its subdivisions.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R005 and RiC-R005i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Identifier -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Identifier">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
-      <rdfs:comment xml:lang="en">A word, number, letter, symbol, or any combination of these used
-            to uniquely identify or reference an individual instance of an entity within a specific
-            information domain.</rdfs:comment>
       <rdfs:label xml:lang="en">Identifier</rdfs:label>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
+      <rdfs:subClassOf>
+         <owl:Restriction>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#hasIdentifierType"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#IdentifierType"/>
+         </owl:Restriction>
+      </rdfs:subClassOf>
+      <rdfs:comment xml:lang="en">A word, number, letter, symbol, or any combination of these used
+         to uniquely identify or reference an individual instance of an entity within a specific
+         information domain.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-A22 (Identifier
-            attribute) (see also the identifier data property)</RiCCMCorrespondingComponent>
+         attribute) (see also the identifier data property)</RiCCMCorrespondingComponent>
+   </owl:Class>
+   <!-- https://www.ica.org/standards/RiC/ontology#IdentifierType -->
+   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#IdentifierType">
+      <rdfs:label xml:lang="en">Identifier Type</rdfs:label>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
+      <rdfs:subClassOf>
+         <owl:Restriction>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#isIdentifierTypeOf"/>
+            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Identifier"
+            />
+         </owl:Restriction>
+      </rdfs:subClassOf>
+      <rdfs:comment xml:lang="en">Categorization of an Identifier.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">For example, 'old identifier' ; 'ISNI' (for a person or
+         corporate body), etc.</skos:scopeNote>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Class added along with hasIdentifierType and isIdentifierTypeOf object
+            properties.</rdf:value>
+         <dc:date>2020-10-19</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Instantiation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation">
+      <rdfs:label xml:lang="en">Instantiation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:subClassOf>
          <owl:Restriction>
             <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasCarrierType"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#CarrierType"/>
+            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#CarrierType"
+            />
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasProductionTechniqueType"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#ProductionTechniqueType"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#hasProductionTechniqueType"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#ProductionTechniqueType"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasRepresentationType"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#RepresentationType"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#hasRepresentationType"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#RepresentationType"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">The inscription of information on a physical carrier in any
-            persistent, recoverable form by an Agent as a means of communicating information through
-            time and space.</rdfs:comment>
-      <rdfs:label xml:lang="en">Instantiation</rdfs:label>
+      <rdfs:comment xml:lang="en">The inscription of information made by an Agent on a physical
+         carrier in any persistent, recoverable form as a means of communicating information through
+         time and space.</rdfs:comment>
       <skos:scopeNote xml:lang="en">A Record or Record Part must have been instantiated at least
-            once, though this instantiation may no longer exist at the moment of description. An
-            instantiation might also exist at the moment of description, but be destroyed at a later
-            moment in time eg. when a derived instantiation becomes the main instantiation. A Record
-            Set may have an instantiation, which is to say that it is not a necessary condition. An
-            Instantiation may be derived from another Instantiation. A Record Resource may have many
-            Instantiations simultaneously (for instance, a record printed and saved in the same time
-            as docx and pdf/A = 3 instantiations) or through time (e.g., (copy of a record).
-            Depending on the context, a new instantiation may be treated as representing a new or as
-            the same record resource. While in the process of re-instantiation something is loss and
-            something is preserved, it is up to the context and the Agent that produce/use that
-            instantiation to assess if the two instantiations are functionally equivalent or not.
-            For instance, a postcard representing a town map from 1874 (instantiation 1) is
-            digitized and kept as a jpeg file (instantiation 2). The digital copy may be considered
-            as instantiating the "same" record by an Agent considering the information
-            transmitted by the record (e.g., the urban landscape displayed), but
-            "different" records by an antiquarian. Successive instantiations may change
-            the perceivable boundaries of a record resource. For instance, a case file comprising
-            many records may be digitized and saved as one single pdf file, which, from management
-            perspective, may be treated as one record. Similarly, a large record set (a fonds or a
-            series) may be dematerialized and kept as one database. On the other hand, one record
-            (main document and its annexes) may be digitized in separate files and each one managed
-            as discrete “physical” items. Instantiations may need mediation for allowing communicate
-            the records resource. While a traditional record resource sufficed human literation in
-            order to receive the information, a vinyl recording, a video cassette or a digital file
-            needs a device (mediator) to codify/decodify the information conveyed. This mediator may
-            imply simple physical components (a turntable needle, for instance), or a complex
-            gallery of software and hardware elements. Instantiations are more than the mere content
-            of record resource and from this perspective they may be the focus of preservation and
-            physical management of records. Using a certain form for medieval charters or a
-            particular format for records may have implications on the authenticity of the records.
-            Hence, the way a record resource is instantiated contributes to the contextualizing the
-            content. Distinguishing the message conveyed (Record Resource) and its physical
-            representations allows to manage their descriptions in an efficient way, and to keep
-            information about a Record Resource even when no physical representation of it exists
-            any more, or is known. The relations between the distinct instantiations can then be
-            expressed wherever these instantiations may be kept, and they can be related to the
-            Record Resource they represent .</skos:scopeNote>
+         once, though this instantiation may no longer exist at the moment of description. An
+         instantiation might also exist at the moment of description, but be destroyed at a later
+         moment in time, when, for example, a derived instantiation might become the only remaining
+         instantiation. &#xD; A Record Set may have an instantiation, which is to say that it is not
+         a necessary condition.&#xD; An Instantiation may be derived from another Instantiation.
+         &#xD; A Record Resource may have many Instantiations simultaneously (for instance, a record
+         printed and saved in the same time as DOCX and PDF/A would have 3 concurrent
+         instantiations) or through time (for example, copy of a record). &#xD; Depending on the
+         context, a new instantiation may be seen as a new or as the same record resource. During in
+         the process of re-instantiation something is lost and something is preserved, but it is up
+         to the context and the Agent that produces or uses that Instantiation to assess whether the
+         two instantiations are functionally equivalent or not. For instance, a postcard
+         representing a town map from 1874 (Instantiation 1) is digitized and kept as a JPEG file
+         (Instantiation 2). The digital copy may be considered as instantiating the "same" Record by
+         an Agent considering the information transmitted by the Record (e.g., the urban landscape
+         displayed), but as a" different" Record by an antiquarian more focused on the materiality
+         of the carrier.&#xD; Successive instantiations may change the perceivable boundaries of a
+         Record Resource. For instance, a case file comprising many records may be digitized and
+         saved as one single PDF file, which, from management perspective, may be treated as one
+         Record. Similarly, a large Record Set (a fonds or a series) may be maintained as one
+         database. On the other hand, one record (main document and its annexes) may be digitized in
+         separate files and each one may be managed as a discrete “physical” item.&#xD;
+         Instantiations may require mediation to communicate the information in the Record Resource.
+         While a traditional Record on paper can simply be read by an Agent in order to understand
+         the information, a vinyl recording, a video cassette or a digital file needs a device
+         (mediator) to codify or decodify the information conveyed. This mediator may imply simple
+         physical components (a turntable needle, for example), or a complex gallery of software and
+         hardware elements.&#xD; Instantiations are more than the mere informational content of
+         Record Resource and may be the focus of preservation and physical management of records.
+         The use of particular document types for records, such as a medieval charter, may have
+         implications for the authenticity of the records. Hence, the way a Record Resource is
+         instantiated contributes to the contextualizing of the content.record resource is
+         instantiated contributes to the contextualizing the content. &#xD; Distinguishing the
+         message conveyed (Record Resource) and its physical representations (Instantiation) allows
+         for the efficient management of their descriptions, and preserve information about a Record
+         Resource even when no physical representation of it exists or is known to exist anymore.
+         The relations between distinct instantiations can then be expressed wherever they coexist,
+         and they can be related to the Record Resource they instantiate.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E06 (Instantiation
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
       <closeTo xml:lang="en">PREMIS Representation</closeTo>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Comment: updated. Scope note: updated and made several paragraphs. Objective: to
+            make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation -->
-   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation">
+   <owl:Class
+      rdf:about="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation">
+      <rdfs:label xml:lang="en">Instantiation to Instantiation Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least two instantiations</rdfs:comment>
-      <rdfs:label xml:lang="en">Instantiation to Instantiation Relation</rdfs:label>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation -->
-   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation">
+   <owl:Class
+      rdf:about="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation">
+      <rdfs:label xml:lang="en">Intellectual Property Rights Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorityRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
                      <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Group"/>
                      <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Person"/>
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Position"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#Position"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -7329,159 +8608,182 @@
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Agent and one Record Resource or
-            Instantiation on which the Agent has some intellectual property rights. </rdfs:comment>
-      <rdfs:label xml:lang="en">Intellectual Property Rights Relation</rdfs:label>
-      <skos:scopeNote xml:lang="en">Can be used, when the record resource is a work, for
-            specifying the connection between the record resource and its
-            author(s).</skos:scopeNote>
+         Instantiation on which the Agent has some intellectual property rights.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Can be used, when the record resource is a work, for specifying
+         the connection between the record resource and its author(s).</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R040 and RiC-R040i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#KnowingOfRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#KnowingOfRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:label xml:lang="en">Knowing Of Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Person to at least another one, when the
-            first one has some knowledge of the second one through time or space. </rdfs:comment>
-      <rdfs:label xml:lang="en">Knowing Of Relation</rdfs:label>
+         first one has some knowledge of the second one through time or space.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R050 and RiC-R050i
-            relationsi</RiCCMCorrespondingComponent>
+         relationsi</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#KnowingRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#KnowingRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:label xml:lang="en">Knowing Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least two Persons that directly know each other
-            during their existence. || This relation is symmetric.</rdfs:comment>
-      <rdfs:label xml:lang="en">Knowing Relation</rdfs:label>
+      <rdfs:comment xml:lang="en">Connects at least two Persons that directly know each other during
+         their existence. &#xD; This relation is symmetric.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Cass implementation of RiC-R051 and RiC—R051i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Language -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Language">
+      <rdfs:label xml:lang="en">Language</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Concept"/>
       <rdfs:comment xml:lang="en">A spoken or written human language represented in the Record
-            Resource or used by the Agent.</rdfs:comment>
-      <rdfs:label xml:lang="en">Language</rdfs:label>
-      <skos:scopeNote xml:lang="en">Language is used in the description of a Record Resource to
-            designate the language used in representing the information conveyed, and in the
-            description of an Agent to designate the language used by the Agent to communicate. When
-            the language of a Record Resource is written, or an Agent communicates using written
-            language, then the Language Type designation (code or name) should be paired with a
-            Script Type designation. There is an ISO maintained Controlled Concept Groups for human
-            languages (ISO 639-2: Codes for the Representation of Names of Languages). ISO 639-2
-            includes a list of three-letter codes for each language, as well as the name of the
-            language in English, French, and German. For obscure or rare languages, ISO 639-5: Codes
-            for the Representation of Names of Languages Part 5: Alpha-3 code for language families
-            and groups may be used to extend the range of languages covered. [Note, that the
-            description any entity is also a Record, and thus Language is used in the description of
-            description]. Any given Record Resource may be represented in more than one language,
-            and any given Agent may use more than one language.</skos:scopeNote>
+         Resource or used by the Agent.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A25 (Language
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Scope note from RiC-CM : deleted.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#LeadershipRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#LeadershipRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentControlRelation"/>
+      <rdfs:label xml:lang="en">Leadership Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentControlRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipWithPosition"/>
-            <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipWithPosition"/>
+            <owl:maxQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:maxQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Person and at least one Group, when the
-            first one leads the second one. </rdfs:comment>
-      <rdfs:label xml:lang="en">Leadership Relation</rdfs:label>
+         first one leads the second one.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R042 and RiC-R042i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#LegalStatus -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#LegalStatus">
+      <rdfs:label xml:lang="en">Legal Status</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:comment xml:lang="en">A status defined by law.</rdfs:comment>
-      <rdfs:label xml:lang="en">Legal Status</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A26 (Legal Status
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#ManagementRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#ManagementRelation">
+      <rdfs:label xml:lang="en">Management Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorityRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Agent, and at least one Record Resource or
-            Instantiation that the Agent manages.</rdfs:comment>
-      <rdfs:label xml:lang="en">Management Relation</rdfs:label>
+         Instantiation that the Agent manages.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R038 and RiC-R038i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Mandate -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Mandate">
+      <rdfs:label xml:lang="en">Mandate</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <rdfs:subClassOf>
          <owl:Restriction>
@@ -7489,168 +8791,218 @@
             <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Delegation of authority by an Agent to another Agent to perform
-            an Activity.</rdfs:comment>
-      <rdfs:label xml:lang="en">Mandate</rdfs:label>
-      <skos:scopeNote xml:lang="en">Mandate is a kind of Rule. A Mandate confers the authority or
-            competencies of Agents to perform a specified Activity. In addition to assigning an
-            Activity and delegating authority to perform the Activity to an Agent, a Mandate
-            commonly limits the Place (jurisdiction) and Date (time period) within which an Agent
-            may perform the Activity (where and when). Mandates exist in a specific social and
-            cultural context, and within that context are subject to change over time. While a
-            Mandate may be tacit, in whole or part, it may be explicitly expressed in a variety of
-            documentary sources (for example, constitutions, legislation, (legal) acts, statutes,
-            legal codes, ordinances, charges, charters, or mission statements). The evidence for
-            identifying a Mandate may be found in its entirety in one documentary source (for
-            example, a law or regulation), or may be found in two or more sources. A Mandate should
-            not be confused with the one or more documentary sources that serve as evidence of its
-            identity. A documentary source is a Record.</skos:scopeNote>
+      <rdfs:comment xml:lang="en">Delegation of authority by an Agent to another Agent to perform an
+         Activity.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Mandate is a kind of Rule. &#xD; A Mandate confers the authority
+         or competencies of Agents to perform a specified Activity.&#xD; In addition to assigning an
+         Activity and delegating authority to perform the Activity to an Agent, a Mandate commonly
+         limits the Place (jurisdiction) and Date (time period) within which an Agent may perform
+         the Activity (where and when). &#xD; Mandates exist in a specific social and cultural
+         context, and within that context are subject to change over time. &#xD; While a Mandate may
+         be tacit, in whole or part, it may be explicitly expressed in a variety of documentary
+         sources (for example, constitutions, legislation, (legal) acts, statutes, legal codes,
+         ordinances, charges, charters, or mission statements). &#xD; The evidence for identifying a
+         Mandate may be found in its entirety in one documentary source (for example, a law or
+         regulation), or may be found in two or more sources. &#xD; A Mandate should not be confused
+         with the one or more documentary sources that serve as evidence of its identity. A
+         documentary source is a Record.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E17 (Mandate
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Scope note: made separate paragraphs and updated. Objective: to make RiC-O
+            compliant with RiC-CM v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#MandateRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#MandateRelation">
+      <rdfs:label xml:lang="en">Mandate Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#RuleRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#authorizingAgent"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#authorizingAgent"/>
             <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#asConcernsActivity"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#asConcernsActivity"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Mandate"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Mandate, and at least one Agent, when the
-            first gives the second one the authority or competencies to act. || May also involve one
-            to many Activities that the Mandate(s) assign(s) to the Agent(s).</rdfs:comment>
-      <rdfs:label xml:lang="en">Mandate Relation</rdfs:label>
+         first gives the second one the authority or competencies to act. &#xD; May also involve one
+         to many Activities that the Mandate(s) assign(s) to the Agent(s).</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R067 and RiC-R067i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Mechanism -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Mechanism">
+      <rdfs:label xml:lang="en">Mechanism</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
+      <rdfs:comment xml:lang="en">A process or system created by a Person or Group that performs an
+         Activity.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Mechanism is a kind of Agent.&#xD; A Mechanism may have both
+         mechanical and software components, or may be exclusively software. A Mechanism acts in the
+         world producing physical or social effects, and frequently generates or modifies
+         Records.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E13 (Mechanism
+         entity)</RiCCMCorrespondingComponent>
       <owl:disjointWith rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:disjointWith rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
-      <rdfs:comment xml:lang="en">A process or system created by a Person or Group that performs
-            an Activity.</rdfs:comment>
-      <rdfs:label xml:lang="en">Mechanism</rdfs:label>
-      <skos:scopeNote xml:lang="en">Mechanism is a kind of Agent. A Mechanism may have both
-            mechanical and software components, or may be exclusively software. A Mechanism acts in
-            the world producing physical or social effects, and frequently generates or modifies
-            Records.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E13 (Mechanism
-            entity)</RiCCMCorrespondingComponent>
+      <owl:disjointWith rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>scope note: made separate paragraphs. Disjoint with: enriched.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#MembershipRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#MembershipRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:label xml:lang="en">Membership Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource"/>
-            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource"/>
+            <owl:qualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipWithPosition"/>
-            <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipWithPosition"/>
+            <owl:maxQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:maxQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects a Group and at least one Person, when the first one has
-            the second one(s) among its members.</rdfs:comment>
-      <rdfs:label xml:lang="en">Membership Relation</rdfs:label>
+         the second one(s) among its members.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R055 and RiC-R055i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#MigrationRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#MigrationRelation">
+      <rdfs:label xml:lang="en">Migration Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#DerivationRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource"/>
-            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource"/>
+            <owl:qualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects an Instantiation and at least another Instantiation,
-            when the first is migrated into the second one(s).</rdfs:comment>
-      <rdfs:label xml:lang="en">Migration Relation</rdfs:label>
+      <rdfs:comment xml:lang="en">Connects an Instantiation and at least another Instantiation, when
+         the first is migrated into the second one(s).</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R015 and RiC-R015i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Name -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Name">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
-      <rdfs:comment xml:lang="en">A label, title or term designating the entity in order to make
-            it distinguishable from other similar entities.</rdfs:comment>
       <rdfs:label xml:lang="en">Name</rdfs:label>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
+      <rdfs:comment xml:lang="en">A label, title or term designating the entity in order to make it
+         distinguishable from other similar entities.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-A28 (Name attribute)
-            (see also the name data property)</RiCCMCorrespondingComponent>
+         (see also the name data property)</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#OccupationType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#OccupationType">
+      <rdfs:label xml:lang="en">Occupation Type</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityType"/>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#DemographicGroup"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#isOccupationTypeOf"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#isOccupationTypeOf"/>
             <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Categorization of a profession, trade, or craft pursued by a
-            person in fulfilment of an Activity.</rdfs:comment>
-      <rdfs:label xml:lang="en">Occupation Type</rdfs:label>
+         person in fulfilment of an Activity.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Occupation Type should not be confused with Position where, for
+         example, an Agent with the Occupation Type “lawyer” holds the Position of “legal counsel”
+         in an agency.&#xD; Occupation Type is related to, but should not be confused with the
+         domain or field of Activity (Actvitity Type), such as an archivist who works in the domain
+         of archival science. &#xD; Occupation Type is a kind of Demographic Group.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A30 (Occupation Type
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>scope note: added.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#OwnershipRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#OwnershipRelation">
+      <rdfs:label xml:lang="en">Ownership Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorityRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
                      <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Group"/>
                      <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Person"/>
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Position"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#Position"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -7658,167 +9010,191 @@
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Group, Person or Position, and at least a
-            Thing that these Agent(s) own(s). </rdfs:comment>
-      <rdfs:label xml:lang="en">Ownership Relation</rdfs:label>
+         Thing that these Agent(s) own(s).</rdfs:comment>
       <skos:scopeNote xml:lang="en">Among other probably more rare use cases for archival
-            description, can be used between agents (a person owns a corporate body, a corporate
-            body owns a mechanism), or between agents and record resources</skos:scopeNote>
+         description, can be used between agents (a person owns a corporate body, a corporate body
+         owns a mechanism), or between agents and record resources</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R037 and RiC-R037i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#PerformanceRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#PerformanceRelation">
+      <rdfs:label xml:lang="en">Performance Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#EventRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Activity to at least one Agent, when the
-            first is performed by the second one(s).</rdfs:comment>
-      <rdfs:label xml:lang="en">Performance Relation</rdfs:label>
+         first is performed by the second one(s).</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R060 and RiC-R060i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Person -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Person">
+      <rdfs:label xml:lang="en">Person</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToDemographicGroup"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#DemographicGroup"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#belongsToDemographicGroup"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#DemographicGroup"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOccupationOfType"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#OccupationType"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOccupationOfType"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#OccupationType"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">A human being with a social identity or persona.</rdfs:comment>
-      <rdfs:label xml:lang="en">Person</rdfs:label>
-      <skos:scopeNote xml:lang="en">Person is a kind of Agent. Most commonly, a human being
-            (biological person) has a single coeval social identity or persona. In everyday
-            discourse, this is the “real person.” Less common though not rare, over the course of a
-            lifetime, personae in addition to the coeval (or “original”) persona may be associated
-            with the human being. Such “alternative personae” are most often created by the original
-            person for specific purposes. Under some circumstances, an alternative persona might
-            eclipse or replace the original person (Mark Twain eclipsing Samuel Clemens; John Wayne
-            eclipsing Marion Mitchell Morrison), that is, the social (shared) alternative identity
-            becomes the predominate identity. Less common yet is two or more persons collaborate to
-            create a shared persona. Persona shared by two or more Persons constitute a kind of
-            Group. Within the archival context, the original Person generally will be the focus of
-            the description, with alternative personae noted. Exceptionally, an alternative persona
-            may displace the coeval persona. This entity includes: historical or current people;
-            people that manage records.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Person is a kind of Agent. &#xD; Most commonly, a human being
+         (biological person) has a single coeval social identity or persona. In everyday discourse,
+         this is the “real person.”&#xD; Less common though not rare, over the course of a lifetime,
+         personae in addition to the coeval (or “original”) persona may be associated with the human
+         being. Such “alternative personae” are most often created by the original person for
+         specific purposes.&#xD; Under some circumstances, an alternative persona might eclipse or
+         replace the original person (Mark Twain eclipsing Samuel Clemens; John Wayne eclipsing
+         Marion Mitchell Morrison), that is, the social (shared) alternative identity becomes the
+         predominate identity.&#xD; Less common is whentwo or more persons collaborate to create a
+         shared persona. Persona shared by two or more Persons constitute a kind of Group.&#xD;
+         Within the archival context, the original Person generally will be the focus of the
+         description, with alternative personae noted. Exceptionally, an alternative persona may
+         displace the coeval persona.s.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E08 (Person
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
+      <owl:disjointWith rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
+      <owl:disjointWith rdf:resource="https://www.ica.org/standards/RiC/ontology#Mechanism"/>
+      <owl:disjointWith rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Scope note: made separate paragraphs and updated. Disjoint with: enriched.
+            Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#PhysicalLocation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#PhysicalLocation">
+      <rdfs:label xml:lang="en">Physical Location</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:subClassOf>
          <owl:Restriction>
             <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasCoordinates"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Coordinates"/>
+            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Coordinates"
+            />
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#isPhysicalLocationOf"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#isPhysicalLocationOf"/>
             <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">A delimitation of the physical territory of a
-            Place.</rdfs:comment>
-      <rdfs:label xml:lang="en">Physical Location</rdfs:label>
-      <skos:scopeNote xml:lang="en">Usually associated to one to many Places, and known during
-            some time. A location may be linked to one to many Coordinates. </skos:scopeNote>
+         Place.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Usually associated to one to many Places, and known during some
+         time. A location may be linked to one to many Coordinates.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-A27 (Location
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Place -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Place">
+      <rdfs:label xml:lang="en">Place</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPhysicalLocation"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#PhysicalLocation"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPhysicalLocation"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#PhysicalLocation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">A bounded, named geographic area or region.</rdfs:comment>
-      <rdfs:label xml:lang="en">Place</rdfs:label>
-      <skos:scopeNote xml:lang="en">A Place may be a jurisdiction, a manmade structure, or a
-            natural feature. A manmade structure or natural feature may also be a jurisdiction. A
-            Place may be systematically referenced to a Physical Location on the earth, or (if you
-            don't want to use the PhysicalLocation class, directly to geographic coordinates.
-            Both jurisdictions and natural features are historical entities. A Place thus may have
-            begin and end dates, and changing boundaries that result from human or natural events. A
-            Jurisdiction is the bounded geographic area within which an Agent has the authority to
-            perform specified activities constrained by rules. This entity includes: - Places of the
-            earth and in outer space. - Historical and current places. - Territorial areas above a
-            corporate body with public powers perform their activities (states, regions, provinces,
-            judicial areas, areas of local municipalities…) - Territorial areas above a religious
-            corporate body performs their activities (ecclesiastical provinces, dioceses,
-            archdioceses, archpriesthood, vicariates…) - Territorial areas above a nobiliary or
-            feudal corporate body performs their activities (Duchies, counties…) - Regions, spot
-            places, - Geographical features and landforms (valleys, mountains, rivers, lakes, caves,
-            gulfs, islands…) - Places protected by their natural value (archaeological sites,
-            national parks…) - Urban spaces (neighborhoods, squares, streets, gardens…) -
-            Engineering works (paths, roads, motorways, highways, bridges, tunnels, aqueducts, dams,
-            pipelines…) - Pilgrimage and commercial routes….</skos:scopeNote>
+      <rdfs:comment xml:lang="en">Bounded, named geographic area or region.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">A Place may be a jurisdiction, a manmade structure, or a natural
+         feature. A manmade structure or natural feature may also be a jurisdiction. &#xD; A Place
+         may be referenced to a Physical Location on the earth, or (if you don't want to use the
+         PhysicalLocation class) directly to geographic coordinates.&#xD; Both jurisdictions and
+         natural features are historical entities. A Place thus may have begin and end dates, and
+         changing boundaries that result from human or natural events.&#xD; A Jurisdiction is the
+         bounded geographic area within which an Agent has the authority to perform specified
+         activities constrained by rules.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E22 (Place
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Comment: updated. Scope note: updated and made several paragraphs. Objective: to
+            make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#PlaceName -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#PlaceName">
+      <rdfs:label xml:lang="en">Place Name</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Name"/>
       <rdfs:comment xml:lang="en">A label, title or term designating a Place in order to make it
-            distinguishable from other similar entities.</rdfs:comment>
-      <rdfs:label xml:lang="en">Place Name</rdfs:label>
-      <RiCCMCorrespondingComponent xml:lang="en">Class implementation of a specialization of
-            RiC-A28 (Name attribute)</RiCCMCorrespondingComponent>
+         distinguishable from other similar entities.</rdfs:comment>
+      <RiCCMCorrespondingComponent xml:lang="en">Class implementation of a specialization of RiC-A28
+         (Name attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#PlaceRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#PlaceRelation">
+      <rdfs:label xml:lang="en">Place Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#placeRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#placeRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#placeRelationHasSource"/>
-            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#placeRelationHasSource"/>
+            <owl:qualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects a Place and at least one Thing, when the first is
-            associated with the existence and lifecycle of the second one.</rdfs:comment>
-      <rdfs:label xml:lang="en">Place Relation</rdfs:label>
+         associated with the existence and lifecycle of the second one.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R074 and RiC-R074i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#PlaceType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#PlaceType">
+      <rdfs:label xml:lang="en">Place Type</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:subClassOf>
          <owl:Restriction>
@@ -7827,106 +9203,141 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Categorization of a Place.</rdfs:comment>
-      <rdfs:label xml:lang="en">Place Type</rdfs:label>
       <skos:scopeNote xml:lang="en">Broadly, a Place may be a member of three broad categories:
-            jurisdiction, manmade structure, or a natural feature. Each of these three categories
-            can subdivided into narrower categories.</skos:scopeNote>
+         jurisdiction, manmade structure, or a natural feature. Each of these three categories can
+         subdivided into narrower categories.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A32 (Place Type
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Position -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Position">
+      <rdfs:label xml:lang="en">Position</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">The functional role of a Person within a Group.</rdfs:comment>
-      <rdfs:label xml:lang="en">Position</rdfs:label>
-      <skos:scopeNote xml:lang="en">Position is a kind of Agent. Position is the intersection of a
-            Person and a Group. Position exists independently of the Person that holds the position.
-            More than one Person may hold a Position. Position is commonly defined in a mandate,
-            often called a position description or job description. The mandate may specify the
-            activity and competencies for performing the activity. A Position is often given a name.
-            A Position may be tied to a project or to a set of tasks and thus have a defined
-            duration. A Position may change over time, as the Group that establishes it changes over
-            time. Position is not to be confused with Occupation or Activity. Within the Records
-            created by a Corporate Body, a Position may be used to identify the Record Sets
-            resulting from Activities performed by one or more Persons holding the Position over
-            time, without necessarily identifying or describing the Person or Persons, or
-            identifying which Records were created by each Person.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Position is a kind of Agent. &#xD; Position is the intersection
+         of a Person and a Group.&#xD; Position exists independently of the Person that holds the
+         Position within a Group.&#xD; More than one Person may hold a Position.&#xD; Position is
+         commonly defined in a Mandate, often called a position description or job description. The
+         Mandate may specify the work to be performed (Activity) as well as the competencies for
+         performing the Activity.&#xD; A Position is often given a Name.&#xD; A Position may be tied
+         to a project or to a set of tasks and thus have a defined duration.&#xD; A Position may
+         change over time, as the Group that establishes it changes over time.&#xD; Position is not
+         to be confused with Occupation or Activity.&#xD; Within the records created by a Corporate
+         Body, a Position may be used to identify the record sets resulting from activities
+         performed by one or more persons holding the Position over time, without necessarily
+         identifying or describing the Person or persons, or identifying which records were created
+         by each Person.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E12 (Position
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
+      <owl:disjointWith rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
+      <owl:disjointWith rdf:resource="https://www.ica.org/standards/RiC/ontology#Mechanism"/>
+      <owl:disjointWith rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Scope note: made separate paragraphs and updated. Disjoint with: enriched.
+            Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#PositionHoldingRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#PositionHoldingRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:label xml:lang="en">Position Holding Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Person, and at least one Position that the
-            Person occupies.</rdfs:comment>
-      <rdfs:label xml:lang="en">Position Holding Relation</rdfs:label>
+         Person occupies.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R054 and RiC-R054i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#PositionToGroupRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#PositionToGroupRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:label xml:lang="en">Position to Group Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget"/>
-            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget"/>
+            <owl:qualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least one Position, and a Group, when the first
-            one(s) exist(s) in/is defined within the second one.</rdfs:comment>
-      <rdfs:label xml:lang="en">Position to Group Relation</rdfs:label>
+      <rdfs:comment xml:lang="en">Connects at least one Position, and a Group, when the first one(s)
+         exist(s) in/is defined within the second one.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R056 and RiC-R056i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#ProductionTechniqueType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#ProductionTechniqueType">
+      <rdfs:label xml:lang="en">Production Technique Type</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#isProductionTechniqueTypeOf"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#isProductionTechniqueTypeOf"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">The method used in the representation of information on the
-            Instantiation.</rdfs:comment>
-      <rdfs:label xml:lang="en">Production Technique Type</rdfs:label>
+      <rdfs:comment xml:lang="en">Categorization of the method used in the representation of
+         information on the Instantiation.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-A33 (Production
-            Technique attribute)</RiCCMCorrespondingComponent>
+         Technique attribute)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Comment: updated. Objective: to make RiC-O compliant with RiC-CM
+            v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#ProvenanceRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#ProvenanceRelation">
+      <rdfs:label xml:lang="en">Provenance Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -7934,103 +9345,129 @@
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Activity"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#Activity"/>
                      <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Agent"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Specifies the provenance or origin of at least one Record
-            Resource or Instantiation, for example the relation between a Record Resource and the
-            Agent which created it or the Activity from which it resulted.</rdfs:comment>
-      <rdfs:label xml:lang="en">Provenance Relation</rdfs:label>
+      <rdfs:comment xml:lang="en">Specifies the provenance or origin of at least one Record Resource
+         or Instantiation, for example the relation between a Record Resource and the Agent which
+         created it or the Activity from which it resulted.</rdfs:comment>
       <skos:scopeNote xml:lang="en">This relation stands for organic and for functional
-            provenance.</skos:scopeNote>
+         provenance.</skos:scopeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Proxy -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Proxy">
+      <rdfs:label xml:lang="en">Proxy</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Concept"/>
       <rdfs:subClassOf>
          <owl:Restriction>
             <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
-            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+            <owl:qualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
             <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIn"/>
-            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+            <owl:qualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">A Proxy represents (stands for) a Record Resource as it exists
-            in a specific Record Set. </rdfs:comment>
-      <rdfs:label xml:lang="en">Proxy</rdfs:label>
-      <skos:scopeNote xml:lang="en">Useful for handling in RDF the sequencing of records or
-            records sets in the context of a Record set. A Record Resource has only one Proxy in the
-            context of one specific Record Set. It may have many Proxies simultaneously or through
-            time.</skos:scopeNote>
+      <rdfs:comment xml:lang="en">A Proxy represents (stands for) a Record Resource as it exists in
+         a specific Record Set.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Useful for handling in RDF the sequencing of records or records
+         sets in the context of a Record set. A Record Resource has only one Proxy in the context of
+         one specific Record Set. It may have many Proxies simultaneously or through
+         time.</skos:scopeNote>
       <closeTo xml:lang="en">ORE Proxy (http://www.openarchives.org/ore/terms/Proxy)</closeTo>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Record -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Record">
+      <rdfs:label xml:lang="en">Record</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDocumentaryFormType"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#DocumentaryFormType"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDocumentaryFormType"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#DocumentaryFormType"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Information inscribed at least once by any method on any
-            physical carrier in any persistent, recoverable form by an Agent in the course of life
-            or work Activity.</rdfs:comment>
-      <rdfs:label xml:lang="en">Record</rdfs:label>
-      <skos:scopeNote xml:lang="en">Record is a kind of Record Resource. A Record must have or
-            have had at least one Record Instantiation. A Record may have more than one Record
-            Instantiation. A re-instantiation of the record may be considered the same record or a
-            new record, depending on the context and of the functions that record serves. Such
-            information may serve a variety of purposes, though it always documents or is evidence
-            of Activity.</skos:scopeNote>
+      <rdfs:comment xml:lang="en">Information inscribed at least once by any method on any physical
+         carrier in any persistent, recoverable form by an Agent in the course of life or work
+         Activity.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Record is a kind of Record Resource. &#xD; A Record must have or
+         have had at least one Instantiation. A Record may have more than one Instantiation. &#xD; A
+         re-instantiation of the record may be considered the same record or a new record, depending
+         on the context and of the functions that record serves. &#xD; Such information may serve a
+         variety of purposes, though it always documents or is evidence of
+         Activity.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E04 (Record
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Scope note: updated and made several paragraphs. Objective: to make RiC-O
+            compliant with RiC-CM v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RecordPart -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordPart">
+      <rdfs:label xml:lang="en">Record Part</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDocumentaryFormType"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#DocumentaryFormType"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDocumentaryFormType"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#DocumentaryFormType"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">A part of a Record with discrete information content that
-            contributes to the Record's physical or intellectual completeness.</rdfs:comment>
-      <rdfs:label xml:lang="en">Record Part</rdfs:label>
-      <skos:scopeNote xml:lang="en">Record Part is a kind of Record Resource. A Record Part may
-            itself have Record Parts.</skos:scopeNote>
+      <rdfs:comment xml:lang="en">Part of a Record with discrete information content that
+         contributes to the Record's physical or intellectual completeness.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Record Part is a kind of Record Resource.&#xD; A Record Part may
+         itself have Record Parts.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E05 (Record Part
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>comment: updated. Scope note: made several paragraphs. Objective: to make RiC-O
+            compliant with RiC-CM v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RecordResource -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource">
+      <rdfs:label xml:lang="en">Record Resource</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasContentOfType"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#ContentType"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#hasContentOfType"/>
+            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#ContentType"
+            />
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasInstantiation"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#hasInstantiation"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
@@ -8042,13 +9479,16 @@
       <rdfs:subClassOf>
          <owl:Restriction>
             <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasLegalStatus"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#LegalStatus"/>
+            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#LegalStatus"
+            />
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasRecordResourceState"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceState"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#hasRecordResourceState"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceState"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
@@ -8058,197 +9498,242 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">A Record, Record Set, or Record Part produced or acquired and
-            retained by an Agent in the course of Activity.</rdfs:comment>
-      <rdfs:label xml:lang="en">Record Resource</rdfs:label>
-      <skos:scopeNote xml:lang="en">Producing a record resource may imply either its newly
-            creation or a reuse of previous existing information by combination, rearrangement,
-            selecting, reformatting etc. Records, Record Sets, and Record Parts are all evidence of
-            the activities of an Agent. More than one Agent may be involved in the creation of a
-            Record Resource. The role of the Agent in creating the Record Resource may take
-            different forms, for example, authoring of an individual record, accumulating a set of
-            records, or forming a set of records. Though a Record, Record Set, and Record Part,
-            under most circumstances, may be easily distinguished from one another, frequently
-            identifying the boundary of each and how the “bounded information regions” interrelate,
-            may present particular challenges. Documentary Forms provide the rules governing many
-            Records, providing criteria for identifying its boundary, and identifying its essential
-            Record Parts. Many Records, though, do not have well-established Documentary Forms,
-            particularly electronic Records, where it may be difficult to determine whether
-            individual elements represented in separate bitstreams are Record Parts, Records, or
-            Record Sets. For example, is a photograph represented independently in a bitstream
-            embedded in a text document a Record, or a Record Part. Or is the same photograph
-            attached to an email, maintaining its independent representation, a Record or a Record
-            Part? A further challenge is presented when information is grouped for some purpose, for
-            example, zip or tar “file compression” for saving storage space. One file comprises
-            multiple bitstreams subjected to techniques that remove bits that can be losslessly
-            recovered when decompressed. Under what circumstances is such a compressed bitstream a
-            Record or a Record Set? Determining when an information object is a Record, Record Part,
-            or Record Set is based on perspective and judgement exercised in a particular context.
-            In one context, the Agent describing an information object may designate it a Record,
-            while another Agent in a different context may designate it a Record Part. Both
-            designations are supported by RiC, and the significance of the difference for users of
-            the Records is ameliorated by the fact that attributes and relations employed in
-            describing each of the Record Entities are shared.</skos:scopeNote>
+         retained by an Agent in the course of Activity.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Producing a record resource may imply either its newly creation
+         or a reuse of previous existing information by combination, rearrangement, selecting,
+         reformatting etc.&#xD; Records, Record Sets, and Record Parts are all evidence of the
+         activities of an Agent. More than one Agent may be involved in the creation of a Record
+         Resource. The role of the Agent in creating the Record Resource may take different forms,
+         for example, authoring of an individual record, accumulating a set of records, or forming a
+         set of records.&#xD; Though a Record, Record Set, and Record Part, under most
+         circumstances, may be easily distinguished from one another, frequently identifying the
+         boundary of each and how the “bounded information regions” interrelate, may present
+         particular challenges.&#xD; Documentary Forms provide the rules governing many Records,
+         providing criteria for identifying its boundary, and identifying its essential Record
+         Parts. Many Records, though, do not have well-established documentary forms, particularly
+         electronic records, where it may be difficult to determine whether individual elements
+         represented in separate bitstreams are record parts, records, or record sets. &#xD; For
+         example, is a photograph represented independently in a bitstream embedded in a text
+         document a Record, or a Record Part ? Or is the same photograph attached to an email,
+         maintaining its independent representation, a Record or a Record Part?&#xD; When
+         information is grouped for some purpose, for example, zip or tar “file compression” for
+         saving storage space, presents a further challenge. One file comprises multiple bitstreams
+         subjected to techniques that remove bits that can be losslessly recovered when
+         decompressed. Under what circumstances is such a compressed bitstream a Record or a Record
+         Set?&#xD; Determining when an information object is a Record, Record Part, or Record Set is
+         based on perspective and judgement exercised in a particular context. In one context, the
+         Agent describing an information object may designate it a Record, while another Agent in a
+         different context may designate it a Record Part.&#xD; Both designations are supported by
+         RiC, and the significance of the difference for users of the records is ameliorated by the
+         fact that attributes and relations employed in describing each of the record entities are
+         shared.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E02 (Record Resource
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Scope note: made separate paragraphs plus very few changes.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RecordResourceGeneticRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResourceGeneticRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation"/>
+      <rdfs:label xml:lang="en">Record Resource Genetic Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceGeneticRelationConnects"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceGeneticRelationConnects"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects two to more Record Resources when there is a genetic
-            relation between them. Genetic in this sense is as defined by diplomatics, i.e. the
-            process by which a Record Resource is developed.</rdfs:comment>
-      <rdfs:label xml:lang="en">Record Resource Genetic Relation</rdfs:label>
+         relation between them. Genetic in this sense is as defined by diplomatics, i.e. the process
+         by which a Record Resource is developed.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R023 and RiC-023i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation">
+      <rdfs:label xml:lang="en">Record Resource Holding Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ManagementRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Agent, and one or more Record Resource or
-            Instantiation that the Agent holds.</rdfs:comment>
-      <rdfs:label xml:lang="en">Record Resource Holding Relation</rdfs:label>
+         Instantiation that the Agent holds.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R039 and RiC-039i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RecordResourceState -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResourceState">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
-      <rdfs:comment xml:lang="en">The production or reproduction status of the Record
-            Resource.</rdfs:comment>
       <rdfs:label xml:lang="en">Record Resource State</rdfs:label>
-      <skos:scopeNote xml:lang="en">Can refer both to the record state of creation and its form of
-            transmission when the record was received.</skos:scopeNote>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
+      <rdfs:comment xml:lang="en">Categorization of the production or reproduction status of a
+         Record Resource.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Can in particular refer to a record state of development or its
+         status of transmission once finished (draft, original, copy...). &#xD; Specifying that a
+         record resource has state copy usually implies that another record resource existed or
+         exists, of which the one described is the copy. In such a case you can also use 'is copy
+         of' object property.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A39 (State
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>scope note: updated. Objective: to make RiC-O compliant with RiC-CM
+            v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation -->
-   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation">
+   <owl:Class
+      rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation">
+      <rdfs:label xml:lang="en">Record Resource to Instantiation Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource"/>
-            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource"/>
+            <owl:qualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects a Record Resource to one or more Instantiations that
-            instantiate it.</rdfs:comment>
-      <rdfs:label xml:lang="en">Record Resource to Instantiation Relation</rdfs:label>
+         instantiate it.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R025 and RiC-R025i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation -->
-   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation">
+   <owl:Class
+      rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation">
+      <rdfs:label xml:lang="en">Record Resource to Record Resource Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least two Record Resources.</rdfs:comment>
-      <rdfs:label xml:lang="en">Record Resource to Record Resource Relation</rdfs:label>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R022 and RiC-022i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RecordSet -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordSet">
+      <rdfs:label xml:lang="en">Record Set</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasRecordSetType"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSetType"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#hasRecordSetType"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSetType"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">One or more records that are associated by categorization and/or
-            physical aggregation by the creator or other Agent responsible for preserving the
-            creator’s records..</rdfs:comment>
-      <rdfs:label xml:lang="en">Record Set</rdfs:label>
-      <skos:scopeNote xml:lang="en">The Record members in a Record Set may physically reside
-            together, though physical proximity is not essential. In a particular context, an Agent
-            (e.g. administrator, records manager, archivist, end-user, etc.) may select the Record
-            members of a Record Set based on a shared attribute or attributes, or a shared Relation
-            or Relations. The grouping of the Records serves a purpose or purposes specific to the
-            context of the Agent. Any shared attribute or relation, or combination of shared
-            attributes or relations may designate the Record members in a Record Set. All Record
-            members of a Record Set may share the attribute of having been accumulated by the same
-            Agent, or all share the same Documentary Form and are created over time by the same
-            Activity. A Record Set may represent the act of classifying the Records in accordance
-            with a formal classification scheme that may be based on Activity (or Function or
-            Process), subject, organizational structure, or other criteria; an act of archival
-            arrangement (e.g. based on common provenance); or some other selection and grouping that
-            fulfils a particular purpose or purposes (e.g. a classification that reflects or
-            supports the purposes of a researcher). By exception, some Records are brought together
-            based on their not belonging in the context of selection to other designated groups: a
-            ‘Miscellaneous’ series for example. Record Set created by an Agent in the course of life
-            or work Activity should be kept in a manner that preserves context and evidential value.
-            Records Sets may also contain other Records Sets. Both a Record Set and a Record may
-            simultaneously be a member of more than one Record Set, and over the course of its
-            existence, a Record Set or Record may be a member of an indeterminate number of Record
-            Sets in an indeterminate number of contexts. Record Sets and Records contained within a
-            Record Set may be ordered into a sequence based on a common property or relation, or
-            common properties or relations (e.g. alphabetical by Agent or related Place name);
-            chronological order by an allocated Date; or some other criterion (e.g. an imposed order
-            by relevance).</skos:scopeNote>
+         physical aggregation by the creator or other Agent.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Record Set is a kind of Record Resource.&#xD; The Record members
+         in a Record Set may physically reside together, though physical proximity is not
+         essential.&#xD; In a particular context, an Agent (e.g. administrator, records manager,
+         archivist, end-user, etc.) may select the Record members of a Record Set based on a shared
+         attribute or attributes, or a shared Relation or Relations. The grouping of the Records
+         serves a purpose or purposes specific to the context of the Agent. &#xD; All Record members
+         of a Record Set may share the attribute of having been accumulated by the same Agent, or
+         all share the same Documentary Form Type and are created over time by the same
+         Activity.&#xD; A Record Set may represent the act of classifying the Records in accordance
+         with a formal classification scheme that may be based on Activity, subject, organizational
+         structure, or other criteria; an act of archival arrangement (e.g. based on common
+         provenance); or some other selection and grouping that fulfils a particular purpose or
+         purposes (e.g. a classification that reflects or supports the purposes of a researcher).
+         &#xD; By exception, some Records are brought together based on their not belonging in the
+         context of selection to other designated groups: a ‘Miscellaneous’ series, for example.
+         &#xD; A Record Set accumulated by an Agent in the course of life or work Activity should be
+         kept in a manner that preserves context and evidential value. &#xD; Records Sets may also
+         contain other Records Sets. Both a Record Set and a Record may simultaneously be a member
+         of more than one Record Set, and over the course of its existence, a Record Set or Record
+         may be a member of an indeterminate number of Record Sets in an indeterminate number of
+         contexts.&#xD; Record Sets and Records contained within a Record Set may be ordered into a
+         sequence based on a common property or relation, or common properties or relations (e.g.
+         alphabetical by Agent or related Place name; chronological order by an allocated Date); or
+         some other criterion (e.g. an imposed order by relevance).</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E03 (Record Set
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>comment: updated. Scope note: updated and made several paragraphs. Objective: to
+            make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RecordSetType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordSetType">
+      <rdfs:label xml:lang="en">Record Set Type</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordSetTypeOf"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordSetTypeOf"/>
             <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">A broad categorization of the type of Record Set.</rdfs:comment>
-      <rdfs:label xml:lang="en">Record Set Type</rdfs:label>
-      <skos:scopeNote xml:lang="en">Four instances of Record Set Type are included for now in
-            RiC-O; they also are instances of skos:Concept and, as such, part of a SKOS vocabulary.
-            Record Set Type may be extended to reflect types of Record Sets that are not
-            archival.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Four instances of Record Set Type are included for now in RiC-O;
+         they also are instances of skos:Concept and, as such, part of a SKOS vocabulary. &#xD;
+         Record Set Type may also be used to categorize types of Record Set that have not
+         traditionally been considered archival, e.g. search result list.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A36 (Record Set Type
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>scope note: updated. Objective: to make RiC-O compliant with RiC-CM
+            v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Relation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Relation">
+      <rdfs:label xml:lang="en">Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:subClassOf>
          <owl:Restriction>
@@ -8257,7 +9742,8 @@
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
                      <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Agent"/>
-                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+                     <rdf:Description
+                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:allValuesFrom>
@@ -8266,305 +9752,392 @@
       <rdfs:subClassOf>
          <owl:Restriction>
             <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#certainty"/>
-            <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
+            <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:maxCardinality>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
             <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#relationState"/>
-            <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxCardinality>
+            <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:maxCardinality>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">The top level relation class. It connects at least two Things.
-            An instance of a Relation may have some data and object properties : a descriptive note
-            (data property) like any Thing ; certainty (for 'certain', 'quite
-            probable', 'uncertain','unknown'); a date ; a state
-            (relationState) ; a location ; a source of information that can be used as an evidence
-            for it.</rdfs:comment>
-      <rdfs:label xml:lang="en">Relation</rdfs:label>
+      <rdfs:comment xml:lang="en">The top level relation class. It connects at least two Things. An
+         instance of a Relation may have some data and object properties : a descriptive note (data
+         property) like any Thing ; certainty (for 'certain', 'quite probable',
+         'uncertain','unknown'); a date ; a state (relationState) ; a location ; a source of
+         information that can be used as an evidence for it.</rdfs:comment>
       <skos:scopeNote xml:lang="en">it is recommended to use the subclasses of the Relation
-            class.</skos:scopeNote>
+         class.</skos:scopeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RepresentationType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RepresentationType">
+      <rdfs:label xml:lang="en">Representation Type</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#isRepresentationTypeOf"/>
-            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#isRepresentationTypeOf"/>
+            <owl:allValuesFrom
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">A method of recording the content type of a Record
-            Resource.</rdfs:comment>
-      <rdfs:label xml:lang="en">Representation Type</rdfs:label>
-      <skos:scopeNote xml:lang="en">Representation Types can be unmediated (which allows humans to
-            receive the message communicated without an intermediation of a device) and mediated
-            (which needs a device to decode the message). Most contemporary mediated types are
-            digital. Each Representation Type may present specific features: bit rate for audio,
-            resolution for digital images, encoding format for video etc. Depending of the type,
-            specific attributes may be added to describe their characteristics. Not to be confused
-            with Content Type or Carrier Type since the form of representation can be independent of
-            the communication or carrier.</skos:scopeNote>
+      <rdfs:comment xml:lang="en">Categorization of the method of recording the content type of a
+         Record Resource.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Representation Type can be unmediated (which allows humans to
+         receive the message communicated without an intermediation of a device) and mediated (which
+         needs a device to decode the message). A lot of contemporary mediated types are digital.
+         &#xD; Each Representation Type may present specific features: bit rate for audio,
+         resolution for digital images, encoding format for video etc. Depending of the type,
+         properties may thus be needed to describe their characteristics. &#xD; Not be confused with
+         Content Type or Carrier Type since the form of representation can be independent of the
+         communication or carrier.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A37 (Representation Type
-            attribute)</RiCCMCorrespondingComponent>
+         attribute)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Comment and scope note: updated. Objective: to make RiC-O compliant with RiC-CM
+            v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RoleType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RoleType">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
-      <rdfs:comment xml:lang="en">The role an agent plays in some context (usually in some
-            creation relation). Not to be confused with a position (position of an agent in some
-            group). For example, a person who is the head of some corporate body may play the role
-            of annotator (of a record) in a creation relation.</rdfs:comment>
       <rdfs:label xml:lang="en">Role Type</rdfs:label>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
+      <rdfs:comment xml:lang="en">The role an agent plays in some context (usually in some creation
+         relation). Not to be confused with a position (position of an agent in some group). For
+         example, a person who is the head of some corporate body may play the role of annotator (of
+         a record) in a creation relation.</rdfs:comment>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Rule -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Rule">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <rdfs:comment xml:lang="en">The conditions under which an Activity is performed by an Agent,
-            including the authority to perform the Activity, or specifications with respect to how
-            the Activity is performed.</rdfs:comment>
       <rdfs:label xml:lang="en">Rule</rdfs:label>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
+      <rdfs:subClassOf>
+         <owl:Restriction>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#hasRuleType"/>
+            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#RuleType"/>
+         </owl:Restriction>
+      </rdfs:subClassOf>
+      <rdfs:comment xml:lang="en">Conditions under which an Activity is performed by an Agent,
+         including the authority to perform the Activity, or specifications with respect to how the
+         Activity is performed.</rdfs:comment>
       <skos:scopeNote xml:lang="en">A Rule may be unwritten or written or otherwise documented.
-            Unwritten rules may include though are not limited to the following: social mores,
-            customs, or community expectations. Written rules may include though are not limited to
-            the following: constitutions, legislation, acts (legal), statutes, legal codes,
-            ordinances, charters, mission statements, regulations, policies, procedures,
-            instructions, codes of conduct or ethics, professional standards, work assignments or
-            work plans. The source or sources of some Rules are external to the Agent (for example,
-            expressed in elections, social mores, customs, community expectations, laws,
-            regulations, standards and best practice codes), while others are expressed within the
-            Agent’s immediate context (for example, policies, or written or verbal instructions).
-            The evidence for identifying Rules may be found in their entirety in one documentary
-            source (for example, a law or regulation) or may be found in two or more sources. Rule
-            should not be confused with the one or more documentary sources that serve as evidence
-            of its identity. A documentary source is a Record.</skos:scopeNote>
+         Unwritten rules may include though are not limited to the following: social mores, customs,
+         or community expectations. Written rules may include though are not limited to the
+         following: constitutions, legislation, acts (legal), statutes, legal codes, ordinances,
+         charters, mission statements, regulations, policies, procedures, instructions, codes of
+         conduct or ethics, professional standards, work assignments or work plans. &#xD; The source
+         or sources of some Rules are external to the Agent (for example, expressed in elections,
+         social mores, customs, community expectations, laws, regulations, standards and best
+         practice codes), while others are expressed within the Agent’s immediate context (for
+         example, policies, or written or verbal instructions).&#xD; The evidence for identifying
+         Rules may be found in their entirety in one documentary source (for example, a law or
+         regulation) or may be found in two or more sources. &#xD; Rule should not be confused with
+         the one or more documentary sources that serve as evidence of its identity. A documentary
+         source is a Record.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E16 (Rule
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Scope note: made separate paragraphs and updated. Objective: to make RiC-O
+            compliant with RiC-CM v0.2.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RuleRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RuleRelation">
+      <rdfs:label xml:lang="en">Rule Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Rule to at least one Thing, when it is
-            associated with existence and lifecycle of the Thing.</rdfs:comment>
-      <rdfs:label xml:lang="en">Rule Relation</rdfs:label>
+         associated with existence and lifecycle of the Thing.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R062 and RiC-R062i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
+   </owl:Class>
+   <!-- https://www.ica.org/standards/RiC/ontology#RuleType -->
+   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RuleType">
+      <rdfs:label xml:lang="en">Rule Type</rdfs:label>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
+      <rdfs:subClassOf>
+         <owl:Restriction>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleTypeOf"/>
+            <owl:allValuesFrom rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
+         </owl:Restriction>
+      </rdfs:subClassOf>
+      <rdfs:comment xml:lang="en">Categorization of a Rule.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">For example, for rules that can be applied to record resources :
+         access rule, use rule, etc.</skos:scopeNote>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>Class added along with hasRuleType and isRuleTypeOf object
+            properties.</rdf:value>
+         <dc:date>2020-10-19</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#SequentialRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#SequentialRelation">
+      <rdfs:label xml:lang="en">Sequential Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least one Thing to at least one Thing that follows
-            it in some sequence.</rdfs:comment>
-      <rdfs:label xml:lang="en">Sequential Relation</rdfs:label>
+      <rdfs:comment xml:lang="en">Connects at least one Thing to at least one Thing that follows it
+         in some sequence.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R008 and RiC-R008i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#SiblingRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#SiblingRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#FamilyRelation"/>
-      <rdfs:subClassOf>
-         <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#siblingRelationConnects"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
-            <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
-         </owl:Restriction>
-      </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least two Persons, when they are siblings. </rdfs:comment>
       <rdfs:label xml:lang="en">Sibling Relation</rdfs:label>
-      <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R048 and048i
-            relations RiC-</RiCCMCorrespondingComponent>
-   </owl:Class>
-   <!-- https://www.ica.org/standards/RiC/ontology#SingleDate -->
-   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#SingleDate">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
-      <rdfs:comment xml:lang="en">Chronological information associated with an entity that
-            contributes to its identification and contextualization related to a single point in
-            time.</rdfs:comment>
-      <rdfs:label xml:lang="en">Single Date</rdfs:label>
-      <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E19 (SingleDate
-            entity)</RiCCMCorrespondingComponent>
-   </owl:Class>
-   <!-- https://www.ica.org/standards/RiC/ontology#SpouseRelation -->
-   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#SpouseRelation">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#FamilyRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#spouseRelationConnects"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#siblingRelationConnects"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least two Persons, when they are
-            spouses.</rdfs:comment>
+         siblings.</rdfs:comment>
+      <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R048 and048i relations
+         RiC-</RiCCMCorrespondingComponent>
+   </owl:Class>
+   <!-- https://www.ica.org/standards/RiC/ontology#SingleDate -->
+   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#SingleDate">
+      <rdfs:label xml:lang="en">Single Date</rdfs:label>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
+      <rdfs:comment xml:lang="en">Chronological information associated with an entity that
+         contributes to its identification and contextualization, related to a single point in
+         time.</rdfs:comment>
+      <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E19 (SingleDate
+         entity)</RiCCMCorrespondingComponent>
+   </owl:Class>
+   <!-- https://www.ica.org/standards/RiC/ontology#SpouseRelation -->
+   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#SpouseRelation">
       <rdfs:label xml:lang="en">Spouse Relation</rdfs:label>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#FamilyRelation"/>
+      <rdfs:subClassOf>
+         <owl:Restriction>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#spouseRelationConnects"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >2</owl:minQualifiedCardinality>
+            <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
+         </owl:Restriction>
+      </rdfs:subClassOf>
+      <rdfs:comment xml:lang="en">Connects at least two Persons, when they are
+         spouses.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R049 and RiC-R049i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#TeachingRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#TeachingRelation">
+      <rdfs:label xml:lang="en">Teaching Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#KnowingRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Person to at least another Person, who is
-            their student.</rdfs:comment>
-      <rdfs:label xml:lang="en">Teaching Relation</rdfs:label>
+         their student.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R053 and RiC-R053i
-            relation</RiCCMCorrespondingComponent>
+         relation</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#TemporalRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#TemporalRelation">
+      <rdfs:label xml:lang="en">Temporal Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#SequentialRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least one Thing to at least one Thing that follows
-            it in chronological order.</rdfs:comment>
-      <rdfs:label xml:lang="en">Temporal Relation</rdfs:label>
+      <rdfs:comment xml:lang="en">Connects at least one Thing to at least one Thing that follows it
+         in chronological order.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R009 and RiC-R009i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Thing -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Thing">
-      <rdfs:comment xml:lang="en">Any idea, material thing, or event within the realm of human
-            experience.</rdfs:comment>
       <rdfs:label xml:lang="en">Thing</rdfs:label>
-      <skos:scopeNote xml:lang="en">Includes all RiC entities as well as any concept, material thing, or event
-            that may be the subject of a Record Resource or associated with an Activity. Examples of
-            entities not explicitly addressed in RiC includes but is not limited to the following:
-            abstract concepts; cultural movements, named periods and events; named things, objects
-            and works; legendary, mythical or fictitious figures, characters or
-            beings.</skos:scopeNote>
+      <rdfs:comment xml:lang="en">Any idea, material thing, or event within the realm of human
+         experience.</rdfs:comment>
+      <skos:scopeNote xml:lang="en">Includes all RiC entities as well as any concept, material
+         thing, or event that may be the subject of a Record Resource or associated with an
+         Activity. &#xD; Examples of entities not explicitly addressed in RiC includes but is not
+         limited to the following: abstract concepts; cultural movements, named periods and events;
+         named things, objects and works; legendary, mythical or fictitious figures, characters or
+         beings.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E01 (Thing
-            entity)</RiCCMCorrespondingComponent>
+         entity)</RiCCMCorrespondingComponent>
+      <skos:changeNote rdf:parseType="Resource">
+         <rdf:value>made separate paragraphs in the scope note.</rdf:value>
+         <dc:date>2020-10-23</dc:date>
+      </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Title -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Title">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Name"/>
-      <rdfs:comment xml:lang="en">A name that is used for a Record Resource or a
-            Rule</rdfs:comment>
       <rdfs:label xml:lang="en">Title</rdfs:label>
-      <RiCCMCorrespondingComponent xml:lang="en">Class implementation of a specialization of
-            RiC-A28 (Name attribute)</RiCCMCorrespondingComponent>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Name"/>
+      <rdfs:comment xml:lang="en">A name that is used for a Record Resource or a Rule</rdfs:comment>
+      <RiCCMCorrespondingComponent xml:lang="en">Class implementation of a specialization of RiC-A28
+         (Name attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Type -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Type">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Concept"/>
-      <rdfs:comment xml:lang="en">A superclass for any category of some thing. A type
-            characterizes an entity.</rdfs:comment>
       <rdfs:label xml:lang="en">Type</rdfs:label>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Concept"/>
+      <rdfs:comment xml:lang="en">A superclass for any category of some thing. A type characterizes
+         an entity.</rdfs:comment>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#TypeRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#TypeRelation">
+      <rdfs:label xml:lang="en">Type Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#typeRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#typeRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#typeRelationHasSource"/>
-            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#typeRelationHasSource"/>
+            <owl:qualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects a category (a Type) and at least one Thing that belongs
-            to this category.</rdfs:comment>
-      <rdfs:label xml:lang="en">Type Relation</rdfs:label>
+         to this category.</rdfs:comment>
       <skos:scopeNote xml:lang="en">may be useful at least for some types (e.g. demographic
-            group)</skos:scopeNote>
+         group)</skos:scopeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#WholePartRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#WholePartRelation">
+      <rdfs:label xml:lang="en">Whole Part Relation</rdfs:label>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource"/>
-            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource"/>
+            <owl:qualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects a Thing to at least one constitutive or component part
-            of that Thing.</rdfs:comment>
-      <rdfs:label xml:lang="en">Whole Part Relation</rdfs:label>
+      <rdfs:comment xml:lang="en">Connects a Thing to at least one constitutive or component part of
+         that Thing.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R002 and RiC-R002i
-            relations</RiCCMCorrespondingComponent>
+         relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#WorkRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#WorkRelation">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:label xml:lang="en">Work Relation</rdfs:label>
+      <rdfs:subClassOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#workRelationConnects"/>
-            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
+            <owl:onProperty
+               rdf:resource="https://www.ica.org/standards/RiC/ontology#workRelationConnects"/>
+            <owl:minQualifiedCardinality
+               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+               >2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least two Agents that have some type of work
-            relation in the course of their activities.</rdfs:comment>
-      <rdfs:label xml:lang="en">Work Relation</rdfs:label>
+      <rdfs:comment xml:lang="en">Connects at least two Agents that have some type of work relation
+         in the course of their activities.</rdfs:comment>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R046 and RiR046i
-            relations-</RiCCMCorrespondingComponent>
+         relations-</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -8574,90 +10147,99 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
    <!-- https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes -->
-   <owl:NamedIndividual rdf:about="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes">
+   <owl:NamedIndividual
+      rdf:about="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes">
       <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
       <dc:creator xml:lang="en">International Coucil on Archives Expert Group on Archival
-            Description (ICA EGAD)</dc:creator>
+         Description (ICA EGAD)</dc:creator>
       <dc:title xml:lang="en">International Council on Archives Records in Contexts Vocabulary for
-            Documentary Form Types</dc:title>
+         Documentary Form Types</dc:title>
       <rdfs:label xml:lang="en">Documentary Form Types</rdfs:label>
       <skos:definition xml:lang="en">A vocabulary that includes documentary form
-            types</skos:definition>
+         types</skos:definition>
    </owl:NamedIndividual>
    <!-- https://www.ica.org/standards/RiC/vocabularies/recordSetTypes -->
    <owl:NamedIndividual rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes">
       <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
       <dc:creator xml:lang="en">International Coucil on Archives Expert Group on Archival
-            Description (ICA EGAD)</dc:creator>
+         Description (ICA EGAD)</dc:creator>
       <dc:title xml:lang="en">International Council on Archives Records in Contexts Vocabulary for
-            Record Set Types</dc:title>
+         Record Set Types</dc:title>
       <rdfs:label xml:lang="en">Record Set Types</rdfs:label>
       <skos:definition xml:lang="en">A vocabulary on Record Set types</skos:definition>
    </owl:NamedIndividual>
    <!-- https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes#AuthorityRecord -->
-   <owl:NamedIndividual rdf:about="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes#AuthorityRecord">
+   <owl:NamedIndividual
+      rdf:about="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes#AuthorityRecord">
       <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <rdf:type rdf:resource="https://www.ica.org/standards/RiC/ontology#DocumentaryFormType"/>
       <rdfs:label xml:lang="en">Authority record</rdfs:label>
       <skos:definition xml:lang="en">This category can be used for records that describe an
-            entity.</skos:definition>
-      <skos:inScheme rdf:resource="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes"/>
+         entity.</skos:definition>
+      <skos:inScheme
+         rdf:resource="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes"/>
       <skos:prefLabel xml:lang="en">Authority record</skos:prefLabel>
    </owl:NamedIndividual>
    <!-- https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes#FindingAid -->
-   <owl:NamedIndividual rdf:about="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes#FindingAid">
+   <owl:NamedIndividual
+      rdf:about="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes#FindingAid">
       <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <rdf:type rdf:resource="https://www.ica.org/standards/RiC/ontology#DocumentaryFormType"/>
       <rdfs:label xml:lang="en">Finding aid</rdfs:label>
       <skos:definition xml:lang="en">This documentary form type can be used for records that
-            aggregate and organizes metadata on some record(s) or record set(s).</skos:definition>
-      <skos:inScheme rdf:resource="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes"/>
+         aggregate and organizes metadata on some record(s) or record set(s).</skos:definition>
+      <skos:inScheme
+         rdf:resource="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes"/>
    </owl:NamedIndividual>
    <!-- https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Collection -->
-   <owl:NamedIndividual rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Collection">
+   <owl:NamedIndividual
+      rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Collection">
       <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <rdf:type rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSetType"/>
       <rdfs:label xml:lang="en">collection</rdfs:label>
-      <skos:definition xml:lang="en">An artificial assemblage of documents accumulated on the
-            basis of some common characteristic without regard to the provenance of those documents.
-            Not to be confused with an archival fonds. (From ICA ISAD(G))</skos:definition>
+      <skos:definition xml:lang="en">An artificial assemblage of documents accumulated on the basis
+         of some common characteristic without regard to the provenance of those documents. Not to
+         be confused with an archival fonds. (From ICA ISAD(G))</skos:definition>
       <skos:inScheme rdf:resource="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes"/>
       <skos:prefLabel xml:lang="en">collection</skos:prefLabel>
    </owl:NamedIndividual>
    <!-- https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#File -->
-   <owl:NamedIndividual rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#File">
+   <owl:NamedIndividual
+      rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#File">
       <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <rdf:type rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSetType"/>
       <rdfs:label xml:lang="en">file</rdfs:label>
       <skos:definition xml:lang="en">An organized unit of documents grouped together either for
-            current use by the creator or in the process of archival arrangement, because they
-            relate to the same subject, activity, or transaction. A file is usually the basic unit
-            within a record series. (From ICA ISAD(G))</skos:definition>
+         current use by the creator or in the process of archival arrangement, because they relate
+         to the same subject, activity, or transaction. A file is usually the basic unit within a
+         record series. (From ICA ISAD(G))</skos:definition>
       <skos:inScheme rdf:resource="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes"/>
       <skos:prefLabel xml:lang="en">file</skos:prefLabel>
    </owl:NamedIndividual>
    <!-- https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Fonds -->
-   <owl:NamedIndividual rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Fonds">
+   <owl:NamedIndividual
+      rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Fonds">
       <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <rdf:type rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSetType"/>
       <rdfs:label xml:lang="en">fonds</rdfs:label>
       <skos:definition xml:lang="en">The whole of the records, regardless of form or medium,
-            organically created and/or accumulated and used by a particular person, family, or
-            corporate body in the course of that creator's activities and functions. (From ICA
-            ISAD(G))</skos:definition>
+         organically created and/or accumulated and used by a particular person, family, or
+         corporate body in the course of that creator's activities and functions. (From ICA
+         ISAD(G))</skos:definition>
       <skos:inScheme rdf:resource="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes"/>
       <skos:prefLabel xml:lang="en">fonds</skos:prefLabel>
    </owl:NamedIndividual>
    <!-- https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Series -->
-   <owl:NamedIndividual rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Series">
+   <owl:NamedIndividual
+      rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Series">
       <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <rdf:type rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSetType"/>
       <rdfs:label xml:lang="en">series</rdfs:label>
       <skos:definition xml:lang="en">Documents arranged in accordance with a filing system or
-            maintained as a unit because they result from the same accumulation or filing process,
-            or the same activity; have a particular form; or because of some other relationship
-            arising out of their creation, receipt, or use. A series is also known as a records
-            series. (From ICA ISAD(G))</skos:definition>
+         maintained as a unit because they result from the same accumulation or filing process, or
+         the same activity; have a particular form; or because of some other relationship arising
+         out of their creation, receipt, or use. A series is also known as a records series. (From
+         ICA ISAD(G))</skos:definition>
       <skos:inScheme rdf:resource="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes"/>
       <skos:prefLabel xml:lang="en">series</skos:prefLabel>
    </owl:NamedIndividual>
@@ -8668,10 +10250,11 @@
     //
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
-   <rdf:Description rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#RecordSetTypes">
+   <rdf:Description
+      rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#RecordSetTypes">
       <rdfs:label xml:lang="en">Record Set Types</rdfs:label>
       <rdfs:comment xml:lang="en">A SKOS vocabulary for categorizing archival record sets. Can be
-            used along with RiC-O ontology (the RiC-O RecordSetType class</rdfs:comment>
+         used along with RiC-O ontology (the RiC-O RecordSetType class</rdfs:comment>
       <skos:prefLabel xml:lang="en">Record Set Types</skos:prefLabel>
    </rdf:Description>
 </rdf:RDF>


### PR DESCRIPTION
As said in issue #8, updated the text definition and/or scope note of 33  classes (not 3 as said in the commit message), that correspond to RiC-CM entities or attributes, in order to make them  compliant with RiC-CM v0.2. Added a skos:changeNote to every updated class. 
In addition to this, I have added a few owl:disjointWith properties. Updated the owl:versionInfo and owl:historyNote annotation properties. Removed a few duplicated definitions of SKOS annotation properties.
Any other change only concerns line ends or the order of the properties in the specification of the components.
