### PR TITLE
Translate labels to spanish

### DIFF
--- a/ontology/current-version/RiC-O_v1-0.rdf
+++ b/ontology/current-version/RiC-O_v1-0.rdf
@@ -595,6 +595,7 @@
                   isPlaceAssociatedWithAgent, isBirthPlaceOf, isDeathPlaceOf,
                   isOrWasLocationOfAgent, and their inverse properties. Fixed a bug in the history
                   note of the ontology. Regenerated the inverse properties.</html:li>
+               <html:li>2023, November 2:  added Spanish labels to 59 datatype properties, 103 classes and 277 object properties.</html:li>
             </html:ul>
          </html:div>
       </skos:historyNote>
@@ -774,6 +775,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">activity is context of relation </rdfs:label>
       <rdfs:label xml:lang="fr">activité est le contexte de la relation</rdfs:label>
+      <rdfs:label xml:lang="es">actividad es contexto de relación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -791,6 +799,13 @@
          Relation</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">activity is source of performance relation</rdfs:label>
+      <rdfs:label xml:lang="es">actividad es fuente de relación funcional</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#activityIsTargetOfActivityDocumentationRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#activityIsTargetOfActivityDocumentationRelation">
@@ -814,6 +829,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">affecte ou a affecté</rdfs:label>
       <rdfs:label xml:lang="en">affects or affected</rdfs:label>
+      <rdfs:label xml:lang="es">afecta o afectaba a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -888,6 +910,13 @@
       <rdfs:comment xml:lang="en">Connects an Agent to a Work Relation</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">agent has work relation</rdfs:label>
+      <rdfs:label xml:lang="es">agente tiene relación profesional con</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource">
@@ -922,6 +951,13 @@
       <rdfs:comment xml:lang="en">Connects an Agent to an Agent Relation</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">agent is connected to agent relation</rdfs:label>
+      <rdfs:label xml:lang="es">agente está conectado a relación entre agentes</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation">
@@ -1199,6 +1235,13 @@
          Agents</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">agent relation connects</rdfs:label>
+      <rdfs:label xml:lang="es">relación entre agentes conecta a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource">
@@ -1275,6 +1318,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">as concerns activity </rdfs:label>
       <rdfs:label xml:lang="fr">en ce qui concerne l’activité</rdfs:label>
+      <rdfs:label xml:lang="es">en cuanto a actividad</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -1318,6 +1368,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">authorized by </rdfs:label>
       <rdfs:label xml:lang="fr">autorisé par</rdfs:label>
+      <rdfs:label xml:lang="es">controlado por</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -1342,6 +1399,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">authorizes</rdfs:label>
       <rdfs:label xml:lang="fr">autorise</rdfs:label>
+      <rdfs:label xml:lang="es">controla</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -1368,6 +1432,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">authorizing agent </rdfs:label>
       <rdfs:label xml:lang="fr">autorisation donnée par l’agent</rdfs:label>
+      <rdfs:label xml:lang="es">agente controlado por</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -1470,6 +1541,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">contains or contained</rdfs:label>
       <rdfs:label xml:lang="fr">contient ou a contenu</rdfs:label>
+      <rdfs:label xml:lang="es">contiene o contenía</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -1561,6 +1639,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">creation with role </rdfs:label>
       <rdfs:label xml:lang="fr">création avec pour rôle</rdfs:label>
+      <rdfs:label xml:lang="es">creación con el rol de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -1627,6 +1712,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">describes or described</rdfs:label>
       <rdfs:label xml:lang="fr">décrit ou a décrit</rdfs:label>
+      <rdfs:label xml:lang="es">describe o describía</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -1760,6 +1852,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">documented by</rdfs:label>
       <rdfs:label xml:lang="fr">est documenté par</rdfs:label>
+      <rdfs:label xml:lang="es">se documenta en </rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -1798,6 +1897,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">documente</rdfs:label>
       <rdfs:label xml:lang="en">documents</rdfs:label>
+      <rdfs:label xml:lang="es">documenta</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -1860,6 +1966,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">existe ou a existé dans</rdfs:label>
       <rdfs:label xml:lang="en">exists or existed in</rdfs:label>
+      <rdfs:label xml:lang="es">existe o existía en</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -1888,6 +2001,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">expresses or expressed</rdfs:label>
       <rdfs:label xml:lang="fr">exprime ou a exprimé</rdfs:label>
+      <rdfs:label xml:lang="es">expresa o expresaba</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -1914,6 +2034,13 @@
       <rdfs:comment xml:lang="en">Connects a Family Relation to a Person.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">family relation connects</rdfs:label>
+      <rdfs:label xml:lang="es">relación familiar conecta a </rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#followedInSequence -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#followedInSequence">
@@ -1980,6 +2107,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">follows in time</rdfs:label>
       <rdfs:label xml:lang="fr">suit dans le temps</rdfs:label>
+      <rdfs:label xml:lang="es">sigue en el tiempo a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -2015,6 +2149,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">follows or followed</rdfs:label>
       <rdfs:label xml:lang="fr">suit ou a suivi</rdfs:label>
+      <rdfs:label xml:lang="es">sigue o seguía a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -2042,6 +2183,13 @@
          functionally equivalent Instantiations.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">functional equivalence relation connects</rdfs:label>
+      <rdfs:label xml:lang="es">relación de equivalencia funcional conecta a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#groupIsSourceOfGroupSubdivisionRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfGroupSubdivisionRelation">
@@ -2284,6 +2432,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est accumulé par</rdfs:label>
       <rdfs:label xml:lang="en">has accumulator</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como acumulador a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -2312,6 +2467,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour type d’activité</rdfs:label>
       <rdfs:label xml:lang="en">has activity type</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como tipo de actividad a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -2343,6 +2505,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour destinataire</rdfs:label>
       <rdfs:label xml:lang="en">has addressee</rdfs:label>
+      <rdfs:label xml:lang="es">se dirige a </rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -2377,6 +2546,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour ancêtre</rdfs:label>
       <rdfs:label xml:lang="en">has ancestor</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como ancestro a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -2422,6 +2598,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour responsable intellectuel</rdfs:label>
       <rdfs:label xml:lang="en">has author</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como autor a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-12-29</dc:date>
@@ -2452,6 +2635,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour date de début</rdfs:label>
       <rdfs:label xml:lang="en">has beginning date </rdfs:label>
+      <rdfs:label xml:lang="es">tiene como fecha de inicio</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -2471,6 +2661,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour date de naissance</rdfs:label>
       <rdfs:label xml:lang="en">has birth date </rdfs:label>
+      <rdfs:label xml:lang="es">tiene como fecha de nacimiento</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -2512,6 +2709,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour type de support</rdfs:label>
       <rdfs:label xml:lang="en">has carrier type</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como tipo de soporte</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -2539,6 +2743,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour enfant</rdfs:label>
       <rdfs:label xml:lang="en">has child</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como hijo o hija a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -2572,6 +2783,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est collecté par</rdfs:label>
       <rdfs:label xml:lang="en">has collector</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como coleccionista a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -2669,6 +2887,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour type de contenu</rdfs:label>
       <rdfs:label xml:lang="en">has content of type</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como tipo de contenido</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -2694,6 +2919,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour copie</rdfs:label>
       <rdfs:label xml:lang="en">has copy </rdfs:label>
+      <rdfs:label xml:lang="es">tiene como copia</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -2747,6 +2979,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour créateur</rdfs:label>
       <rdfs:label xml:lang="en">has creator</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como creador a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -2799,6 +3038,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour date de décès</rdfs:label>
       <rdfs:label xml:lang="en">has death date </rdfs:label>
+      <rdfs:label xml:lang="es">tiene como fecha de muerte</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -2846,6 +3092,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour descendant</rdfs:label>
       <rdfs:label xml:lang="en">has descendant</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como descendiente a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -3055,6 +3308,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour type d’objet informtionnel</rdfs:label>
       <rdfs:label xml:lang="en">has documentary form type</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como tipo documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -3093,6 +3353,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour ébauche</rdfs:label>
       <rdfs:label xml:lang="en">has draft </rdfs:label>
+      <rdfs:label xml:lang="es">tiene como borrador</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -3112,6 +3379,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour date de fin</rdfs:label>
       <rdfs:label xml:lang="en">has end date </rdfs:label>
+      <rdfs:label xml:lang="es">tiene como fecha final</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -3132,6 +3406,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour type d’événement</rdfs:label>
       <rdfs:label xml:lang="en">has event type</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como tipo de evento</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -3156,6 +3437,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour mesure</rdfs:label>
       <rdfs:label xml:lang="en">has extent</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como extensión</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -3189,6 +3477,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour type de mesure</rdfs:label>
       <rdfs:label xml:lang="en">has extent type</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como tipo de extensión</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -3219,6 +3514,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a une relation familiale avec</rdfs:label>
       <rdfs:label xml:lang="en">has family association with</rdfs:label>
+      <rdfs:label xml:lang="es">tiene asociación familiar con</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -3247,6 +3549,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour type de famille</rdfs:label>
       <rdfs:label xml:lang="en">has family type</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como tipo de familia</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -3273,6 +3582,13 @@
       <rdfs:label xml:lang="fr">a une relation génétique avec la ressource
          archivistique</rdfs:label>
       <rdfs:label xml:lang="en">has genetic link to record resource </rdfs:label>
+      <rdfs:label xml:lang="es">tiene vínculo de origen con recurso documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -3296,6 +3612,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour type d’identifiant</rdfs:label>
       <rdfs:label xml:lang="en">has identifier type</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como tipo de identificador </rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-19</dc:date>
@@ -3327,6 +3650,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour date de modification</rdfs:label>
       <rdfs:label xml:lang="en">has modification date </rdfs:label>
+      <rdfs:label xml:lang="es">tiene como fecha de modificación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -3347,6 +3677,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour nom d’agent</rdfs:label>
       <rdfs:label xml:lang="en">has or had agent name</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como nombre de agente</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -3373,6 +3710,13 @@
       <rdfs:label xml:lang="en">has or had all members with category</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres ayant tous pour
          catégorie</rdfs:label>
+      <rdfs:label xml:lang="es">tienen o tenían todos sus miembros como categoría </rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-12-28</dc:date>
@@ -3401,6 +3745,13 @@
       <rdfs:label xml:lang="en">has or had all members with content type</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres ayant tous pour type de
          contenu</rdfs:label>
+      <rdfs:label xml:lang="es">tienen o tenían todos sus miembros como tipo de contenido</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -3462,6 +3813,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">has or had all members with documentary form type</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres ayant tous pour type</rdfs:label>
+      <rdfs:label xml:lang="es">tienen o tenían todos sus miembros como tipo documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-12-28</dc:date>
@@ -3489,6 +3847,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">has or had all members with language</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres ayant tous pour langue</rdfs:label>
+      <rdfs:label xml:lang="es">tienen o tenían todos sus miembros como lengua</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -3517,6 +3882,13 @@
       <rdfs:label xml:lang="en">has or had all members with legal status</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres ayant tous pour statut
          légal</rdfs:label>
+      <rdfs:label xml:lang="es">tienen o tenían todos sus miembros como status jurídico</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -3544,6 +3916,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">has or had all members with record state</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres ayant tous pour état</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenían todos sus miembros como estado de documento</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -3596,6 +3975,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour appellation</rdfs:label>
       <rdfs:label xml:lang="en">has or had appellation</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como denominación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -3625,6 +4011,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu autorité sur</rdfs:label>
       <rdfs:label xml:lang="en">has or had authority over</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía control sobre</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -3657,6 +4050,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour catégorie</rdfs:label>
       <rdfs:label xml:lang="en">has or had category</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como categoría</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -3683,6 +4083,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour composant</rdfs:label>
       <rdfs:label xml:lang="en">has or had component</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como componente</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -3726,6 +4133,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour constituant</rdfs:label>
       <rdfs:label xml:lang="en">has or had constituent</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como elemento constitutivo</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-10-19</dc:date>
@@ -3765,6 +4179,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a été contrôlé par</rdfs:label>
       <rdfs:label xml:lang="en">has or had controller</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como controlador</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -3793,6 +4214,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour coordonnées</rdfs:label>
       <rdfs:label xml:lang="en">has or had coordinates</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como coordenadas de lugar</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -3824,6 +4252,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour type de collectivité</rdfs:label>
       <rdfs:label xml:lang="en">has or had corporate body type</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como tipo de institucion</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -3854,6 +4289,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour correspondant</rdfs:label>
       <rdfs:label xml:lang="en">has or had correspondent</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como correspondiente</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -3889,6 +4331,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour catégorie démographique</rdfs:label>
       <rdfs:label xml:lang="en">has or had demographic group</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como categoría demográfica</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -4015,6 +4464,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été détenu par</rdfs:label>
       <rdfs:label xml:lang="en">has or had holder</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como conservador a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -4043,6 +4499,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour identifiant</rdfs:label>
       <rdfs:label xml:lang="en">has or had identifier</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como identificador</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -4131,6 +4594,13 @@
       <rdfs:label xml:lang="fr">a ou a détenu les droits de propriété intellectuelle
          sur</rdfs:label>
       <rdfs:label xml:lang="en">has or had intellectual property rights holder</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como titular de derechos de propiedad intelectual a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -4159,6 +4629,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour ressort</rdfs:label>
       <rdfs:label xml:lang="en">has or had jurisdiction</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como jurisdicción</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-10-19</dc:date>
@@ -4202,6 +4679,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour langue</rdfs:label>
       <rdfs:label xml:lang="en">has or had language</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como lengua</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -4237,6 +4721,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour dirigeant</rdfs:label>
       <rdfs:label xml:lang="en">has or had leader</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como líder a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -4273,6 +4764,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour statut légal</rdfs:label>
       <rdfs:label xml:lang="en">has or had legal status</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como status jurídico</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -4297,6 +4795,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour localisation</rdfs:label>
       <rdfs:label xml:lang="en">has or had location</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como localización </rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -4325,6 +4830,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour sujet principal</rdfs:label>
       <rdfs:label xml:lang="en">has or had main subject</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como matería principal</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -4366,6 +4878,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour gestionnaire</rdfs:label>
       <rdfs:label xml:lang="en">has or had manager</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como gestor a </rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -4398,6 +4917,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour membre</rdfs:label>
       <rdfs:label xml:lang="en">has or had member</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como miembro a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -4467,6 +4993,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour nom</rdfs:label>
       <rdfs:label xml:lang="en">has or had name</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como nombre</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -4493,6 +5026,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour type d’occupation</rdfs:label>
       <rdfs:label xml:lang="en">has or had occupation of type</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como tipo de ocupación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -4530,6 +5070,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour propriétaire</rdfs:label>
       <rdfs:label xml:lang="en">has or had owner</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como poseedor a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -4562,6 +5109,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour partie</rdfs:label>
       <rdfs:label xml:lang="en">has or had part</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como parte</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -4592,6 +5146,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour participant</rdfs:label>
       <rdfs:label xml:lang="en">has or had participant</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como participante</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -4620,6 +5181,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour localisation physique</rdfs:label>
       <rdfs:label xml:lang="en">has or had physical location</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como localización física</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-02-01</dc:date>
@@ -4653,6 +5221,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour nom de lieu</rdfs:label>
       <rdfs:label xml:lang="en">has or had place name</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como nombre de lugar</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -4679,6 +5254,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour type de lieu</rdfs:label>
       <rdfs:label xml:lang="en">has or had place type</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como tipo de lugar</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -4704,6 +5286,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">has or had position</rdfs:label>
       <rdfs:label xml:lang="fr">occupe ou a occupé le poste</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como puesto</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -4732,6 +5321,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour type de règle</rdfs:label>
       <rdfs:label xml:lang="en">has or had rule type</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como tipo de regla</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -4765,6 +5361,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">has or had some members with category</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres ayant pour type</rdfs:label>
+      <rdfs:label xml:lang="es">tienen o tenían algunos de sus miembros como categoría</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -4793,6 +5396,13 @@
       <rdfs:label xml:lang="en">has or had some members with content type</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres ayant pour type de
          contenu</rdfs:label>
+      <rdfs:label xml:lang="es">tienen o tenían algunos de sus miembros como tipo de contenido</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -4854,6 +5464,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">has or had some members with language</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres ayant pour langue</rdfs:label>
+      <rdfs:label xml:lang="es">tienen o tenían algunos de sus miembros como lengua</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-12-28</dc:date>
@@ -4881,6 +5498,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">has or had some members with legal status</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres ayant pour statut légal</rdfs:label>
+      <rdfs:label xml:lang="es">tienen o tenían algunos de sus miembros como status jurídico</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -4908,6 +5532,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">has or had some members with record state</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres ayant pour état</rdfs:label>
+      <rdfs:label xml:lang="es">tienen o tenía algunos de sus miembros como estado de documento</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-12-28</dc:date>
@@ -4937,6 +5568,13 @@
       <rdfs:label xml:lang="en">has or had some members with documentary form type</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres ayant pour type de
          document</rdfs:label>
+      <rdfs:label xml:lang="es">tienen o tenía algunos de sus miembros como tipo documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-12-28</dc:date>
@@ -4968,6 +5606,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour conjoint</rdfs:label>
       <rdfs:label xml:lang="en">has or had spouse</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como cónyuge a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -4999,6 +5644,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour étudiant</rdfs:label>
       <rdfs:label xml:lang="en">has or had student</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como estudiante a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -5032,6 +5684,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour subdivision</rdfs:label>
       <rdfs:label xml:lang="en">has or had subdivision</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como subdivisión</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -5062,6 +5721,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été constitué de l’événement</rdfs:label>
       <rdfs:label xml:lang="en">has or had subevent</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como parte de evento</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -5092,6 +5758,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour sujet</rdfs:label>
       <rdfs:label xml:lang="en">has or had subject</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como materia</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -5124,6 +5797,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour subalterne</rdfs:label>
       <rdfs:label xml:lang="en">has or had subordinate</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como subordinado o subordinada a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -5158,6 +5838,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour enseignant</rdfs:label>
       <rdfs:label xml:lang="en">has or had teacher</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como profesor(a) a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -5194,6 +5881,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour intitulé</rdfs:label>
       <rdfs:label xml:lang="en">has or had title</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como título</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -5220,6 +5914,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu une relation professionnelle avec</rdfs:label>
       <rdfs:label xml:lang="en">has or had work relation with</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía relación profesional con</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -5262,6 +5963,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour original</rdfs:label>
       <rdfs:label xml:lang="en">has original </rdfs:label>
+      <rdfs:label xml:lang="es">tiene como original</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -5305,6 +6013,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour type de technique de production</rdfs:label>
       <rdfs:label xml:lang="en">has production technique type</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como técnica de producción</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -5340,6 +6055,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour provenance</rdfs:label>
       <rdfs:label xml:lang="en">has provenance </rdfs:label>
+      <rdfs:label xml:lang="es">tiene como productor(a) a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -5383,6 +6105,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour éditeur</rdfs:label>
       <rdfs:label xml:lang="en">has publisher</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como editor(a) a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -5415,6 +6144,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est reçu par</rdfs:label>
       <rdfs:label xml:lang="en">has receiver</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como receptor(a) a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -5449,6 +6185,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour type d’ensemble d’objets informationnels</rdfs:label>
       <rdfs:label xml:lang="en">has record set type</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como tipo de agrupación documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -5480,6 +6223,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour état</rdfs:label>
       <rdfs:label xml:lang="en">has record state</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como estado de documento</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-12-28</dc:date>
@@ -5507,6 +6257,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour réponse</rdfs:label>
       <rdfs:label xml:lang="en">has reply</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como contestación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -5535,6 +6292,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour type de représentation</rdfs:label>
       <rdfs:label xml:lang="en">has representation type</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como tipo de grabación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -5566,6 +6330,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour expéditeur</rdfs:label>
       <rdfs:label xml:lang="en">has sender </rdfs:label>
+      <rdfs:label xml:lang="es">tiene como remitente a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -5590,6 +6361,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour frère ou sœur</rdfs:label>
       <rdfs:label xml:lang="en">has sibling</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como hermano o hermana a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -5631,6 +6409,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour source</rdfs:label>
       <rdfs:label xml:lang="en">has source </rdfs:label>
+      <rdfs:label xml:lang="es">tiene como fuente</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -5715,6 +6500,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour successeur</rdfs:label>
       <rdfs:label xml:lang="en">has successor</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como sucesor(a) a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -5745,6 +6537,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour unité de mesure</rdfs:label>
       <rdfs:label xml:lang="en">has unit of measurement</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como unidad de medida</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-28</dc:date>
@@ -5834,6 +6633,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">includes or included</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus</rdfs:label>
+      <rdfs:label xml:lang="es">incluye o incluía</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -5898,6 +6704,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">instantiation is connected to functional equivalence relation
       </rdfs:label>
+      <rdfs:label xml:lang="es">instanciación está conectada con relación de equivalencia funcional</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation">
@@ -5909,6 +6722,13 @@
          Relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">instantiation is connected to instantiation relation</rdfs:label>
+      <rdfs:label xml:lang="es">instanciación está conectada con relación de instanciación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation">
@@ -5980,6 +6800,13 @@
          related Instantiations.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">instantiation to instantiation relation connects</rdfs:label>
+      <rdfs:label xml:lang="es">relación entre instanciación conecta</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource">
@@ -6067,6 +6894,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">accumule</rdfs:label>
       <rdfs:label xml:lang="en">is accumulator of</rdfs:label>
+      <rdfs:label xml:lang="es">es acumulador(a) de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -6095,6 +6929,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est le type d’activité de</rdfs:label>
       <rdfs:label xml:lang="en">is activity type of</rdfs:label>
+      <rdfs:label xml:lang="es">es tipo de actividad de </rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -6125,6 +6966,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est le destinataire de</rdfs:label>
       <rdfs:label xml:lang="en">is addressee of </rdfs:label>
+      <rdfs:label xml:lang="es">es destino de </rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -6149,6 +6997,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est associé à l’agent</rdfs:label>
       <rdfs:label xml:lang="en">is agent associated with agent </rdfs:label>
+      <rdfs:label xml:lang="es">agente está asociado con agente</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -6195,6 +7050,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est associé à la date</rdfs:label>
       <rdfs:label xml:lang="en">is associated with date </rdfs:label>
+      <rdfs:label xml:lang="es">está asociado con fecha</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -6219,6 +7081,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est associé à l’événement</rdfs:label>
       <rdfs:label xml:lang="en">is associated with event </rdfs:label>
+      <rdfs:label xml:lang="es">está asociado con evento</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -6243,6 +7112,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est associé au lieu</rdfs:label>
       <rdfs:label xml:lang="en">is associated with place</rdfs:label>
+      <rdfs:label xml:lang="es">está asociado con lugar</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -6267,6 +7143,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est associé à la règle</rdfs:label>
       <rdfs:label xml:lang="en">is associated with rule </rdfs:label>
+      <rdfs:label xml:lang="es">está asociado con regla</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -6298,6 +7181,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est le responsable intellectuel de</rdfs:label>
       <rdfs:label xml:lang="en">is author of</rdfs:label>
+      <rdfs:label xml:lang="es">es autor(a) de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-12-29</dc:date>
@@ -6324,6 +7214,13 @@
          Relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">is authorizing agent in mandate relation</rdfs:label>
+      <rdfs:label xml:lang="es">es agente controlado por relación normativa</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isBeginningDateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf">
@@ -6336,6 +7233,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est la date de début de</rdfs:label>
       <rdfs:label xml:lang="en">is beginning date of </rdfs:label>
+      <rdfs:label xml:lang="es">es fecha de inicio de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -6356,6 +7260,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est la date de naissance de</rdfs:label>
       <rdfs:label xml:lang="en">is birth date of </rdfs:label>
+      <rdfs:label xml:lang="es">es fecha de nacimiento de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -6397,6 +7308,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est le type de support de</rdfs:label>
       <rdfs:label xml:lang="en">is carrier type of</rdfs:label>
+      <rdfs:label xml:lang="es">es tipo de soporte de </rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -6420,6 +7338,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est l’enfant de</rdfs:label>
       <rdfs:label xml:lang="en">is child of</rdfs:label>
+      <rdfs:label xml:lang="es">es hijo o hija de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -6454,6 +7379,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">collecte</rdfs:label>
       <rdfs:label xml:lang="en">is collector of</rdfs:label>
+      <rdfs:label xml:lang="es">es coleccionista de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -6570,6 +7502,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est le type de contenu de</rdfs:label>
       <rdfs:label xml:lang="en">is content type of</rdfs:label>
+      <rdfs:label xml:lang="es">es tipo de contenido de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -6594,6 +7533,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est la copie de</rdfs:label>
       <rdfs:label xml:lang="en">is copy of</rdfs:label>
+      <rdfs:label xml:lang="es">es copia de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -6662,6 +7608,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est le créateur de</rdfs:label>
       <rdfs:label xml:lang="en">is creator of</rdfs:label>
+      <rdfs:label xml:lang="es">es creador(a) de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -6688,6 +7641,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est une date associée a</rdfs:label>
       <rdfs:label xml:lang="en">is date associated with</rdfs:label>
+      <rdfs:label xml:lang="es">es fecha asociada con</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -6769,6 +7729,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est la date de décès de</rdfs:label>
       <rdfs:label xml:lang="en">is death date of </rdfs:label>
+      <rdfs:label xml:lang="es">es fecha de muerte de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7036,6 +8003,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est le type de document de</rdfs:label>
       <rdfs:label xml:lang="en">is documentary form type of</rdfs:label>
+      <rdfs:label xml:lang="es">es tipo documental de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -7074,6 +8048,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est l’ébauche de</rdfs:label>
       <rdfs:label xml:lang="en">is draft of </rdfs:label>
+      <rdfs:label xml:lang="es">es borrador de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7094,6 +8075,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est la date de fin de</rdfs:label>
       <rdfs:label xml:lang="en">is end date of </rdfs:label>
+      <rdfs:label xml:lang="es">es fecha final de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7113,6 +8101,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est l’équivalent de</rdfs:label>
       <rdfs:label xml:lang="en">is equivalent to </rdfs:label>
+      <rdfs:label xml:lang="es">equivale a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7135,6 +8130,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est un événement associé a</rdfs:label>
       <rdfs:label xml:lang="en">is event associated with </rdfs:label>
+      <rdfs:label xml:lang="es">es evento asociado con</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7155,6 +8157,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est le type d’événement de</rdfs:label>
       <rdfs:label xml:lang="en">is event type of</rdfs:label>
+      <rdfs:label xml:lang="es">es tipo de evento de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -7186,6 +8195,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est la mesure de</rdfs:label>
       <rdfs:label xml:lang="en">is extent of</rdfs:label>
+      <rdfs:label xml:lang="es">es extensión de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7219,6 +8235,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est le type de mesure de</rdfs:label>
       <rdfs:label xml:lang="en">is extent type of</rdfs:label>
+      <rdfs:label xml:lang="es">es tipo de extensión de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-11-21</dc:date>
@@ -7250,6 +8273,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est le type de famille de</rdfs:label>
       <rdfs:label xml:lang="en">is family type of</rdfs:label>
+      <rdfs:label xml:lang="es">es tipo de familia de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -7274,6 +8304,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est la date à partir de laquelle est utilisé</rdfs:label>
       <rdfs:label xml:lang="en">is from use date of </rdfs:label>
+      <rdfs:label xml:lang="es">es fecha desde la que se usa de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7303,6 +8340,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est fonctionnellement équivalente à</rdfs:label>
       <rdfs:label xml:lang="en">is functionally equivalent to</rdfs:label>
+      <rdfs:label xml:lang="es">equivale funcionalmente a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -7333,6 +8377,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est le type d’identifiant de</rdfs:label>
       <rdfs:label xml:lang="en">is identifier type of</rdfs:label>
+      <rdfs:label xml:lang="es">es tipo de identificador de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -7395,6 +8446,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est associée à l’instanciation</rdfs:label>
       <rdfs:label xml:lang="en">is instantiation associated with instantiation </rdfs:label>
+      <rdfs:label xml:lang="es">se asocia con la instanciación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7415,6 +8473,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est la date de dernière mise à jour de</rdfs:label>
       <rdfs:label xml:lang="en">is last update date of </rdfs:label>
+      <rdfs:label xml:lang="es">es fecha de última actualización de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7433,6 +8498,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est une date de modification de</rdfs:label>
       <rdfs:label xml:lang="en">is modification date of </rdfs:label>
+      <rdfs:label xml:lang="es">es fecha de modificación de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7454,6 +8526,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été adjacent à</rdfs:label>
       <rdfs:label xml:lang="en">is or was adjacent to</rdfs:label>
+      <rdfs:label xml:lang="es">es o era un lugar contiguo a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -7481,6 +8560,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été affecté par</rdfs:label>
       <rdfs:label xml:lang="en">is or was affected by</rdfs:label>
+      <rdfs:label xml:lang="es">es o era afectado por</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -7509,6 +8595,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été le nom de</rdfs:label>
       <rdfs:label xml:lang="en">is or was agent name of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era el nombre de agente de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7552,6 +8645,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été l’appellation de</rdfs:label>
       <rdfs:label xml:lang="en">is or was appellation of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era la denominación de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7581,6 +8681,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été la catégorie de</rdfs:label>
       <rdfs:label xml:lang="en">is or was category of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era la categoría de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7606,6 +8713,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été la catégorie de tous les membres de</rdfs:label>
       <rdfs:label xml:lang="en">is or was category of all members of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era la categoría de todos los miembros de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7633,6 +8747,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été la catégorie de certains membres de</rdfs:label>
       <rdfs:label xml:lang="en">is or was category of some members of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era la categoría de algunos miembros de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7660,6 +8781,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été un composant de</rdfs:label>
       <rdfs:label xml:lang="en">is or was component of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era componente de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7703,6 +8831,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été un constituant de</rdfs:label>
       <rdfs:label xml:lang="en">is or was constituent of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era elemento constitutivo de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-10-26</dc:date>
@@ -7738,6 +8873,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été contenu par</rdfs:label>
       <rdfs:label xml:lang="en">is or was contained by</rdfs:label>
+      <rdfs:label xml:lang="es">está o estaba contenido en</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -7766,6 +8908,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été le type de contenu de tous les membres de</rdfs:label>
       <rdfs:label xml:lang="en">is or was content type of all members of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era tipo de contenido de todos los miembros de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7793,6 +8942,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été le type de contenu de certains membres de</rdfs:label>
       <rdfs:label xml:lang="en">is or was content type of some members of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era tipo de contenido de algunos miembros de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7825,6 +8981,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a contrôlé ou contrôle</rdfs:label>
       <rdfs:label xml:lang="en">is or was controller of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era controlador de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -7853,6 +9016,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">is or was coordinates of</rdfs:label>
       <rdfs:label xml:lang="fr">ont ou ont été les coordonnées de</rdfs:label>
+      <rdfs:label xml:lang="es">son o eran coordenadas de lugar de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -7878,6 +9048,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été le type de collectivité de </rdfs:label>
       <rdfs:label xml:lang="en">is or was corporate body type of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era tipo de institución de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -8019,6 +9196,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été la catégorie démographique de</rdfs:label>
       <rdfs:label xml:lang="en">is or was demographic group of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era grupo demográfico de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -8075,6 +9259,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été décrit par</rdfs:label>
       <rdfs:label xml:lang="en">is or was described by</rdfs:label>
+      <rdfs:label xml:lang="es">es o fue descrito por</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -8127,6 +9318,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été le type de document de tous les membres de</rdfs:label>
       <rdfs:label xml:lang="en">is or was documentary form type of all members of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era tipo documental de todos los miembros de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-12-28</dc:date>
@@ -8154,6 +9352,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été le type de document de certains membres de</rdfs:label>
       <rdfs:label xml:lang="en">is or was documentary form type of some members of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era tipo documental de algunos miembros de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -8212,6 +9417,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été fait appliquer par</rdfs:label>
       <rdfs:label xml:lang="en">is or was enforced by</rdfs:label>
+      <rdfs:label xml:lang="es">es o era una regla aplicada por</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -8240,6 +9452,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été exprimé par</rdfs:label>
       <rdfs:label xml:lang="en">is or was expressed by</rdfs:label>
+      <rdfs:label xml:lang="es">es o era una regla expresada en</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -8279,6 +9498,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">détient ou a détenu</rdfs:label>
       <rdfs:label xml:lang="en">is or was holder of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era conservador de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -8327,6 +9553,13 @@
       <rdfs:label xml:lang="fr">détient ou a détenu les droits de propriété intellectuelle
          sur</rdfs:label>
       <rdfs:label xml:lang="en">is or was holder of intellectual property rights of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era conservador de derechos de propiedad intelectual de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -8355,6 +9588,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été l’identifiant de</rdfs:label>
       <rdfs:label xml:lang="en">is or was identifier of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era identificador de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -8388,6 +9628,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été inclus dans</rdfs:label>
       <rdfs:label xml:lang="en">is or was included in</rdfs:label>
+      <rdfs:label xml:lang="es">está o estaba incluido en</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -8464,6 +9711,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a été le ressort de</rdfs:label>
       <rdfs:label xml:lang="en">is or was jurisdiction of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era jurisdicción de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -8515,6 +9769,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été la langue de</rdfs:label>
       <rdfs:label xml:lang="en">is or was language of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era lengua de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -8540,6 +9801,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été la langue de tous les membres de</rdfs:label>
       <rdfs:label xml:lang="en">is or was language of all members of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era lengua de todos los miembros de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -8567,6 +9835,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été la langue de certains membres de</rdfs:label>
       <rdfs:label xml:lang="en">is or was language of some members of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era lengua de algunos miembros de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -8598,6 +9873,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été le dirigeant de </rdfs:label>
       <rdfs:label xml:lang="en">is or was leader of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era líder de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -8634,6 +9916,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été le statut légal de</rdfs:label>
       <rdfs:label xml:lang="en">is or was legal status of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era status jurídico de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -8662,6 +9951,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été le statut légal de tous les membres de</rdfs:label>
       <rdfs:label xml:lang="en">is or was legal status of all members of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era status jurídico de todos los miembros de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-12-28</dc:date>
@@ -8689,6 +9985,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été le statut légal de certains membres de</rdfs:label>
       <rdfs:label xml:lang="en">is or was legal status of some members of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era status jurídico de algunos miembros de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-12-28</dc:date>
@@ -8716,6 +10019,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été la localisation de</rdfs:label>
       <rdfs:label xml:lang="en">is or was location of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era localización de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -8768,6 +10078,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été le sujet principal de</rdfs:label>
       <rdfs:label xml:lang="en">is or was main subject of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era la materia principal de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -8807,6 +10124,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été le gestionnaire de</rdfs:label>
       <rdfs:label xml:lang="en">is or was manager of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era gestor de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -8838,6 +10162,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été membre de</rdfs:label>
       <rdfs:label xml:lang="en">is or was member of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era miembro de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -8866,6 +10197,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été le nom de</rdfs:label>
       <rdfs:label xml:lang="en">is or was name of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era nombre de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -8892,6 +10230,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été le type d’occupation de</rdfs:label>
       <rdfs:label xml:lang="en">is or was occupation type of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era tipo de ocupación de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -8921,6 +10266,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été occupé par</rdfs:label>
       <rdfs:label xml:lang="en">is or was occupied by</rdfs:label>
+      <rdfs:label xml:lang="es">está o estaba ocupado por</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -8961,6 +10313,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été propriétaire de</rdfs:label>
       <rdfs:label xml:lang="en">is or was owner of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era poseedor(a) de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -8992,6 +10351,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été une partie de</rdfs:label>
       <rdfs:label xml:lang="en">is or was part of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era parte de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9020,6 +10386,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">is or was participant in</rdfs:label>
       <rdfs:label xml:lang="fr">participe ou a participé à</rdfs:label>
+      <rdfs:label xml:lang="es">es o era participante de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9052,6 +10425,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été réalisée par</rdfs:label>
       <rdfs:label xml:lang="en">is or was performed by</rdfs:label>
+      <rdfs:label xml:lang="es">es o fue desarrollado por</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9080,6 +10460,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a été la localisation physique de</rdfs:label>
       <rdfs:label xml:lang="en">is or was physical location of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era localización física de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9113,6 +10500,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a été le nom de lieu de</rdfs:label>
       <rdfs:label xml:lang="en">is or was place name of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era nombre de lugar de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9139,6 +10533,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a été le type de lieu de</rdfs:label>
       <rdfs:label xml:lang="en">is or was place type of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era tipo de lugar de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9165,6 +10566,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a été l’état de tous les membres de</rdfs:label>
       <rdfs:label xml:lang="en">is or was record state of all members of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era estado de documento de todos los miembros de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9192,6 +10600,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a été l’état de certains membres de</rdfs:label>
       <rdfs:label xml:lang="en">is or was record state of some members of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era estado de documento de algunos miembros de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9219,6 +10634,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été régulé par</rdfs:label>
       <rdfs:label xml:lang="en">is or was regulated by</rdfs:label>
+      <rdfs:label xml:lang="es">está o estaba regulado por</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9246,6 +10668,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a fait ou fait appliquer </rdfs:label>
       <rdfs:label xml:lang="en">is or was responsible for enforcing</rdfs:label>
+      <rdfs:label xml:lang="es">es o era responsable de aplicar</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9275,6 +10704,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été le type de règle de</rdfs:label>
       <rdfs:label xml:lang="en">is or was rule type of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era tipo de regla de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-19</dc:date>
@@ -9313,6 +10749,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été une subdivision de </rdfs:label>
       <rdfs:label xml:lang="en">is or was subdivision of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era subdivisión de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -9342,6 +10785,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été un événement constituant de</rdfs:label>
       <rdfs:label xml:lang="en">is or was subevent of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era parte de evento de </rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -9369,6 +10819,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été le sujet de</rdfs:label>
       <rdfs:label xml:lang="en">is or was subject of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era materia de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9401,6 +10858,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été le subalterne de</rdfs:label>
       <rdfs:label xml:lang="en">is or was subordinate to</rdfs:label>
+      <rdfs:label xml:lang="es">está o estaba subordinado(a) a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -9437,6 +10901,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été l’intitulé de</rdfs:label>
       <rdfs:label xml:lang="en">is or was title of</rdfs:label>
+      <rdfs:label xml:lang="es">es o era título de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9467,6 +10938,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été sous l’autorité de</rdfs:label>
       <rdfs:label xml:lang="en">is or was under authority of</rdfs:label>
+      <rdfs:label xml:lang="es">está o estaba bajo control de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9510,6 +10988,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est l’original de</rdfs:label>
       <rdfs:label xml:lang="en">is original of </rdfs:label>
+      <rdfs:label xml:lang="es">es original de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9559,6 +11044,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est un lieu associé à </rdfs:label>
       <rdfs:label xml:lang="en">is place associated with </rdfs:label>
+      <rdfs:label xml:lang="es">es lugar asociado con</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9603,6 +11095,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est le type de technique de production de</rdfs:label>
       <rdfs:label xml:lang="en">is production technique type of</rdfs:label>
+      <rdfs:label xml:lang="es">es tipo de técnica de producción de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9637,6 +11136,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est la provenance de</rdfs:label>
       <rdfs:label xml:lang="en">is provenance of </rdfs:label>
+      <rdfs:label xml:lang="es">es producto de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9681,6 +11187,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est l’éditeur de</rdfs:label>
       <rdfs:label xml:lang="en">is publisher of</rdfs:label>
+      <rdfs:label xml:lang="es">es editor(a) de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -9712,6 +11225,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">is receiver of</rdfs:label>
       <rdfs:label xml:lang="fr">reçoit</rdfs:label>
+      <rdfs:label xml:lang="es">es receptor(a) de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9744,6 +11264,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est associée avec la ressource archivistique</rdfs:label>
       <rdfs:label xml:lang="en">is record resource associated with record resource </rdfs:label>
+      <rdfs:label xml:lang="es">es recurso documental asociado con</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9764,6 +11291,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est le type d’ensemble d’objets informationnels de</rdfs:label>
       <rdfs:label xml:lang="en">is record set type of</rdfs:label>
+      <rdfs:label xml:lang="es">es tipo de agrupación documental de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -9795,6 +11329,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est l’état de</rdfs:label>
       <rdfs:label xml:lang="en">is record state of</rdfs:label>
+      <rdfs:label xml:lang="es">es estado de documento de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-12-28</dc:date>
@@ -9819,6 +11360,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est relié à</rdfs:label>
       <rdfs:label xml:lang="en">is related to </rdfs:label>
+      <rdfs:label xml:lang="es">está relacionado con</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9839,6 +11387,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est une réponse à</rdfs:label>
       <rdfs:label xml:lang="en">is reply to</rdfs:label>
+      <rdfs:label xml:lang="es">es contestación de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -9867,6 +11422,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est le type de représentation de</rdfs:label>
       <rdfs:label xml:lang="en">is representation type of</rdfs:label>
+      <rdfs:label xml:lang="es">es tipo de grabación de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9890,6 +11452,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est chargé de rendre publique</rdfs:label>
       <rdfs:label xml:lang="en">is responsible for issuing </rdfs:label>
+      <rdfs:label xml:lang="es">es responsable de emisión de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9914,6 +11483,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est une règle associée à</rdfs:label>
       <rdfs:label xml:lang="en">is rule associated with </rdfs:label>
+      <rdfs:label xml:lang="es">es regla asociada con</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9940,6 +11516,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est l’expéditeur de</rdfs:label>
       <rdfs:label xml:lang="en">is sender of </rdfs:label>
+      <rdfs:label xml:lang="es">es remitente de </rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -9975,6 +11558,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est la source de</rdfs:label>
       <rdfs:label xml:lang="en">is source of </rdfs:label>
+      <rdfs:label xml:lang="es">es fuente de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -10057,6 +11647,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est le successeur de</rdfs:label>
       <rdfs:label xml:lang="en">is successor of</rdfs:label>
+      <rdfs:label xml:lang="es">es sucesor(a) de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -10084,6 +11681,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est la date jusqu’à laquelle est utilisé</rdfs:label>
       <rdfs:label xml:lang="en">is to use date of </rdfs:label>
+      <rdfs:label xml:lang="es">es fecha hasta la que se usa</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-10-19</dc:date>
@@ -10108,6 +11712,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est l’unité de mesure de</rdfs:label>
       <rdfs:label xml:lang="en">is unit of measurement of</rdfs:label>
+      <rdfs:label xml:lang="es">es unidad de medida de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -10162,6 +11773,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">issued by </rdfs:label>
       <rdfs:label xml:lang="fr">rendue publique par</rdfs:label>
+      <rdfs:label xml:lang="es">emitido por</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -10205,6 +11823,13 @@
          involved.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">knowing relation connects</rdfs:label>
+      <rdfs:label xml:lang="es">relación de conocimiento directo entre personas conecta a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#knownBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#knownBy">
@@ -10220,6 +11845,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est connue par</rdfs:label>
       <rdfs:label xml:lang="en">known by </rdfs:label>
+      <rdfs:label xml:lang="es">conocido por</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -10244,6 +11876,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">connaît</rdfs:label>
       <rdfs:label xml:lang="en">knows </rdfs:label>
+      <rdfs:label xml:lang="es">conoce a </rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -10268,6 +11907,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a connaissance de la personne</rdfs:label>
       <rdfs:label xml:lang="en">knows of </rdfs:label>
+      <rdfs:label xml:lang="es">conoce indirectamente a </rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -10309,6 +11955,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">leadership with position </rdfs:label>
       <rdfs:label xml:lang="fr">relation de direction dans le cadre du poste</rdfs:label>
+      <rdfs:label xml:lang="es">liderazgo en puesto</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -10411,6 +12064,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">membership with position </rdfs:label>
       <rdfs:label xml:lang="fr">relation d’appartenance dans le cadre du poste</rdfs:label>
+      <rdfs:label xml:lang="es">membresía en puesto</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -10432,6 +12092,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a été produite par migration de</rdfs:label>
       <rdfs:label xml:lang="en">migrated from</rdfs:label>
+      <rdfs:label xml:lang="es">migrado desde</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -10472,6 +12139,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a été migrée vers</rdfs:label>
       <rdfs:label xml:lang="en">migrated into</rdfs:label>
+      <rdfs:label xml:lang="es">migrado a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -10534,6 +12208,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">occupe ou a occupé</rdfs:label>
       <rdfs:label xml:lang="en">occupies or occupied</rdfs:label>
+      <rdfs:label xml:lang="es">ocupa u ocupaba</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -10592,6 +12273,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">chevauche ou a chevauché</rdfs:label>
       <rdfs:label xml:lang="en">overlaps or overlapped</rdfs:label>
+      <rdfs:label xml:lang="es">se superpone o superponía con</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -10676,6 +12364,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">exerce ou a exercé</rdfs:label>
       <rdfs:label xml:lang="en">performs or performed</rdfs:label>
+      <rdfs:label xml:lang="es">desarrolla o desarrollaba</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -10702,6 +12397,13 @@
       <rdfs:comment xml:lang="en">Connects a Person to a Correspondence Relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">person has correspondence relation</rdfs:label>
+      <rdfs:label xml:lang="es">persona tiene como relación entre personas por correspondencia</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation">
@@ -10712,6 +12414,13 @@
       <rdfs:comment xml:lang="en">Connects a Person to a Family Relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">person has family relation</rdfs:label>
+      <rdfs:label xml:lang="es">persona tiene como relación familiar</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation">
@@ -10722,6 +12431,13 @@
       <rdfs:comment xml:lang="en">Connects a Person to a Knowing Relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">person has knowing relation</rdfs:label>
+      <rdfs:label xml:lang="es">persona tiene como relacion de conocimiento directo entre personas</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personHasSiblingRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSiblingRelation">
@@ -10732,6 +12448,13 @@
       <rdfs:comment xml:lang="en">Connects a Person to a Sibling Relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">person has sibling relation</rdfs:label>
+      <rdfs:label xml:lang="es">persona tiene como relación familiar entre hermanos</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personHasSpouseRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSpouseRelation">
@@ -10742,6 +12465,13 @@
       <rdfs:comment xml:lang="en">Connects a Person to a Spouse Relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">person has spouse relation</rdfs:label>
+      <rdfs:label xml:lang="es">persona tiene como relación matrimonial entre personas</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsSourceOfChildRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfChildRelation">
@@ -10937,6 +12667,13 @@
          occupies that Position).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">position is context of leadership relation</rdfs:label>
+      <rdfs:label xml:lang="es">puesto es contexto de relación de liderazgo</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionIsContextOfMembershipRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsContextOfMembershipRelation">
@@ -10948,6 +12685,13 @@
          occupies that Position).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">position is context of membership relation</rdfs:label>
+      <rdfs:label xml:lang="es">puesto es contexto de relación de membresía</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionIsSourceOfPositionToGroupRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsSourceOfPositionToGroupRelation">
@@ -11064,6 +12808,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">precedes in time</rdfs:label>
       <rdfs:label xml:lang="fr">précède dans le temps</rdfs:label>
+      <rdfs:label xml:lang="es">precede en el tiempo a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -11103,6 +12854,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">precedes or preceded</rdfs:label>
       <rdfs:label xml:lang="fr">précède ou a précédé</rdfs:label>
+      <rdfs:label xml:lang="es">precede o precedía secuencialmente a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -11171,6 +12929,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy for </rdfs:label>
       <rdfs:label xml:lang="fr">proxy pour</rdfs:label>
+      <rdfs:label xml:lang="es">es proxy para</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -11188,6 +12953,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">proxy dans</rdfs:label>
       <rdfs:label xml:lang="en">proxy in </rdfs:label>
+      <rdfs:label xml:lang="es">es proxy en</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -11222,6 +12994,13 @@
          associated Record Resources.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">record resource genetic relation connects</rdfs:label>
+      <rdfs:label xml:lang="es">relación genética entre recursos documentales conecta</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource">
@@ -11263,6 +13042,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">record resource is connected to record resource genetic relation
       </rdfs:label>
+      <rdfs:label xml:lang="es">recurso documental está conectado con relación genético entre recursos documentales</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation">
@@ -11275,6 +13061,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">record resource is connected to record resource relation
       </rdfs:label>
+      <rdfs:label xml:lang="es">recurso documental está conectado con relación de recurso documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceIsSourceOfRecordResourceToInstantiationRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsSourceOfRecordResourceToInstantiationRelation">
@@ -11451,6 +13244,13 @@
          Resources.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">record resource relation connects</rdfs:label>
+      <rdfs:label xml:lang="es">relación de recurso documental conecta</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource">
@@ -11485,6 +13285,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">regulates or regulated</rdfs:label>
       <rdfs:label xml:lang="fr">régule ou a régulé</rdfs:label>
+      <rdfs:label xml:lang="es">regula o regulaba</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -11513,6 +13320,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">relation connecte</rdfs:label>
       <rdfs:label xml:lang="en">relation connects </rdfs:label>
+      <rdfs:label xml:lang="es">relación conecta</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -11531,6 +13345,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">relation a pour contexte</rdfs:label>
       <rdfs:label xml:lang="en">relation has context </rdfs:label>
+      <rdfs:label xml:lang="es">relación tiene como contexto</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -11551,6 +13372,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">relation a pour source</rdfs:label>
       <rdfs:label xml:lang="en">relation has source </rdfs:label>
+      <rdfs:label xml:lang="es">relación tiene como fuente</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -11569,6 +13397,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">relation a pour cible</rdfs:label>
       <rdfs:label xml:lang="en">relation has target </rdfs:label>
+      <rdfs:label xml:lang="es">relación tiene como objetivo</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -11585,6 +13420,13 @@
       <rdfs:comment xml:lang="en">inverse of 'was merged into' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">resulted from the merger of</rdfs:label>
+      <rdfs:label xml:lang="es">resultado de la fusión de </rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-06-21</dc:date>
@@ -11602,6 +13444,13 @@
       <rdfs:comment xml:lang="en">Inverse of 'was split into' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">resulted from the split of</rdfs:label>
+      <rdfs:label xml:lang="es">resultado de la separación de</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date xml:lang="en">2023-06-21</dc:date>
@@ -11622,6 +13471,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">results or resulted from</rdfs:label>
       <rdfs:label xml:lang="fr">résulte ou a résulté de</rdfs:label>
+      <rdfs:label xml:lang="es">resulta o resultaba</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -11650,6 +13506,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a ou a eu pour résultat</rdfs:label>
       <rdfs:label xml:lang="en">results or resulted in</rdfs:label>
+      <rdfs:label xml:lang="es">tiene o tenía como resultado a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -11679,6 +13542,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">role is context of creation relation </rdfs:label>
       <rdfs:label xml:lang="fr">rôle est le contexte de la relation de création</rdfs:label>
+      <rdfs:label xml:lang="es">rol es contexto de relación de creación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -11749,6 +13619,13 @@
          involved.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">sibling relation connects</rdfs:label>
+      <rdfs:label xml:lang="es">relación familiar entre hermanos conecta</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#spouseRelationConnects -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#spouseRelationConnects">
@@ -11760,6 +13637,13 @@
          involved.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">spouse relation connects</rdfs:label>
+      <rdfs:label xml:lang="es">relación matrimonial entre personas conecta</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource">
@@ -11816,6 +13700,13 @@
       <rdfs:comment xml:lang="en">Connects a Thing to a n-ary Relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">thing is connected to relation</rdfs:label>
+      <rdfs:label xml:lang="es">cosa está conectada con relación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation">
@@ -11827,6 +13718,13 @@
          the existence of the Relation) to a n-ary Relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">thing is context of relation</rdfs:label>
+      <rdfs:label xml:lang="es">cosa es contexto de relación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation">
@@ -12141,6 +14039,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour date de dernière mise à jour</rdfs:label>
       <rdfs:label xml:lang="en">was last updated at date </rdfs:label>
+      <rdfs:label xml:lang="es">fue actualizado por última vez en fecha</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -12159,6 +14064,13 @@
          bodies.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">was merged into</rdfs:label>
+      <rdfs:label xml:lang="es">se fusionó en </rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-06-21</dc:date>
@@ -12196,6 +14108,13 @@
          bodies.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">was split into</rdfs:label>
+      <rdfs:label xml:lang="es">se separó en</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-06-21</dc:date>
@@ -12274,6 +14193,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a été utilisé à partir de la date</rdfs:label>
       <rdfs:label xml:lang="en">was used from date </rdfs:label>
+      <rdfs:label xml:lang="es">fue usado desde</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -12298,6 +14224,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a été utilisé jusqu’à la date</rdfs:label>
       <rdfs:label xml:lang="en">was used to date </rdfs:label>
+      <rdfs:label xml:lang="es">fue usado hasta</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-10-19</dc:date>
@@ -12342,6 +14275,13 @@
       <rdfs:comment xml:lang="en">Connects a Work Relation to an Agent.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">work relation connects</rdfs:label>
+      <rdfs:label xml:lang="es">relación profesional conecta</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////

--- a/ontology/current-version/RiC-O_v1-0.rdf
+++ b/ontology/current-version/RiC-O_v1-0.rdf
@@ -1,17 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns="https://www.ica.org/standards/RiC/ontology#"
-   xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:dcterms="http://purl.org/dc/terms/" xmlns:html="http://www.w3.org/1999/xhtml"
-   xmlns:owl="http://www.w3.org/2002/07/owl#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-   xmlns:ric-dft="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes#"
-   xmlns:ric-rst="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#"
-   xmlns:rico="https://www.ica.org/standards/RiC/ontology#"
-   xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:vann="http://purl.org/vocab/vann/"
-   xmlns:voaf="http://purl.org/vocommons/voaf#" xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
-   xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-   xml:base="https://www.ica.org/standards/RiC/ontology">
+         xmlns:cc="http://creativecommons.org/ns#"
+         xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:dcterms="http://purl.org/dc/terms/"
+         xmlns:html="http://www.w3.org/1999/xhtml"
+         xmlns:owl="http://www.w3.org/2002/07/owl#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:ric-dft="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes#"
+         xmlns:ric-rst="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#"
+         xmlns:rico="https://www.ica.org/standards/RiC/ontology#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:vann="http://purl.org/vocab/vann/"
+         xmlns:voaf="http://purl.org/vocommons/voaf#"
+         xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
+         xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+         xml:base="https://www.ica.org/standards/RiC/ontology">
    <owl:Ontology rdf:about="https://www.ica.org/standards/RiC/ontology">
       <cc:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
       <dc:contributor xml:lang="en">Aaron Rubinstein (University of Massachusetts Amherst, USA),
@@ -40,8 +44,7 @@
                representation of Records in Contexts Conceptual Model (RiC-CM). </html:p>
             <html:p>The current official version is <html:strong>v0.2</html:strong>; it is compliant
                with RiC-CM v0.2 full draft, that will be published in February or March 2021, and
-               that is slightly different from <html:a
-                  href="https://www.ica.org/sites/default/files/ric-cm-0.2_preview.pdf">RiC-CM v0.2
+               that is slightly different from <html:a href="https://www.ica.org/sites/default/files/ric-cm-0.2_preview.pdf">RiC-CM v0.2
                   preview</html:a>, that was published in December 2019.</html:p>
             <html:p>RiC-O provides a generic vocabulary and formal rules for creating RDF datasets
                (or generating them from existing archival metadata) that describe in a consistent
@@ -61,9 +64,9 @@
                is v0.2, is the current official release. It is compliant with RiC-CM v0.2, that will
                be published soon after the release of RiC-O v0.2.</html:p>
             <html:p>The following diagram shows the main RiC-CM v0.2 entities and a few relations
-               between them: <html:img
-                  src="https://raw.githubusercontent.com/ICA-EGAD/RiC-O/master/diagrams/diagrams_v0-2/RiC-CM-overview/diagram_RiC-CM-overview-RiC-v0-2.jpg"
-                  alt="A partial overview of RiC-CM v0.2 main entities" class="diagram"/>
+               between them: <html:img src="https://raw.githubusercontent.com/ICA-EGAD/RiC-O/master/diagrams/diagrams_v0-2/RiC-CM-overview/diagram_RiC-CM-overview-RiC-v0-2.jpg"
+                         alt="A partial overview of RiC-CM v0.2 main entities"
+                         class="diagram"/>
             </html:p>
             <html:div id="design-principles">
                <html:h4>RiC-O design principles</html:h4>
@@ -184,19 +187,14 @@
                      classes address special needs:</html:p>
                   <html:ul>
                      <html:li>some correspond to RiC-CM attributes, when it may be considered
-                        necessary to handle them as full entities. This is the case for <html:a
-                           href="#rico:Type">Type</html:a> and its subclasses, that correspond to
+                        necessary to handle them as full entities. This is the case for <html:a href="#rico:Type">Type</html:a> and its subclasses, that correspond to
                         RiC-CM attributes that contain controlled values, and that can help to
                         articulate RiC-O with external RDF resources like SKOS vocabularies; and
-                        also for <html:a href="#rico:Language">Language</html:a>, <html:a
-                           href="#rico:Name">Name</html:a> and <html:a href="#rico:Identifier"
-                           >Identifier</html:a>, that can be considered as full entities and as key
+                        also for <html:a href="#rico:Language">Language</html:a>, <html:a href="#rico:Name">Name</html:a> and <html:a href="#rico:Identifier">Identifier</html:a>, that can be considered as full entities and as key
                         linking nodes in a RDF graph. All these classes have been grouped under a
                            <html:a href="#rico:Concept">Concept</html:a> class. </html:li>
                      <html:li>some classes have been added in order to provide a more accurate
-                        definition and model for some entities. <html:a href="#rico:Place"
-                           >Place</html:a> thus comes along with a <html:a
-                           href="#rico:PhysicalLocation">Physical Location class</html:a>, and with
+                        definition and model for some entities. <html:a href="#rico:Place">Place</html:a> thus comes along with a <html:a href="#rico:PhysicalLocation">Physical Location class</html:a>, and with
                         a <html:a href="#rico:Coordinates">Coordinates class</html:a>. A Place is
                         considered both a geographical and historical entity. As a historical
                         entity, among other features, it has a history, and may be preceded or
@@ -204,34 +202,27 @@
                         Location through time (for instance, its boundaries, if it is an
                         administrative area or a country, may change). Each Physical Location may be
                         connected to zero to many Coordinates. This model is quite close to the
-                        Linked Places Format (<html:a
-                           href="https://github.com/LinkedPasts/linked-places"
-                           >https://github.com/LinkedPasts/linked-places</html:a>). Another example
+                        Linked Places Format (<html:a href="https://github.com/LinkedPasts/linked-places">https://github.com/LinkedPasts/linked-places</html:a>). Another example
                         of such an addition is the <html:a href="#rico:Proxy">Proxy class</html:a>,
                         that represents (stands for) a Record Resource as it exists in a specific
                         Record Set.</html:li>
                      <html:li>Finally, a system of classes helps to implement the Relations section
                         of RiC-CM.<html:br/> While these relations also are represented as simple,
-                        binary object properties (e.g. <html:a href="#rico:hasProvenance"
-                           >‘hasProvenance’</html:a> that corresponds to RiC-R026 relation), you may
+                        binary object properties (e.g. <html:a href="#rico:hasProvenance">‘hasProvenance’</html:a> that corresponds to RiC-R026 relation), you may
                         need to assign different attributes to a relation, e.g. a date, certainty or
                         description, as it is already possible, and quite often done, in a
                         XML/EAC-CPF file. One of the standard available methods for representing
                         such a documented relation in RDF for now is to use a class. RDF* and
                         SPARQL* specification, which is being developed by the W3C RDF-DEV Community
                         Group, provides a far simpler method (allowing to consider a triple as the
-                        subject or object of another triple; see <html:a
-                           href="https://w3c.github.io/rdf-star/"
-                           >https://w3c.github.io/rdf-star/</html:a>) and is already being used by
+                        subject or object of another triple; see <html:a href="https://w3c.github.io/rdf-star/">https://w3c.github.io/rdf-star/</html:a>) and is already being used by
                         some tools; however it is not yet a W3C standard. Thus, for example, in
-                        RiC-O an <html:a href="#rico:AgentOriginationRelation"
-                           >AgentOriginationRelation class</html:a> exists. This class may connect
+                        RiC-O an <html:a href="#rico:AgentOriginationRelation">AgentOriginationRelation class</html:a> exists. This class may connect
                         one to many Agents to one to many created or accumulated Record Resources or
                         Instantiations, and has some specific object properties (certainty, date,
                         description, source). Back to the ‘hasProvenance’ object property, let us
                         add that it is formally defined in RiC-O, using OWL 2 property chain axiom
-                        (see <html:a href="https://www.w3.org/TR/owl2-new-features/"
-                           >https://www.w3.org/TR/owl2-new-features/</html:a>, as a ‘shortcut’ for
+                        (see <html:a href="https://www.w3.org/TR/owl2-new-features/">https://www.w3.org/TR/owl2-new-features/</html:a>, as a ‘shortcut’ for
                         the longer path
                         ‘recordResourceOrInstantiationIsSourceOfAgentOriginationRelation/agentOriginationRelationHasTarget’,
                         where the intermediate node is an instance of Agent Origination Relation:<html:br/>
@@ -246,20 +237,15 @@
                   </html:ul>
                   <html:p>Most of the <html:strong>datatype properties in RiC-O
                      </html:strong>correspond to RiC-CM attributes that contain free, plain text.
-                     See for example <html:a href="#rico:descriptiveNote"
-                        >rico:descriptiveNote</html:a>, <html:a href="#rico:history"
-                        >rico:history</html:a> and <html:a href="#scopeAndContent"
-                        >rico:scopeAndContent</html:a>.</html:p>
+                     See for example <html:a href="#rico:descriptiveNote">rico:descriptiveNote</html:a>, <html:a href="#rico:history">rico:history</html:a> and <html:a href="#scopeAndContent">rico:scopeAndContent</html:a>.</html:p>
                   <html:p>In addition to these datatype properties, the Name and Identifier RiC-CM
-                     attributes also have corresponding classes (subclasses of <html:a
-                        href="#rico:Appellation">rico:Appellation</html:a>). A resource may have
+                     attributes also have corresponding classes (subclasses of <html:a href="#rico:Appellation">rico:Appellation</html:a>). A resource may have
                      several Identifiers and each comes with different attributes (e.g. archival
                      reference code, system number, digital object identifier), in this case the
                      identifiers will be modelled in a class. In many simpler usecases it's
                      sufficent to just use the <html:a href="#rico:identifier">identifier datatype
                         property</html:a>, typically for the archival reference code.</html:p>
-                  <html:p>The Location RiC-CM attribute also has a <html:a
-                        href="#rico:PhysicalLocation">rico:Physical Location corresponding
+                  <html:p>The Location RiC-CM attribute also has a <html:a href="#rico:PhysicalLocation">rico:Physical Location corresponding
                         class</html:a> (for users who want to use Place, Physical Location and
                      Coordinates for handling places).</html:p>
                   <html:p>As already said too, every RiC-CM attribute that has ‘controlled value’ or
@@ -276,13 +262,11 @@
                      while consider these carrier types as full entities. Nevertheless you want to
                      produce RiC-O datasets where every piece of information is kept, and you want
                      to avoid blank nodes. If RiC-O would only provide the Carrier Type class, it
-                     would be an issue for you. So RiC-O provides a <html:a href="#rico:type"
-                        >rico:type datatype property</html:a>, with range rdfs:literal, which allows
+                     would be an issue for you. So RiC-O provides a <html:a href="#rico:type">rico:type datatype property</html:a>, with range rdfs:literal, which allows
                      you to move forward.</html:p>
                   <html:p>Therefore, for the RiC-CM *Type attributes, you have a corresponding
                         <html:a href="#rico:type">rico:type datatype property</html:a>. For RiC-CM
-                     Coordinates attribute, you also have <html:a
-                        href="#rico:geographicalCoordinates">rico:geographicalCoordinates datatype
+                     Coordinates attribute, you also have <html:a href="#rico:geographicalCoordinates">rico:geographicalCoordinates datatype
                         property</html:a>.</html:p>
                   <html:p>These datatype properties have a skos:scopeNote which says (for example)
                      "Provided for usability reasons. May be made deprecated or removed later on.
@@ -294,10 +278,8 @@
                      Thus, there of course is Date and Rule classes in RiC-O (since there are Date
                      and Rule entities in RiC-CM). And you also have 'date' datatype properties;
                      plus a <html:a href="#rico:ruleFollowed">rico:ruleFollowed datatype
-                        property</html:a>. The same analysis led us to keep the <html:a
-                        href="#rico:history">rico:history</html:a> datatype property in RiC-O (same
-                     as RiC-CM history attribute), while RiC-CM and RiC-O also provide the <html:a
-                        href="#rico:Event">Event class</html:a>, and using a series of Events may of
+                        property</html:a>. The same analysis led us to keep the <html:a href="#rico:history">rico:history</html:a> datatype property in RiC-O (same
+                     as RiC-CM history attribute), while RiC-CM and RiC-O also provide the <html:a href="#rico:Event">Event class</html:a>, and using a series of Events may of
                      course be a better method, easier to query, link and display, than simply using
                      a history prose discourse. The two methods may be used in parallel within the
                      same dataset by an institution that, for example, would decide to emphasize
@@ -307,20 +289,14 @@
                      above.</html:p>
                   <html:p>Finally, we have introduced a few datatype properties that do not
                      correspond to any RiC-CM attribute.</html:p>
-                  <html:p>Some are superproperties, and thus group datatype properties (<html:a
-                        href="#rico:physicalOrLogicalExtent">rico:physicalOrLogicalExtent</html:a>,
+                  <html:p>Some are superproperties, and thus group datatype properties (<html:a href="#rico:physicalOrLogicalExtent">rico:physicalOrLogicalExtent</html:a>,
                      with rico:carrierExtent, rico:instantiationExtent and rico:recordResourceExtent
-                     as subproperties ; <html:a href="#rico:textualValue"
-                     >rico:textualValue</html:a>, with rico:expressedDate and rico:normalizedValue
+                     as subproperties ; <html:a href="#rico:textualValue">rico:textualValue</html:a>, with rico:expressedDate and rico:normalizedValue
                      as subproperties; <html:a href="#rico:measure">rico:measure</html:a> (and its
-                     subproperties); <html:a href="#rico:referenceSystem"
-                        >rico:referenceSystem</html:a>, superproperty of rico:dateStandard (and of
+                     subproperties); <html:a href="#rico:referenceSystem">rico:referenceSystem</html:a>, superproperty of rico:dateStandard (and of
                      other datatype properties that do not exist in RiC-CM.)</html:p>
-                  <html:p>Some are simply more specific properties : <html:a
-                        href="#rico:accrualStatus">rico:accrualStatus</html:a> ; <html:a
-                        href="#rico:recordResourceStructure">rico:recordResourceStructure</html:a>
-                     and <html:a href="#rico:instantiationStructure"
-                        >rico:instantiationStructure</html:a>, subproperties of rico:structure ;
+                  <html:p>Some are simply more specific properties : <html:a href="#rico:accrualStatus">rico:accrualStatus</html:a> ; <html:a href="#rico:recordResourceStructure">rico:recordResourceStructure</html:a>
+                     and <html:a href="#rico:instantiationStructure">rico:instantiationStructure</html:a>, subproperties of rico:structure ;
                         <html:a href="#rico:title">rico:title</html:a> (subproperty of rico:name) ;
                      rico:altitude, rico:latitude, rico:longitude (subproperties of rico:measure),
                      rico:geodesicSystem and rico:altimetricSystem (subproperties of
@@ -336,16 +312,13 @@
                   <html:p>Finally, let us mention that we added to RiC-O six individuals,
                      considering that they would address current and frequent needs:</html:p>
                   <html:ul>
-                     <html:li>Two (<html:a href="#FindingAid">FindingAid</html:a> and <html:a
-                           href="#AuthorityRecord">AuthorityRecord</html:a>) are instances of both
+                     <html:li>Two (<html:a href="#FindingAid">FindingAid</html:a> and <html:a href="#AuthorityRecord">AuthorityRecord</html:a>) are instances of both
                         RiC-O Documentary Form Type and SKOS Concept. They can be used for
                         categorizing Records, finding aids and authority records being considered as
                         Records. A Record that would have ‘Finding Aid’ as a Documentary Form Type,
                         can be connected to one to many Record Resources using 'rico:describes’
                         object property.</html:li>
-                     <html:li>Four (<html:a href="#Fonds">Fonds</html:a>, <html:a href="#Series"
-                           >Series</html:a>, <html:a href="#File">File</html:a>, and <html:a
-                           href="#Collection">Collection</html:a>) are both instances of the Record
+                     <html:li>Four (<html:a href="#Fonds">Fonds</html:a>, <html:a href="#Series">Series</html:a>, <html:a href="#File">File</html:a>, and <html:a href="#Collection">Collection</html:a>) are both instances of the Record
                         Set Type class, and of skos:Concept. Their definition is taken from the
                         ISAD(G) glossary. They can be used for categorizing Record Sets.</html:li>
                   </html:ul>
@@ -353,8 +326,7 @@
                      be defined by the archival community, forming at least rich SKOS (hopefully
                      multilingual) vocabularies. Considering the concepts thus defined as being also
                      instances of some RiC-O classes may be of great interest for producing a richer
-                     description (for example, an instance of the <html:a
-                        href="#rico:DocumentaryFormType">Documentary Form Type class</html:a> may
+                     description (for example, an instance of the <html:a href="#rico:DocumentaryFormType">Documentary Form Type class</html:a> may
                      have a history and some temporal relations to other documentary form
                      types).</html:p>
                </html:div>
@@ -370,13 +342,11 @@
                      for handling:</html:p>
                   <html:ul>
                      <html:li>Information about the corresponding RiC-CM component when applicable
-                           (<html:a href="#rico:RiCCMCorrespondingComponent"
-                           >rico:RiCCMCorrespondingComponent</html:a>). Various phrasings are used
+                           (<html:a href="#rico:RiCCMCorrespondingComponent">rico:RiCCMCorrespondingComponent</html:a>). Various phrasings are used
                         in this property depending on the rule applied for defining the RiC-CM
                         component.</html:li>
                      <html:li>Information, most often in prose text for now, about possible mappings
-                        with other models or ontologies (<html:a href="#rico:closeTo"
-                           >rico:closeTo</html:a>, rarely used in this 0.1 version)).</html:li>
+                        with other models or ontologies (<html:a href="#rico:closeTo">rico:closeTo</html:a>, rarely used in this 0.1 version)).</html:li>
                   </html:ul>
                   <html:p>Finally, in this official 0.2 release, any change in the definition of a
                      class or property, since December 2019, is documented using a
@@ -391,10 +361,8 @@
                <html:ul>
                   <html:li>providing more examples of known implementations of RiC-O in different
                      institutions and contexts. The goal is to show different practices on how RiC-O
-                     is being implemented. We have begun to release such examples in the <html:a
-                        href="https://github.com/ICA-EGAD/RiC-O">public RiC-O repository on
-                        GitHub</html:a>. One can also have a look at the <html:a
-                        href="https://ica-egad.github.io/RiC-O/projects-and-tools.html">Projects and
+                     is being implemented. We have begun to release such examples in the <html:a href="https://github.com/ICA-EGAD/RiC-O">public RiC-O repository on
+                        GitHub</html:a>. One can also have a look at the <html:a href="https://ica-egad.github.io/RiC-O/projects-and-tools.html">Projects and
                         tools page on RiC-O website</html:a>.</html:li>
                   <html:li>finishing the system of relations (where some subclasses are still
                      missing)</html:li>
@@ -431,9 +399,7 @@
       <skos:historyNote rdf:parseType="Literal">
          <html:div xml:lang="en">
             <html:p>A first beta version of RiC-O was developed in 2017 and used by the National
-               Archives of France for building a proof of concept (<html:a
-                  href="https://piaaf.demo.logilab.fr"
-               >https://piaaf.demo.logilab.fr</html:a>).</html:p>
+               Archives of France for building a proof of concept (<html:a href="https://piaaf.demo.logilab.fr">https://piaaf.demo.logilab.fr</html:a>).</html:p>
             <html:p>EGAD then continued to develop the ontology, and this process entered a very
                active period in 2019, while RiC-CM v0.2 was being designed and edited. From December
                2018 to November 2019, about 65 persons that had applied to a call for reviewers,
@@ -445,8 +411,7 @@
                ontology’s first public release. RiC-O v0.1 was released on December 2019,
                12.</html:p>
             <html:p>The Git repository that is used for handling RiC-O was made public in March 2020
-               (see <html:a href="https://github.com/ICA-EGAD/RiC-O"
-                  >https://github.com/ICA-EGAD/RiC-O</html:a>), so that creating issues or comments,
+               (see <html:a href="https://github.com/ICA-EGAD/RiC-O">https://github.com/ICA-EGAD/RiC-O</html:a>), so that creating issues or comments,
                forking and making pull requests was made possible.</html:p>
             <html:p>In 2020, RiC-CM v0.2 preview was significantly updated: the textual definitions
                of many entities were changed, as well as the specifications of many attributes; and
@@ -696,8 +661,7 @@
    <!-- http://www.w3.org/2004/02/skos/core#scopeNote -->
    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#scopeNote"/>
    <!-- https://www.ica.org/standards/RiC/ontology#RiCCMCorrespondingComponent -->
-   <owl:AnnotationProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#RiCCMCorrespondingComponent">
+   <owl:AnnotationProperty rdf:about="https://www.ica.org/standards/RiC/ontology#RiCCMCorrespondingComponent">
       <rdfs:comment xml:lang="en">When it exists, specifies the identifier and name of RiC-CM
          component that corresponds to the annotated class or property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -734,19 +698,15 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
    <!-- https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAccumulationRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAccumulationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AccumulationRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
@@ -756,12 +716,9 @@
       <rdfs:label xml:lang="en">accumulation relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAccumulationRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAccumulationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AccumulationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Accumulation Relation to one of the accumulating
@@ -770,20 +727,15 @@
       <rdfs:label xml:lang="en">accumulation relation has target</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfActivityDocumentationRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfActivityDocumentationRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
@@ -793,14 +745,10 @@
       <rdfs:label xml:lang="en">activity documentation relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#activityIsTargetOfActivityDocumentationRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#activityIsTargetOfActivityDocumentationRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
       <rdfs:comment xml:lang="en">Connects an Activity Documentation Relation to one of the
          documented Activities</rdfs:comment>
@@ -808,19 +756,15 @@
       <rdfs:label xml:lang="en">activity documentation relation has target</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#activityIsContextOfRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#activityIsContextOfRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#activityIsContextOfRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#asConcernsActivity"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
@@ -838,12 +782,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#activityIsSourceOfPerformanceRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#activityIsSourceOfPerformanceRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#activityIsSourceOfPerformanceRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PerformanceRelation"/>
       <rdfs:comment xml:lang="en">Connects an Activity that is performed to a Performance
@@ -852,15 +793,11 @@
       <rdfs:label xml:lang="en">activity is source of performance relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#activityIsTargetOfActivityDocumentationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#activityIsTargetOfActivityDocumentationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#activityIsTargetOfActivityDocumentationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
-      <rdfs:range
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation"/>
       <rdfs:comment xml:lang="en">Connects an Activity to an Activity Documentation
          Relation</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -868,8 +805,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#affectsOrAffected -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#affectsOrAffected">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadParticipant"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadParticipant"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasAffectedBy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
@@ -896,14 +832,10 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentControlRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent Control Relation to one of the controlling
@@ -912,14 +844,10 @@
       <rdfs:label xml:lang="en">agent control relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentControlRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent Control Relation to one of the controlled
@@ -930,10 +858,8 @@
    <!-- https://www.ica.org/standards/RiC/ontology#agentHasOrHadLocation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentHasOrHadLocation">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadLocation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithPlace"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasLocationOfAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithPlace"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasLocationOfAgent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:comment xml:lang="en">Inverse of 'is or was location of agent' object
@@ -955,8 +881,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentHasWorkRelation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentHasWorkRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#workRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#WorkRelation"/>
@@ -965,16 +890,11 @@
       <rdfs:label xml:lang="en">agent has work relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent Hierarchical Relation to one of the
          hierarchically superior Agents</rdfs:comment>
@@ -982,16 +902,11 @@
       <rdfs:label xml:lang="en">agent hierarchical relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent Hierarchical Relation to one of the
          hierarchically inferior Agents</rdfs:comment>
@@ -999,10 +914,8 @@
       <rdfs:label xml:lang="en">agent hierarchical relation has target</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
@@ -1011,12 +924,9 @@
       <rdfs:label xml:lang="en">agent is connected to agent relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentControlRelation"/>
       <rdfs:comment xml:lang="en">Connects a controlling Agent to an Agent Control
@@ -1025,31 +935,22 @@
       <rdfs:label xml:lang="en">agent is source of agent control relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
-      <rdfs:range
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
       <rdfs:comment xml:lang="en">Connects a hierarchically superior Agent to an Agent Hierarchical
          Relation</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">agent is source of agent hierarchical relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
       <rdfs:comment xml:lang="en">Connects a predecessor Agent to an Agent Temporal
@@ -1058,12 +959,9 @@
       <rdfs:label xml:lang="en">agent is source of agent temporal relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorityRelation"/>
       <rdfs:comment xml:lang="en">Connects an Agent thas has the authority, to an Authority
@@ -1072,12 +970,9 @@
       <rdfs:label xml:lang="en">agent is source of authority relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsSourceOfIntellectualPropertyRightsRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfIntellectualPropertyRightsRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfIntellectualPropertyRightsRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -1087,8 +982,7 @@
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
-      <rdfs:range
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation"/>
       <rdfs:comment xml:lang="en">Connects an Agent having the intellectual property rights, to an
          Intellectual Property Rights Relation</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -1096,12 +990,9 @@
       </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ManagementRelation"/>
       <rdfs:comment xml:lang="en">Connects a manager Agent to a Management Relation</rdfs:comment>
@@ -1109,12 +1000,9 @@
       <rdfs:label xml:lang="en">agent is source of management relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsSourceOfOwnershipRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfOwnershipRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfOwnershipRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -1130,27 +1018,20 @@
       <rdfs:label xml:lang="en">agent is source of ownership relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsSourceOfRecordResourceHoldingRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfRecordResourceHoldingRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfRecordResourceHoldingRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
-      <rdfs:range
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation"/>
       <rdfs:comment xml:lang="en">Connects an Agent that holds a Record Resource or Instantiation,
          to a Record Resource Holding Relation</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">agent is source of record resource holding relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAccumulationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAccumulationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAccumulationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AccumulationRelation"/>
       <rdfs:comment xml:lang="en">Connects one of the accumulating Agents to an Accumulation
@@ -1159,14 +1040,10 @@
       <rdfs:label xml:lang="en">agent is target of accumulation relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentControlRelation"/>
       <rdfs:comment xml:lang="en">Connects one of the controlled Agents to an Agent Control
@@ -1175,29 +1052,21 @@
       <rdfs:label xml:lang="en">agent is target of agent control relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
-      <rdfs:range
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
       <rdfs:comment xml:lang="en">Connects one of the hierarchically inferior Agents to an Agent
          Hierarchical Relation</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">agent is target of agent hierarchical relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
       <rdfs:comment xml:lang="en">Connects one of the Agents that created or accumulated the Record
@@ -1206,14 +1075,10 @@
       <rdfs:label xml:lang="en">agent is target of agent origination relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
       <rdfs:comment xml:lang="en">Connects a successor Agent to an Agent Temporal
@@ -1222,12 +1087,9 @@
       <rdfs:label xml:lang="en">agent is target of agent temporal relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAuthorshipRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAuthorshipRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfCreationRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorshipRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAuthorshipRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfCreationRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorshipRelationHasTarget"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -1251,12 +1113,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsTargetOfCreationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfCreationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfCreationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#CreationRelation"/>
       <rdfs:comment xml:lang="en">Connects a creator Agent to a Creation Relation</rdfs:comment>
@@ -1264,12 +1123,9 @@
       <rdfs:label xml:lang="en">agent is target of creation relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsTargetOfMandateRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfMandateRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfMandateRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
       <rdfs:comment xml:lang="en">Connects a mandated Agent to a Mandate Relation</rdfs:comment>
@@ -1277,12 +1133,9 @@
       <rdfs:label xml:lang="en">agent is target of mandate relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentIsTargetOfPerformanceRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfPerformanceRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfPerformanceRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PerformanceRelation"/>
       <rdfs:comment xml:lang="en">Connects an Agent to a Performance Relation</rdfs:comment>
@@ -1290,12 +1143,9 @@
       <rdfs:label xml:lang="en">agent is target of performance relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -1311,20 +1161,15 @@
       <rdfs:label xml:lang="en">agent or activity is target of provenance relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
@@ -1334,14 +1179,10 @@
       <rdfs:label xml:lang="en">agent origination relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent Origination Relation to one of the creating or
          accumulating Agents</rdfs:comment>
@@ -1351,8 +1192,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#agentRelationConnects -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentRelationConnects">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationConnects"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent Relation to one of the involved
@@ -1361,14 +1201,10 @@
       <rdfs:label xml:lang="en">agent relation connects</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent Temporal Relation to one of the predecessor
@@ -1377,14 +1213,10 @@
       <rdfs:label xml:lang="en">agent temporal relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent Temporal Relation to one of the successor
@@ -1393,12 +1225,9 @@
       <rdfs:label xml:lang="en">agent temporal relation has target</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#appellationIsSourceOfAppellationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#appellationIsSourceOfAppellationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#appellationIsSourceOfAppellationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AppellationRelation"/>
       <rdfs:comment xml:lang="en">Connects an Appellation to an Appellation Relation</rdfs:comment>
@@ -1406,12 +1235,9 @@
       <rdfs:label xml:lang="en">appellation is source of appellation relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationIsSourceOfAppellationRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationIsSourceOfAppellationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AppellationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
       <rdfs:comment xml:lang="en">Connects an Appellation Relation to the concerned
@@ -1420,12 +1246,9 @@
       <rdfs:label xml:lang="en">appellation relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#appellationRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#appellationRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAppellationRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#appellationRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAppellationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AppellationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an Appellation Relation to one of the designated
@@ -1435,17 +1258,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#asConcernsActivity -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#asConcernsActivity">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#activityIsContextOfRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#activityIsContextOfRelation"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -1464,12 +1283,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorityRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Authority Relation to an Agent that has the
@@ -1478,12 +1294,9 @@
       <rdfs:label xml:lang="en">authority relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorityRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an Authority Relation to a Thing over which the Authority
@@ -1493,16 +1306,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#authorizedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#authorizedBy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorizes"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Mandate"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfMandateRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfMandateRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'authorizes' object property</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -1519,16 +1329,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#authorizes -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#authorizes">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorizedBy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Mandate"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#mandateIsSourceOfMandateRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#mandateIsSourceOfMandateRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Mandate to the Agent that the Mandate gives the
          authority or competencies to act.</rdfs:comment>
@@ -1552,10 +1359,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#authorizingAgent -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#authorizingAgent">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAuthorizingAgentInMandateRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAuthorizingAgentInMandateRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Mandate Relation to an Agent that assigns the
@@ -1571,12 +1376,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#authorshipRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#authorshipRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordIsSourceOfAuthorshipRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#authorshipRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordIsSourceOfAuthorshipRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorshipRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Record"/>
       <rdfs:comment xml:lang="en">Connects an Authorship Relation to one of the Records involved in
@@ -1592,12 +1394,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#authorshipRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#authorshipRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAuthorshipRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#authorshipRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAuthorshipRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorshipRelation"/>
       <rdfs:range>
          <owl:Class>
@@ -1622,10 +1421,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#childRelationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#childRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfChildRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfChildRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ChildRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Child Relation to a parent Person</rdfs:comment>
@@ -1634,10 +1431,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#childRelationHasTarget -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#childRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfChildRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfChildRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ChildRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Child Relation to a child Person</rdfs:comment>
@@ -1646,8 +1441,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#contained -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#contained">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#containsOrContained"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#containsOrContained"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hadPart"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasContainedBy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
@@ -1666,10 +1460,8 @@
    <!-- https://www.ica.org/standards/RiC/ontology#containsOrContained -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#containsOrContained">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadPart"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasContainedBy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
@@ -1700,13 +1492,10 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#containsTransitive -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#containsTransitive">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#containsOrContained"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#containsOrContained"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isContainedByTransitive"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isContainedByTransitive"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:comment>Connects a Place to a Place that is, directly or indirectly, contained within
@@ -1722,12 +1511,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasCorrespondenceRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasCorrespondenceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#CorrespondenceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Correspondence Relation to one of the Persons
@@ -1736,19 +1522,15 @@
       <rdfs:label xml:lang="en">correspondence relation connects</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#creationRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfCreationRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfCreationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#CreationRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
@@ -1758,12 +1540,9 @@
       <rdfs:label xml:lang="en">creation relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#creationRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#creationRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfCreationRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#creationRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfCreationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#CreationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Creation Relation to one of the creator
@@ -1773,10 +1552,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#creationWithRole -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#creationWithRole">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#roleIsContextOfCreationRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#roleIsContextOfCreationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#CreationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RoleType"/>
       <rdfs:comment xml:lang="en">Connects a Creation Relation to the Role Type that the creator
@@ -1792,14 +1569,10 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#DerivationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects a Derivation Relation to the Instantiation from which one
@@ -1808,14 +1581,10 @@
       <rdfs:label xml:lang="en">derivation relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfDerivationRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfDerivationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#DerivationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects a Derivation Relation to one of the derived
@@ -1824,14 +1593,10 @@
       <rdfs:label xml:lang="en">derivation relation has target</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#DescendanceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Descendance Relation to one of the ancestor
@@ -1840,14 +1605,10 @@
       <rdfs:label xml:lang="en">descendance relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#DescendanceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Descendance Relation to one of the descendant
@@ -1888,8 +1649,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#directlyContains -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#directlyContains">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#containsTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#containsTransitive"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectlyContainedBy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
@@ -1907,12 +1667,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#directlyFollowsInSequence -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#directlyFollowsInSequence">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInSequenceTransitive"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyPrecedesInSequence"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#directlyFollowsInSequence">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInSequenceTransitive"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyPrecedesInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Thing to a Thing that precedes it directly in some non
@@ -1936,8 +1693,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#directlyIncludes -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#directlyIncludes">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#includesTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#includesTransitive"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectlyIncludedIn"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range>
@@ -1962,12 +1718,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#directlyPrecedesInSequence -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#directlyPrecedesInSequence">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInSequenceTransitive"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyFollowsInSequence"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#directlyPrecedesInSequence">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInSequenceTransitive"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyFollowsInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Thing to a Thing that follows it directly in some non
@@ -1992,16 +1745,14 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#documentedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#documentedBy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#resultsOrResultedIn"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#resultsOrResultedIn"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#documents"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
@@ -2027,25 +1778,20 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#documents -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#documents">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#resultsOrResultedFrom"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#resultsOrResultedFrom"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#documentedBy"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfActivityDocumentationRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfActivityDocumentationRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record Resource or an Instantiation to the Activity
          that generates the Record Resource or Instantiation.</rdfs:comment>
@@ -2070,12 +1816,9 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#eventIsSourceOfEventRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#eventIsSourceOfEventRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#eventRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#eventIsSourceOfEventRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#eventRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#EventRelation"/>
       <rdfs:comment xml:lang="en">Connects an Event to an Event Relation</rdfs:comment>
@@ -2084,10 +1827,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#eventRelationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#eventRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#eventIsSourceOfEventRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#eventIsSourceOfEventRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#EventRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:comment xml:lang="en">Connects an Event Relation to an Event</rdfs:comment>
@@ -2096,10 +1837,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#eventRelationHasTarget -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#eventRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfEventRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfEventRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#EventRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an Event Relation to an associated Thing</rdfs:comment>
@@ -2108,17 +1847,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#existsOrExistedIn -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#existsOrExistedIn">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadPosition"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsSourceOfPositionToGroupRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsSourceOfPositionToGroupRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Position to a Group in which that Position exists or
          existed, or that is defined by that Group�s organizational structure.</rdfs:comment>
@@ -2144,8 +1879,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#expressesOrExpressed -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#expressesOrExpressed">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasExpressedBy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
@@ -2173,10 +1907,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#familyRelationConnects -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#familyRelationConnects">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#FamilyRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Family Relation to a Person.</rdfs:comment>
@@ -2185,8 +1917,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#followedInSequence -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#followedInSequence">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#followsOrFollowed"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsOrFollowed"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precededInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
@@ -2209,13 +1940,10 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#followsInSequenceTransitive -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#followsInSequenceTransitive">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#followsOrFollowed"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#followsInSequenceTransitive">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsOrFollowed"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInSequenceTransitive"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInSequenceTransitive"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Thing to a Thing that directly or indirectly precedes
@@ -2238,17 +1966,14 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#followsInTime -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#followsInTime">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#followsOrFollowed"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsOrFollowed"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInTime"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'precedes in time' object property. This is a
          transitive relation.</rdfs:comment>
@@ -2283,10 +2008,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'precedesOrPreceded' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -2310,14 +2033,10 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToFunctionalEquivalenceRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#FunctionalEquivalenceRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToFunctionalEquivalenceRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#FunctionalEquivalenceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects a Functional Equivalence Relation to one of the
          functionally equivalent Instantiations.</rdfs:comment>
@@ -2325,14 +2044,10 @@
       <rdfs:label xml:lang="en">functional equivalence relation connects</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#groupIsSourceOfGroupSubdivisionRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfGroupSubdivisionRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfGroupSubdivisionRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#GroupSubdivisionRelation"/>
       <rdfs:comment xml:lang="en">Connects the Group that has at least a subdivision, to a Group
@@ -2341,14 +2056,10 @@
       <rdfs:label xml:lang="en">group is source of group subdivision relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#groupIsSourceOfMembershipRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfMembershipRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfMembershipRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#MembershipRelation"/>
       <rdfs:comment xml:lang="en">Connects the Group (that has one to many members) to a Membership
@@ -2357,14 +2068,10 @@
       <rdfs:label xml:lang="en">group is source of membership relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#groupIsTargetOfGroupSubdivisionRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfGroupSubdivisionRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfGroupSubdivisionRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#GroupSubdivisionRelation"/>
       <rdfs:comment xml:lang="en">Connects a Group that is a subdivision, to a Group Subdivision
@@ -2373,12 +2080,9 @@
       <rdfs:label xml:lang="en">group is target of group subdivision relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#groupIsTargetOfLeadershipRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfLeadershipRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfLeadershipRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#LeadershipRelation"/>
       <rdfs:comment xml:lang="en">Connects a Group (which has a leader) to a Leadership
@@ -2387,14 +2091,10 @@
       <rdfs:label xml:lang="en">group is target of leadership relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#groupIsTargetOfPositionToGroupRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfPositionToGroupRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfPositionToGroupRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PositionToGroupRelation"/>
       <rdfs:comment xml:lang="en">Connects the Group (in which a Position exists) to a Position To
@@ -2403,16 +2103,11 @@
       <rdfs:label xml:lang="en">group is target of position to group relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfGroupSubdivisionRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#GroupSubdivisionRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfGroupSubdivisionRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#GroupSubdivisionRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:comment xml:lang="en">Connects a Group Subdivision Relation to the Group that has
          subdivisions</rdfs:comment>
@@ -2420,16 +2115,11 @@
       <rdfs:label xml:lang="en">group subdivision relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfGroupSubdivisionRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#GroupSubdivisionRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfGroupSubdivisionRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#GroupSubdivisionRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:comment xml:lang="en">Connects a Group Subdivision Relation to one of the Groups that is
          a subdivision</rdfs:comment>
@@ -2439,8 +2129,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hadComponent -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hadComponent">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hadPart"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadComponent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadComponent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasComponentOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
@@ -2460,8 +2149,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hadConstituent -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hadConstituent">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hadPart"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadConstituent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadConstituent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasConstituentOf"/>
       <rdfs:domain>
          <owl:Class>
@@ -2520,8 +2208,7 @@
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hadSubdivision">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hadPart"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hadSubordinate"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSubdivision"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSubdivision"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasSubdivisionOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
@@ -2558,8 +2245,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hadSubordinate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hadSubordinate">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSubordinate"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSubordinate"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasSubordinateTo"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
@@ -2583,17 +2269,14 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAccumulationRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAccumulationRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record Resource or an Instantiation to the Agent that
          accumulates it, be it intentionally (collecting) or not (receiving in the course of its
@@ -2650,8 +2333,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -2680,18 +2362,15 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasAncestor -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasAncestor">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyAssociationWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyAssociationWith"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isSuccessorOf"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDescendant"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'has descendant' object property. This is a transitive
          relation.</rdfs:comment>
@@ -2734,10 +2413,8 @@
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#recordIsSourceOfAuthorshipRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#authorshipRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordIsSourceOfAuthorshipRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#authorshipRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record to the Group, Person or Position that is
          responsible for conceiving and formulating the information contained in the
@@ -2767,8 +2444,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasBeginningDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasBeginningDate">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
@@ -2806,8 +2482,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasBirthPlace -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasBirthPlace">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithPlace"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithPlace"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isBirthPlaceOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
@@ -2857,10 +2532,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfChildRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#childRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfChildRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#childRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Person to one of their children.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -2889,8 +2562,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -2919,13 +2591,10 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasComponentTransitive -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasComponentTransitive">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadComponent"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadComponent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isComponentOfTransitive"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isComponentOfTransitive"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation to another Instantiation that is,
@@ -2942,15 +2611,11 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasConstituentTransitive -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasConstituentTransitive">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadConstituent"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasConstituentTransitive">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadConstituent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isConstituentOfTransitive"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isConstituentOfTransitive"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -3019,8 +2684,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasCopy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasCopy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInTime"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isCopyOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
@@ -3047,8 +2711,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -3073,8 +2736,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -3148,8 +2810,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasDeathPlace -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasDeathPlace">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithPlace"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithPlace"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDeathPlaceOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
@@ -3170,18 +2831,15 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasDescendant -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasDescendant">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyAssociationWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyAssociationWith"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSuccessor"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasAncestor"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Person to one of their descendants. This is a
          transitive relation.</rdfs:comment>
@@ -3241,8 +2899,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasDirectComponent -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasDirectComponent">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasComponentTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasComponentTransitive"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectComponentOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
@@ -3262,8 +2919,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasDirectConstituent -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasDirectConstituent">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasConstituentTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasConstituentTransitive"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectConstituentOf"/>
       <rdfs:domain>
@@ -3303,8 +2959,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasDirectPart -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasDirectPart">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
@@ -3326,10 +2981,8 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasDirectSubdivision -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasDirectSubdivision">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectSubordinate"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSubdivisionTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectSubordinate"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSubdivisionTransitive"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectSubdivisionOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
@@ -3348,8 +3001,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasDirectSubevent -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasDirectSubevent">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSubeventTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSubeventTransitive"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectSubeventOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
@@ -3368,8 +3020,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasDirectSubordinate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasDirectSubordinate">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSubordinateTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSubordinateTransitive"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectSubordinateTo"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
@@ -3389,8 +3040,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasDocumentaryFormType -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasDocumentaryFormType">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadCategory"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDocumentaryFormTypeOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDocumentaryFormTypeOf"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -3421,8 +3071,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasDraft -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasDraft">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInTime"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDraftOf"/>
       <rdfs:domain>
          <owl:Class>
@@ -3455,8 +3104,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasEndDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasEndDate">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isEndDateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
@@ -3557,18 +3205,14 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasFamilyAssociationWith -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasFamilyAssociationWith">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasFamilyAssociationWith">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Persons that have some type of family link, i.e.
          belong to the same family. This relation is symmetric.</rdfs:comment>
@@ -3617,10 +3261,8 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
@@ -3676,8 +3318,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasModificationDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasModificationDate">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isModificationDateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
@@ -3721,11 +3362,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCategory -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCategory">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCategory">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfAllMembersOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfAllMembersOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:comment xml:lang="en">Connects a Record Set and a Category (Type) to which all the
@@ -3751,12 +3390,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithContentType -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithContentType">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCategory"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasContentTypeOfAllMembersOf"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithContentType">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCategory"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasContentTypeOfAllMembersOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ContentType"/>
       <rdfs:comment xml:lang="en">Connects a Record Set and a Content Type that categorizes all the
@@ -3782,11 +3418,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCreationDate -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCreationDate">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCreationDate">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasBeginningDate"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCreationDateOfAllMembersOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCreationDateOfAllMembersOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:comment xml:lang="en">Inverse of 'is or was creation date of all members of' object
@@ -3818,12 +3452,9 @@
          date' relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithDocumentaryFormType -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithDocumentaryFormType">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCategory"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasDocumentaryFormTypeOfAllMembersOf"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithDocumentaryFormType">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCategory"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasDocumentaryFormTypeOfAllMembersOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#DocumentaryFormType"/>
       <rdfs:comment xml:lang="en">Connects a Record Set and a Documentary Form Type that categorizes
@@ -3848,11 +3479,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithLanguage -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithLanguage">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithLanguage">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasLanguageOfAllMembersOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasLanguageOfAllMembersOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Language"/>
       <rdfs:comment xml:lang="en">Connects a Record Set and a Language used by all the Records or
@@ -3877,12 +3506,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithLegalStatus -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithLegalStatus">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCategory"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasLegalStatusOfAllMembersOf"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithLegalStatus">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCategory"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasLegalStatusOfAllMembersOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#LegalStatus"/>
       <rdfs:comment xml:lang="en">Connects a Record Set and a Legal Status that categorizes all the
@@ -3908,12 +3534,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithRecordState -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithRecordState">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCategory"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasRecordStateOfAllMembersOf"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithRecordState">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCategory"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasRecordStateOfAllMembersOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordState"/>
       <rdfs:comment xml:lang="en">Connects a Record Set and a Record State that categorizes all the
@@ -3938,12 +3561,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadAnalogueInstantiation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadAnalogueInstantiation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadInstantiation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasAnalogueInstantiationOf"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadAnalogueInstantiation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadInstantiation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasAnalogueInstantiationOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects a record resource to one of its analogue instantiations,
@@ -3968,10 +3588,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAppellationRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAppellationRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Thing to an Appellation that is or was used for
          designating it.</rdfs:comment>
@@ -3995,15 +3613,12 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadAuthorityOver -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadAuthorityOver">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasUnderAuthorityOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasUnderAuthorityOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAuthorityRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Agent to a Thing the Agent has or had authority
          over.</rdfs:comment>
@@ -4034,10 +3649,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTypeRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#typeRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTypeRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#typeRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Thing to a Type that categorizes or categorized
          it.</rdfs:comment>
@@ -4061,8 +3674,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadComponent -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadComponent">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadPart"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasComponentOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
@@ -4091,8 +3703,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadConstituent -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadConstituent">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadPart"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasConstituentOf"/>
       <rdfs:domain>
          <owl:Class>
@@ -4140,18 +3751,14 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadController -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadController">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubordinateTo"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasUnderAuthorityOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubordinateTo"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasUnderAuthorityOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasControllerOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentControlRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is or was controller of' object
          property.</rdfs:comment>
@@ -4207,11 +3814,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadCorporateBodyType -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadCorporateBodyType">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadCorporateBodyType">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadCategory"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCorporateBodyTypeOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCorporateBodyTypeOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#CorporateBody"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#CorporateBodyType"/>
       <rdfs:comment xml:lang="en">Connects a Corporate Body to a Corporate Body Type which
@@ -4241,10 +3846,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#personHasCorrespondenceRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personHasCorrespondenceRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Persons that correspond or have corresponded with
          each other. This relation is symmetric.</rdfs:comment>
@@ -4269,11 +3872,9 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadDemographicGroup -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadDemographicGroup">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadDemographicGroup">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadCategory"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasDemographicGroupOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasDemographicGroupOf"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -4304,20 +3905,15 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadDerivedInstantiation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadDerivedInstantiation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadDerivedInstantiation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInTime"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasDerivedFromInstantiation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasDerivedFromInstantiation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an instantiation to an instantiation that is derived from
          it, whether it exists or has been lost or destroyed.</rdfs:comment>
@@ -4346,12 +3942,9 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadDigitalInstantiation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadDigitalInstantiation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadInstantiation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasDigitalInstantiationOf"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadDigitalInstantiation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadInstantiation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasDigitalInstantiationOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects a record resource to one of its digital instantiations,
@@ -4373,8 +3966,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadEmployer -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadEmployer">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadController"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadController"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasEmployerOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range>
@@ -4410,18 +4002,14 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfRecordResourceHoldingRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfRecordResourceHoldingRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is or was holder of' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -4446,8 +4034,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadIdentifier -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadIdentifier">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAppellation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAppellation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasIdentifierOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Identifier"/>
@@ -4474,16 +4061,12 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadInstantiation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadInstantiation">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasInstantiationOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasInstantiationOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsSourceOfRecordResourceToInstantiationRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsSourceOfRecordResourceToInstantiationRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a record resource to one of its instantiations, whether
          it exists or has been lost or destroyed.</rdfs:comment>
@@ -4518,18 +4101,14 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadIntellectualPropertyRightsHolder -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadIntellectualPropertyRightsHolder">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasUnderAuthorityOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasHolderOfIntellectualPropertyRightsOf"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadIntellectualPropertyRightsHolder">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasUnderAuthorityOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasHolderOfIntellectualPropertyRightsOf"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -4543,11 +4122,8 @@
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfIntellectualPropertyRightsRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfIntellectualPropertyRightsRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is or was holder of intellectual property rights of'
          object property.</rdfs:comment>
@@ -4574,8 +4150,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadJurisdiction -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadJurisdiction">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithPlace"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithPlace"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasJurisdictionOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
@@ -4650,16 +4225,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadLeader -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadLeader">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadController"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadController"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasLeaderOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfLeadershipRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfLeadershipRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is or was leader of' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -4717,8 +4289,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadLocation -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadLocation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasLocationOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
@@ -4776,24 +4347,20 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadManager -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadManager">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasUnderAuthorityOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasUnderAuthorityOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasManagerOf"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is or was manager of' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -4818,16 +4385,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadMember -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadMember">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasMemberOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfMembershipRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfMembershipRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Group to a Person that is or was a member of that
          Group.</rdfs:comment>
@@ -4852,12 +4416,9 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadMostMembersWithCreationDate -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadMostMembersWithCreationDate">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCreationDate"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCreationDateOfMostMembersOf"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadMostMembersWithCreationDate">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCreationDate"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCreationDateOfMostMembersOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:comment xml:lang="en">Inverse of 'is or was creation date of most members of' object
@@ -4886,21 +4447,18 @@
             <rdf:value xml:lang="en">Added in RiC-O 1.0.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-10-12</dc:date>
             <rdf:value xml:lang="en">Added the French label</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R083i ('has or had most members with creation
          date' relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadName -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadName">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAppellation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAppellation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasNameOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Name"/>
@@ -4925,12 +4483,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadOccupationOfType -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadOccupationOfType">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadDemographicGroup"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasOccupationTypeOf"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadOccupationOfType">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadDemographicGroup"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasOccupationTypeOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#OccupationType"/>
       <rdfs:comment xml:lang="en">Connects a Person to an Occupation Type that categorized or
@@ -4955,8 +4510,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadOwner -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadOwner">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasUnderAuthorityOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasUnderAuthorityOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasOwnerOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range>
@@ -4969,10 +4523,8 @@
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfOwnershipRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfOwnershipRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is or was owner of' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -5002,10 +4554,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Thing to a constitutive or component part of that
          Thing.</rdfs:comment>
@@ -5033,8 +4583,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadParticipant -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadParticipant">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasParticipantIn"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
@@ -5061,12 +4610,9 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadPhysicalLocation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadPhysicalLocation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasPhysicalLocationOf"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadPhysicalLocation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasPhysicalLocationOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PhysicalLocation"/>
       <rdfs:comment xml:lang="en">Connects a Place to one of its past or present Physical
@@ -5087,7 +4633,6 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-01-22</dc:date>
@@ -5151,8 +4696,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadPosition -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadPosition">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#existsOrExistedIn"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
@@ -5211,11 +4755,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCategory -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCategory">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCategory">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfSomeMembersOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfSomeMembersOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:comment xml:lang="en">Connects a Record Set and a Category (Type) to which some of the
@@ -5240,12 +4782,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithContentType -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithContentType">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCategory"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasContentTypeOfSomeMembersOf"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithContentType">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCategory"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasContentTypeOfSomeMembersOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ContentType"/>
       <rdfs:comment xml:lang="en">Connects a Record Set and a Content Type that categorizes some of
@@ -5271,11 +4810,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCreationDate -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCreationDate">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCreationDate">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasBeginningDate"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCreationDateOfSomeMembersOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCreationDateOfSomeMembersOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:comment xml:lang="en">Inverse of 'is or was creation date of some members of' object
@@ -5307,11 +4844,9 @@
          date' relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithLanguage -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithLanguage">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithLanguage">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasLanguageOfSomeMembersOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasLanguageOfSomeMembersOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Language"/>
       <rdfs:comment xml:lang="en">Connects a Record Set and a Language used by some of the Records
@@ -5336,12 +4871,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithLegalStatus -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithLegalStatus">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCategory"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasLegalStatusOfSomeMembersOf"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithLegalStatus">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCategory"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasLegalStatusOfSomeMembersOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#LegalStatus"/>
       <rdfs:comment xml:lang="en">Connects a Record Set and a Legal Status that categorizes some of
@@ -5366,12 +4898,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithRecordState -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithRecordState">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCategory"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasRecordStateOfSomeMembersOf"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithRecordState">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCategory"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasRecordStateOfSomeMembersOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordState"/>
       <rdfs:comment xml:lang="en">Connects a Record Set and a Record State that categorizes some of
@@ -5396,12 +4925,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMemberswithDocumentaryFormType -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMemberswithDocumentaryFormType">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCategory"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasDocumentaryFormTypeOfSomeMembersOf"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMemberswithDocumentaryFormType">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCategory"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasDocumentaryFormTypeOfSomeMembersOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#DocumentaryFormType"/>
       <rdfs:comment xml:lang="en">Connects a Record Set and a Documentary Form Type that categorizes
@@ -5429,16 +4955,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadSpouse -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSpouse">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyAssociationWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyAssociationWith"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSpouseRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#spouseRelationConnects"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSpouseRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#spouseRelationConnects"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Persons that are or were married. This relation is
          symmetric.</rdfs:comment>
@@ -5469,10 +4992,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfTeachingRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfTeachingRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'has or had teacher' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -5498,17 +5019,13 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadSubdivision -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSubdivision">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadPart"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSubordinate"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSubordinate"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubdivisionOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfGroupSubdivisionRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfGroupSubdivisionRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Group to one of its present or past
          subdivisions.</rdfs:comment>
@@ -5535,10 +5052,8 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadSubevent -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSubevent">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadPart"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubeventOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
@@ -5596,17 +5111,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadSubordinate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadSubordinate">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubordinateTo"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentHierarchicalRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Agent to an Agent that is hierarchically
          inferior.</rdfs:comment>
@@ -5639,10 +5150,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfTeachingRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfTeachingRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Person to another Person who is or was their
          student.</rdfs:comment>
@@ -5674,8 +5183,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Rule"/>
             </owl:unionOf>
          </owl:Class>
@@ -5702,10 +5210,8 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrHadWorkRelationWith -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadWorkRelationWith">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrHadWorkRelationWith">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
@@ -5734,8 +5240,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasOriginal -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOriginal">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInTime"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOriginalOf"/>
       <rdfs:domain>
          <owl:Class>
@@ -5790,11 +5295,9 @@
          things.</skos:scopeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasProductionTechniqueType -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasProductionTechniqueType">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasProductionTechniqueType">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadCategory"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isProductionTechniqueTypeOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isProductionTechniqueTypeOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ProductionTechniqueType"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation to a Production Technique Type that
@@ -5823,18 +5326,14 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record Resource or an Instantiation to an Agent that
          creates or accumulates the Record Resource, receives it, or sends it.</rdfs:comment>
@@ -5852,8 +5351,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasPublicationDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasPublicationDate">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPublicationDateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
@@ -5907,8 +5405,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -6000,8 +5497,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasReply -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasReply">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInTime"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isReplyTo"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
@@ -6031,8 +5527,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasRepresentationType -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasRepresentationType">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadCategory"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRepresentationTypeOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRepresentationTypeOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RepresentationType"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation to a Representation Type that
@@ -6061,8 +5556,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -6083,16 +5577,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasSibling -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasSibling">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyAssociationWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyAssociationWith"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSiblingRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#siblingRelationConnects"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSiblingRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#siblingRelationConnects"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Persons that are siblings. This relation is
          symmetric.</rdfs:comment>
@@ -6121,8 +5612,7 @@
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Relation"/>
             </owl:unionOf>
          </owl:Class>
@@ -6131,8 +5621,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Agent"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
@@ -6150,17 +5639,12 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasSubdivisionTransitive -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasSubdivisionTransitive">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSubdivision"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSubordinateTransitive"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasSubdivisionTransitive">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSubdivision"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSubordinateTransitive"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isSubdivisionOfTransitive"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isSubdivisionOfTransitive"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:comment xml:lang="en">Connects a Group to another Group that is one of its direct or
@@ -6178,11 +5662,9 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasSubeventTransitive -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasSubeventTransitive">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSubevent"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isSubeventOfTransitive"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isSubeventOfTransitive"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:comment xml:lang="en">Connects an ongoing Event to one of a series of Events that
@@ -6199,13 +5681,10 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasSubordinateTransitive -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasSubordinateTransitive">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSubordinate"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasSubordinateTransitive">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSubordinate"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isSubordinateToTransitive"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isSubordinateToTransitive"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent to an Agent that is directly or indirectly
@@ -6222,17 +5701,14 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasSuccessor -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasSuccessor">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInTime"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isSuccessorOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Agent to another Agent that succeeds it
          chronologically.</rdfs:comment>
@@ -6287,10 +5763,8 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasWithin -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasWithin">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadPart"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isWithin"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
@@ -6317,8 +5791,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#included -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#included">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hadPart"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#includesOrIncluded"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#includesOrIncluded"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasIncludedIn"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range>
@@ -6345,8 +5818,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#includesOrIncluded -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#includesOrIncluded">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadPart"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasIncludedIn"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range>
@@ -6390,13 +5862,10 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#includesTransitive -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#includesTransitive">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#includesOrIncluded"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#includesOrIncluded"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isIncludedInTransitive"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isIncludedInTransitive"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range>
          <owl:Class>
@@ -6419,15 +5888,11 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToFunctionalEquivalenceRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToFunctionalEquivalenceRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToFunctionalEquivalenceRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-      <rdfs:range
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#FunctionalEquivalenceRelation"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#FunctionalEquivalenceRelation"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation to a Functional Equivalence
          Relation</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -6435,31 +5900,22 @@
       </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-      <rdfs:range
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation to an Instantiation to Instantiation
          Relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">instantiation is connected to instantiation relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#DerivationRelation"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation (from which at least one Instantiation
@@ -6468,12 +5924,9 @@
       <rdfs:label xml:lang="en">instantiation is source of derivation relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfMigrationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfMigrationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfMigrationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfDerivationRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#MigrationRelation"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation (from which at least one Instantiation
@@ -6482,16 +5935,11 @@
       <rdfs:label xml:lang="en">instantiation is source of migration relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfDerivationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfDerivationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfDerivationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#DerivationRelation"/>
       <rdfs:comment xml:lang="en">Connects a derived Instantiation to a Derivation
@@ -6500,12 +5948,9 @@
       <rdfs:label xml:lang="en">instantiation is target of derivation relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfMigrationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfMigrationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfDerivationRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfMigrationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfDerivationRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#MigrationRelation"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation which results from a migration, to a
@@ -6514,15 +5959,11 @@
       <rdfs:label xml:lang="en">instantiation is target of migration relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfRecordResourceToInstantiationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfRecordResourceToInstantiationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfRecordResourceToInstantiationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-      <rdfs:range
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation of a Record Resource to the Record
          Resource to Instantiation Relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -6530,13 +5971,10 @@
          relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationConnects"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation to Instantiation Relation to one of the
          related Instantiations.</rdfs:comment>
@@ -6544,14 +5982,10 @@
       <rdfs:label xml:lang="en">instantiation to instantiation relation connects</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfIntellectualPropertyRightsRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfIntellectualPropertyRightsRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -6567,20 +6001,15 @@
       <rdfs:label xml:lang="en">intellectual property rights relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfIntellectualPropertyRightsRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfIntellectualPropertyRightsRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
@@ -6591,10 +6020,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#intersects -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#intersects">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
@@ -6628,16 +6055,13 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAccumulationRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAccumulationRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'has accumulator' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -6662,8 +6086,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isActivityTypeOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isActivityTypeOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasActivityType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
@@ -6694,8 +6117,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
@@ -6713,17 +6135,14 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Agents. This object property is
          symmetric.</rdfs:comment>
@@ -6743,12 +6162,9 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithPlace -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithPlace">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWithAgent"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithPlace">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWithAgent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:comment xml:lang="en">Inverse of 'is place associated with agent' object
@@ -6795,10 +6211,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfEventRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#eventRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfEventRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#eventRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is event associated with' object
          property.</rdfs:comment>
@@ -6821,10 +6235,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfPlaceRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#placeRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfPlaceRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#placeRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is place associated with' object
          property.</rdfs:comment>
@@ -6847,10 +6259,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is rule associated with' object
          property.</rdfs:comment>
@@ -6881,10 +6291,8 @@
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Record"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAuthorshipRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#authorshipRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAuthorshipRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#authorshipRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'has author' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -6907,10 +6315,8 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isAuthorizingAgentInMandateRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isAuthorizingAgentInMandateRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isAuthorizingAgentInMandateRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorizingAgent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
@@ -6921,8 +6327,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isBeginningDateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasBeginningDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
@@ -6942,8 +6347,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isBirthDateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isBirthDateOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasBirthDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
@@ -6963,8 +6367,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isBirthPlaceOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isBirthPlaceOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWithAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasBirthPlace"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
@@ -6985,8 +6388,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isCarrierTypeOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isCarrierTypeOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasCarrierType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#CarrierType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
@@ -7044,8 +6446,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
@@ -7071,15 +6472,11 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isComponentOfTransitive -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isComponentOfTransitive">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasComponentOf"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isComponentOfTransitive">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasComponentOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasComponentTransitive"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasComponentTransitive"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects an Instantiation to another Instantiation of which it is,
@@ -7095,15 +6492,11 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isConstituentOfTransitive -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isConstituentOfTransitive">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasConstituentOf"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isConstituentOfTransitive">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasConstituentOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasConstituentTransitive"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasConstituentTransitive"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -7140,12 +6533,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isContainedByTransitive -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isContainedByTransitive">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasContainedBy"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isContainedByTransitive">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasContainedBy"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#containsTransitive"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
@@ -7164,8 +6554,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isContentTypeOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isContentTypeOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasContentOfType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ContentType"/>
       <rdfs:range>
@@ -7197,8 +6586,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#isCopyOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isCopyOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInTime"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasCopy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
@@ -7217,16 +6605,14 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isCreationDateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isCreationDateOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasCreationDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
@@ -7264,16 +6650,13 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfCreationRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfCreationRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'has creator' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -7319,10 +6702,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDateOfOccurrenceOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDateOfOccurrenceOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#occurredAtDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
@@ -7357,8 +6738,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDateTypeOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDateTypeOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDateType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#DateType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
@@ -7400,8 +6780,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDeathPlaceOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDeathPlaceOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWithAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDeathPlace"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
@@ -7453,8 +6832,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDirectComponentOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDirectComponentOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isComponentOfTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isComponentOfTransitive"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectComponent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
@@ -7474,8 +6852,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDirectConstituentOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDirectConstituentOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isConstituentOfTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isConstituentOfTransitive"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectConstituent"/>
       <rdfs:domain>
@@ -7515,8 +6892,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDirectPartOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDirectPartOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
@@ -7538,10 +6914,8 @@
    <!-- https://www.ica.org/standards/RiC/ontology#isDirectSubdivisionOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDirectSubdivisionOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectSubordinateTo"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isSubdivisionOfTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectSubordinateTo"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isSubdivisionOfTransitive"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectSubdivision"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
@@ -7561,8 +6935,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#isDirectSubeventOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDirectSubeventOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isSubeventOfTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isSubeventOfTransitive"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectSubevent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
@@ -7581,8 +6954,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDirectSubordinateTo -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDirectSubordinateTo">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isSubordinateToTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isSubordinateToTransitive"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectSubordinate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
@@ -7601,8 +6973,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDirectlyContainedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDirectlyContainedBy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isContainedByTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isContainedByTransitive"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyContains"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
@@ -7623,8 +6994,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#isDirectlyIncludedIn -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDirectlyIncludedIn">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isIncludedInTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isIncludedInTransitive"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyIncludes"/>
       <rdfs:domain>
          <owl:Class>
@@ -7649,12 +7019,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDocumentaryFormTypeOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isDocumentaryFormTypeOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDocumentaryFormType"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDocumentaryFormTypeOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDocumentaryFormType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#DocumentaryFormType"/>
       <rdfs:range>
          <owl:Class>
@@ -7684,8 +7051,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDraftOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDraftOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInTime"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDraft"/>
       <rdfs:domain>
@@ -7719,8 +7085,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isEndDateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isEndDateOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasEndDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
@@ -7762,10 +7127,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#eventIsSourceOfEventRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#eventRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#eventIsSourceOfEventRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#eventRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Event to a Thing that is associated with the existence
          and lifecycle of the Event.</rdfs:comment>
@@ -7783,8 +7146,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isEventTypeOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isEventTypeOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasEventType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#EventType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
@@ -7815,8 +7177,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
@@ -7849,8 +7210,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isExtentTypeOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isExtentTypeOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasExtentType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ExtentType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Extent"/>
@@ -7881,8 +7241,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isFamilyTypeOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isFamilyTypeOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasFamilyType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#FamilyType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Family"/>
@@ -7906,8 +7265,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isFromUseDateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isFromUseDateOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasUsedFromDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
@@ -7930,20 +7288,15 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isFunctionallyEquivalentTo -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isFunctionallyEquivalentTo">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isFunctionallyEquivalentTo">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isEquivalentTo"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToFunctionalEquivalenceRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToFunctionalEquivalenceRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Instantiations which may be considered as equivalent.
          This relation is symmetric.</rdfs:comment>
@@ -7971,8 +7324,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isIdentifierTypeOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isIdentifierTypeOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasIdentifierType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#IdentifierType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Identifier"/>
@@ -8003,10 +7355,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isIncludedInTransitive -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isIncludedInTransitive">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasIncludedIn"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasIncludedIn"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#includesTransitive"/>
       <rdfs:domain>
@@ -8031,18 +7381,14 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsConnectedToInstantiationRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Instantiations. This object property is
          symmetric.</rdfs:comment>
@@ -8060,8 +7406,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isLastUpdateDateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isLastUpdateDateOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isModificationDateOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isModificationDateOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasLastUpdatedAtDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
@@ -8079,8 +7424,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isModificationDateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isModificationDateOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasModificationDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
@@ -8100,10 +7444,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasAdjacentTo -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasAdjacentTo">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
@@ -8131,8 +7473,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasAffectedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasAffectedBy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasParticipantIn"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasParticipantIn"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#affectsOrAffected"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
@@ -8183,12 +7524,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasAnalogueInstantiationOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasAnalogueInstantiationOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasInstantiationOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAnalogueInstantiation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasAnalogueInstantiationOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasInstantiationOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAnalogueInstantiation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:comment xml:lang="en">Inverse of 'has or had analogue instantiation' object
@@ -8235,10 +7573,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#typeIsSourceOfTypeRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#typeRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#typeIsSourceOfTypeRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#typeRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Type (a category) to a Thing that it categorizes or
          categorized.</rdfs:comment>
@@ -8260,11 +7596,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfAllMembersOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfAllMembersOf">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfAllMembersOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCategory"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCategory"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a Category (Type) and a Record Set whose all present or
@@ -8289,11 +7623,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfSomeMembersOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfSomeMembersOf">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfSomeMembersOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCategory"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCategory"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a Category (Type) and a Record Set whose some present or
@@ -8319,8 +7651,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasComponentOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasComponentOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasPartOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadComponent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
@@ -8349,8 +7680,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasConstituentOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasConstituentOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasPartOf"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadConstituent"/>
       <rdfs:domain>
          <owl:Class>
@@ -8393,17 +7723,14 @@
                property in RiC-O 0.1 was "isConstituentOf").</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R003i ('is or was constituent of'
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasContainedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasContainedBy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasPartOf"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#containsOrContained"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
@@ -8429,12 +7756,9 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasContentTypeOfAllMembersOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasContentTypeOfAllMembersOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfAllMembersOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithContentType"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasContentTypeOfAllMembersOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfAllMembersOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithContentType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ContentType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a Content Type and a Record Set whose all past or present
@@ -8459,12 +7783,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasContentTypeOfSomeMembersOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasContentTypeOfSomeMembersOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfSomeMembersOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithContentType"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasContentTypeOfSomeMembersOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfSomeMembersOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithContentType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ContentType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a Content Type and a Record Set whose some past or
@@ -8490,18 +7811,14 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasControllerOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasControllerOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAuthorityOver"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSubordinate"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAuthorityOver"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSubordinate"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadController"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Agent to another Agent it controls or controlled via
          Activities, i.e. controls by function.</rdfs:comment>
@@ -8551,12 +7868,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasCorporateBodyTypeOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasCorporateBodyTypeOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadCorporateBodyType"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasCorporateBodyTypeOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadCorporateBodyType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#CorporateBodyType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#CorporateBody"/>
       <rdfs:comment xml:lang="en">Connects a Corporate Body Type to a Corporate Body that it
@@ -8579,12 +7893,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasCreationDateOfAllMembersOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasCreationDateOfAllMembersOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCreationDate"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasCreationDateOfAllMembersOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithCreationDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a Date to a Record Set all of whose present or past
@@ -8599,7 +7910,6 @@
                record set into account. Adjusted the annotations accordingly.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-09-22</dc:date>
@@ -8616,12 +7926,9 @@
          of' relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasCreationDateOfMostMembersOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasCreationDateOfMostMembersOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCreationDateOfSomeMembersOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadMostMembersWithCreationDate"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasCreationDateOfMostMembersOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCreationDateOfSomeMembersOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadMostMembersWithCreationDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a Date to a Record Set most of whose present or past
@@ -8644,7 +7951,6 @@
                record set into account. Adjusted the annotations accordingly.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-09-22</dc:date>
@@ -8663,12 +7969,9 @@
          of' relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasCreationDateOfSomeMembersOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasCreationDateOfSomeMembersOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCreationDate"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasCreationDateOfSomeMembersOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithCreationDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a Date to a Record Set some of whose present or past
@@ -8699,12 +8002,9 @@
          of' relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasDemographicGroupOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasDemographicGroupOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadDemographicGroup"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasDemographicGroupOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadDemographicGroup"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#DemographicGroup"/>
       <rdfs:range>
          <owl:Class>
@@ -8735,13 +8035,10 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasDerivedFromInstantiation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasDerivedFromInstantiation">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasDerivedFromInstantiation">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInTime"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadDerivedInstantiation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isInstantiationAssociatedWithInstantiation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadDerivedInstantiation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Inverse of 'has or had derived instantiation' object
@@ -8802,12 +8099,9 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasDigitalInstantiationOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasDigitalInstantiationOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasInstantiationOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadDigitalInstantiation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasDigitalInstantiationOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasInstantiationOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadDigitalInstantiation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:comment xml:lang="en">Inverse of 'has or had digital instantiation' object
@@ -8823,12 +8117,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasDocumentaryFormTypeOfAllMembersOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasDocumentaryFormTypeOfAllMembersOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfAllMembersOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithDocumentaryFormType"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasDocumentaryFormTypeOfAllMembersOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfAllMembersOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithDocumentaryFormType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#DocumentaryFormType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a Documentary Form Type and a Record Set whose all past
@@ -8853,12 +8144,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasDocumentaryFormTypeOfSomeMembersOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasDocumentaryFormTypeOfSomeMembersOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfSomeMembersOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMemberswithDocumentaryFormType"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasDocumentaryFormTypeOfSomeMembersOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfSomeMembersOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMemberswithDocumentaryFormType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#DocumentaryFormType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a Documentary Form Type and a Record Set whose some past
@@ -8884,8 +8172,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasEmployerOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasEmployerOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasControllerOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasControllerOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadEmployer"/>
       <rdfs:domain>
          <owl:Class>
@@ -8916,10 +8203,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasEnforcedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasEnforcedBy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasResponsibleForEnforcing"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasResponsibleForEnforcing"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Rule to an Agent that enforces or enforced the
@@ -8946,8 +8231,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasExpressedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasExpressedBy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#expressesOrExpressed"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
@@ -8982,17 +8266,13 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfRecordResourceHoldingRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfRecordResourceHoldingRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Agent to a Record Resource or Instantiation that the
          Agent holds or held.</rdfs:comment>
@@ -9017,12 +8297,9 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasHolderOfIntellectualPropertyRightsOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasHolderOfIntellectualPropertyRightsOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAuthorityOver"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadIntellectualPropertyRightsHolder"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasHolderOfIntellectualPropertyRightsOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAuthorityOver"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadIntellectualPropertyRightsHolder"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -9036,17 +8313,13 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfIntellectualPropertyRightsRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfIntellectualPropertyRightsRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Agent to a Record Resource or Instantiation on which
          the Agent has or had some intellectual property rights.</rdfs:comment>
@@ -9073,8 +8346,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasIdentifierOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasIdentifierOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasAppellationOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasAppellationOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadIdentifier"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Identifier"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
@@ -9101,8 +8373,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasIncludedIn -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasIncludedIn">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasPartOf"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#includesOrIncluded"/>
       <rdfs:domain>
          <owl:Class>
@@ -9148,11 +8419,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfRecordResourceToInstantiationRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfRecordResourceToInstantiationRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'has or had instantiation' object
          property.</rdfs:comment>
@@ -9187,8 +8455,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasJurisdictionOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasJurisdictionOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWithAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadJurisdiction"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
@@ -9263,11 +8530,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasLanguageOfAllMembersOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasLanguageOfAllMembersOf">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasLanguageOfAllMembersOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithLanguage"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithLanguage"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Language"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a Language and a Record Set whose all present or past
@@ -9292,11 +8557,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasLanguageOfSomeMembersOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasLanguageOfSomeMembersOf">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasLanguageOfSomeMembersOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithLanguage"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithLanguage"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Language"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a Language and a Record Set whose some present or past
@@ -9322,16 +8585,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasLeaderOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasLeaderOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasControllerOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasControllerOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadLeader"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfLeadershipRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfLeadershipRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Person to the Group that Person leads or led in the
          past.</rdfs:comment>
@@ -9357,8 +8617,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasLegalStatusOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasLegalStatusOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadLegalStatus"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#LegalStatus"/>
       <rdfs:range>
@@ -9393,12 +8652,9 @@
          it categorized or categorizes.</skos:scopeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasLegalStatusOfAllMembersOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasLegalStatusOfAllMembersOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfAllMembersOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithLegalStatus"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasLegalStatusOfAllMembersOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfAllMembersOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithLegalStatus"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#LegalStatus"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a Legal Status and a Record Set whose all past or present
@@ -9423,12 +8679,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasLegalStatusOfSomeMembersOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasLegalStatusOfSomeMembersOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfSomeMembersOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithLegalStatus"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasLegalStatusOfSomeMembersOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfSomeMembersOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithLegalStatus"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#LegalStatus"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a Legal Status and a Record Set whose some past or
@@ -9454,8 +8707,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasLocationOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasLocationOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadLocation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
@@ -9483,10 +8735,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasLocationOfAgent -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasLocationOfAgent">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasLocationOf"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWithAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasLocationOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHasOrHadLocation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
@@ -9537,24 +8787,20 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasManagerOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasManagerOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAuthorityOver"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAuthorityOver"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadManager"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Agent to a Record Resource or Instantiation that the
          Agent managed or manages.</rdfs:comment>
@@ -9580,16 +8826,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasMemberOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasMemberOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadMember"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfMembershipRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfMembershipRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'has or had member' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -9614,8 +8857,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasNameOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasNameOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasAppellationOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasAppellationOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadName"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Name"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
@@ -9640,12 +8882,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasOccupationTypeOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasOccupationTypeOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasDemographicGroupOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadOccupationOfType"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasOccupationTypeOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasDemographicGroupOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadOccupationOfType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#OccupationType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects an Occupation Type to a Person whose occupation is or was
@@ -9670,17 +8909,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasOccupiedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasOccupiedBy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#occupiesOrOccupied"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsTargetOfPositionHoldingRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsTargetOfPositionHoldingRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'occupies or occupied' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -9705,8 +8940,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasOwnerOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasOwnerOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAuthorityOver"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAuthorityOver"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadOwner"/>
       <rdfs:domain>
          <owl:Class>
@@ -9719,10 +8953,8 @@
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfOwnershipRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfOwnershipRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Group, Person or Position to a Thing that this Agent
          owns or owned.</rdfs:comment>
@@ -9753,10 +8985,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'has or had part' relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -9781,8 +9011,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasParticipantIn -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasParticipantIn">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadParticipant"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
@@ -9810,16 +9039,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasPerformedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasPerformedBy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadParticipant"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadParticipant"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#performsOrPerformed"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#activityIsSourceOfPerformanceRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#activityIsSourceOfPerformanceRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Activity to an Agent that performed or performs the
          Activity.</rdfs:comment>
@@ -9844,12 +9070,9 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasPhysicalLocationOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasPhysicalLocationOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadPhysicalLocation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasPhysicalLocationOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadPhysicalLocation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PhysicalLocation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:comment xml:lang="en">Connects a Physical Location to a Place, when it is or was its
@@ -9907,8 +9130,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasPlaceTypeOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasPlaceTypeOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadPlaceType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PlaceType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
@@ -9933,12 +9155,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasRecordStateOfAllMembersOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasRecordStateOfAllMembersOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfAllMembersOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithRecordState"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasRecordStateOfAllMembersOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfAllMembersOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAllMembersWithRecordState"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordState"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a Record State and a Record Set whose all past or present
@@ -9963,12 +9182,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasRecordStateOfSomeMembersOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasRecordStateOfSomeMembersOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfSomeMembersOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithRecordState"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasRecordStateOfSomeMembersOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOfSomeMembersOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSomeMembersWithRecordState"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordState"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a Record State and a Record Set whose some past or
@@ -9994,8 +9210,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasRegulatedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasRegulatedBy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#regulatesOrRegulated"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
@@ -10022,10 +9237,8 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasResponsibleForEnforcing -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasResponsibleForEnforcing">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasResponsibleForEnforcing">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasEnforcedBy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
@@ -10053,8 +9266,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasRuleTypeOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasRuleTypeOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadRuleType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RuleType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
@@ -10088,17 +9300,13 @@
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasSubdivisionOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasSubdivisionOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasPartOf"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubordinateTo"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubordinateTo"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSubdivision"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfGroupSubdivisionRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfGroupSubdivisionRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'has or had subdivision' object
          property.</rdfs:comment>
@@ -10124,10 +9332,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasSubeventOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasSubeventOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasPartOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSubevent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
@@ -10182,17 +9388,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasSubordinateTo -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasSubordinateTo">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadSubordinate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentHierarchicalRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'has or had subordinate' object
          property.</rdfs:comment>
@@ -10225,8 +9427,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Rule"/>
             </owl:unionOf>
          </owl:Class>
@@ -10252,17 +9453,14 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrWasUnderAuthorityOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasUnderAuthorityOf">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrWasUnderAuthorityOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadAuthorityOver"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'has or had authority over' object
          property.</rdfs:comment>
@@ -10288,8 +9486,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOriginalOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOriginalOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasGeneticLinkToRecordResource"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInTime"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOriginal"/>
       <rdfs:domain>
@@ -10354,10 +9551,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#placeIsSourceOfPlaceRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#placeRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#placeIsSourceOfPlaceRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#placeRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Place to a Thing that Place is associated with the
          existence and lifecycle of.</rdfs:comment>
@@ -10374,12 +9569,9 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWithAgent -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWithAgent">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithPlace"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWithAgent">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithPlace"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Place to an Agent which is related to that
@@ -10401,12 +9593,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isProductionTechniqueTypeOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isProductionTechniqueTypeOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasProductionTechniqueType"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isProductionTechniqueTypeOf">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasProductionTechniqueType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ProductionTechniqueType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects a Production Technique Type to an Instantiation whose
@@ -10436,17 +9625,13 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentOriginationRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">inverse of 'has provenance' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -10463,8 +9648,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isPublicationDateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isPublicationDateOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPublicationDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
@@ -10520,8 +9704,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
@@ -10547,17 +9730,14 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Record Resources. This object property is
          symmetric.</rdfs:comment>
@@ -10575,8 +9755,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isRecordSetTypeOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isRecordSetTypeOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasRecordSetType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSetType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
@@ -10600,8 +9779,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isRecordStateOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isRecordStateOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasRecordState"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordState"/>
       <rdfs:range>
@@ -10653,8 +9831,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#isReplyTo -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isReplyTo">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInTime"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRecordResourceAssociatedWithRecordResource"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasReply"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
@@ -10681,8 +9858,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isRepresentationTypeOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isRepresentationTypeOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasCategoryOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasRepresentationType"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RepresentationType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
@@ -10705,10 +9881,8 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isResponsibleForIssuing -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isResponsibleForIssuing">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isResponsibleForIssuing">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithRule"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#issuedBy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
@@ -10732,10 +9906,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Rule to a Thing that is associated with the existence
          and lifecycle of the Rule.</rdfs:comment>
@@ -10760,8 +9932,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
@@ -10786,16 +9957,14 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Agent"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Relation"/>
             </owl:unionOf>
          </owl:Class>
@@ -10814,17 +9983,12 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isSubdivisionOfTransitive -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isSubdivisionOfTransitive">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubdivisionOf"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isSubordinateToTransitive"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isSubdivisionOfTransitive">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubdivisionOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isSubordinateToTransitive"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSubdivisionTransitive"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSubdivisionTransitive"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:comment xml:lang="en">Connects a Group to the Group it is a direct or indirect
@@ -10841,10 +10005,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isSubeventOfTransitive -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isSubeventOfTransitive">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubeventOf"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubeventOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSubeventTransitive"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
@@ -10862,13 +10024,10 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isSubordinateToTransitive -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isSubordinateToTransitive">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubordinateTo"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isSubordinateToTransitive">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubordinateTo"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSubordinateTransitive"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSubordinateTransitive"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects an Agent to an Agent that is directly or indirectly
@@ -10886,16 +10045,13 @@
    <!-- https://www.ica.org/standards/RiC/ontology#isSuccessorOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isSuccessorOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInTime"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSuccessor"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'has successor' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -10969,10 +10125,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isWithin -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isWithin">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasPartOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasWithin"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
@@ -10999,10 +10153,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#issuedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#issuedBy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isResponsibleForIssuing"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isResponsibleForIssuing"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Rule to the Agent that issued or published the
@@ -11020,14 +10172,10 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfKnowingOfRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfKnowingOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#KnowingOfRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Knowing Of Relation to a 'knowing of' Person (a Person
@@ -11036,14 +10184,10 @@
       <rdfs:label xml:lang="en">knowing of relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfKnowingOfRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfKnowingOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#KnowingOfRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Knowing Of Relation to a 'known by' Person (a Person on
@@ -11052,12 +10196,9 @@
       <rdfs:label xml:lang="en">knowing of relation has target</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#knowingRelationConnects -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#KnowingRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects Knowing Relation to any known Person
@@ -11067,16 +10208,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#knownBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#knownBy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#knowsOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfKnowingOfRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfKnowingOfRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'knows of' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -11093,16 +10231,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#knows -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#knows">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects two Persons that directly know each other during their
          existence. This object property is symmetric.</rdfs:comment>
@@ -11120,16 +10255,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#knowsOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#knowsOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#knownBy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfKnowingOfRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfKnowingOfRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Person to another Person they have some knowledge of
          through time or space.</rdfs:comment>
@@ -11146,12 +10278,9 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfLeadershipRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfLeadershipRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#LeadershipRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Leadership Relation to a Person who is involved as a
@@ -11160,12 +10289,9 @@
       <rdfs:label xml:lang="en">leadership relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfLeadershipRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfLeadershipRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#LeadershipRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:comment xml:lang="en">Connects a Leadership Relation to a lead Group.</rdfs:comment>
@@ -11174,10 +10300,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#leadershipWithPosition -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#leadershipWithPosition">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#positionIsContextOfLeadershipRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#positionIsContextOfLeadershipRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#LeadershipRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:comment xml:lang="en">Connects a Leadership Relation to the Position occupied by the
@@ -11193,12 +10317,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#managementRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfManagementRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ManagementRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Management Relation to an Agent who is involved as a
@@ -11207,19 +10328,15 @@
       <rdfs:label xml:lang="en">management relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ManagementRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
@@ -11229,12 +10346,9 @@
       <rdfs:label xml:lang="en">management relation has target</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#mandateIsSourceOfMandateRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#mandateIsSourceOfMandateRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#mandateIsSourceOfMandateRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Mandate"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
       <rdfs:comment xml:lang="en">Connects a Mandate to a Mandate Relation.</rdfs:comment>
@@ -11242,12 +10356,9 @@
       <rdfs:label xml:lang="en">mandate is source of mandate relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateIsSourceOfMandateRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateIsSourceOfMandateRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Mandate"/>
       <rdfs:comment xml:lang="en">Connects a Mandate Relation to a Mandate.</rdfs:comment>
@@ -11255,12 +10366,9 @@
       <rdfs:label xml:lang="en">mandate relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfMandateRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfMandateRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#MandateRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Mandate Relation to an Agent who is given the authority
@@ -11269,14 +10377,10 @@
       <rdfs:label xml:lang="en">mandate relation has target</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfMembershipRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsSourceOfMembershipRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#MembershipRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:comment xml:lang="en">Connects a Membership Relation to the Group that has
@@ -11285,14 +10389,10 @@
       <rdfs:label xml:lang="en">membership relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfMembershipRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfMembershipRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#MembershipRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Membership Relation to a Person who is involved as a
@@ -11302,10 +10402,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#membershipWithPosition -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#membershipWithPosition">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#positionIsContextOfMembershipRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#positionIsContextOfMembershipRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#MembershipRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:comment xml:lang="en">Connects a Membership Relation to the Position occupied by the
@@ -11322,16 +10420,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#migratedFrom -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#migratedFrom">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasDerivedFromInstantiation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasDerivedFromInstantiation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#migratedInto"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfMigrationRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfMigrationRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'migrated into' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -11364,16 +10459,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#migratedInto -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#migratedInto">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadDerivedInstantiation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrHadDerivedInstantiation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#migratedFrom"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfMigrationRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfMigrationRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects an Instantiation to a version it has been migrated
          to.</rdfs:comment>
@@ -11406,12 +10498,9 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfMigrationRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsSourceOfMigrationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#MigrationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects a Migration Relation to the migrated
@@ -11420,12 +10509,9 @@
       <rdfs:label xml:lang="en">migration relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfMigrationRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfMigrationRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#MigrationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects a Migration Relation to a resulting
@@ -11435,17 +10521,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#occupiesOrOccupied -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#occupiesOrOccupied">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAgentAssociatedWithAgent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasOccupiedBy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfPositionHoldingRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget"
-         />
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfPositionHoldingRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Person to a Position they occupy or
          occupied.</rdfs:comment>
@@ -11471,10 +10553,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#occurredAtDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#occurredAtDate">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateOfOccurrenceOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
@@ -11502,10 +10582,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#overlapsOrOverlapped -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#overlapsOrOverlapped">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithPlace"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPlaceAssociatedWith"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
@@ -11532,12 +10610,9 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfOwnershipRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfOwnershipRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#OwnershipRelation"/>
       <rdfs:range>
          <owl:Class>
@@ -11554,12 +10629,9 @@
       <rdfs:label xml:lang="en">ownership relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfOwnershipRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfOwnershipRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#OwnershipRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an Ownership Relation to a Thing that is
@@ -11568,12 +10640,9 @@
       <rdfs:label xml:lang="en">owner ship relation has target</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#activityIsSourceOfPerformanceRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#activityIsSourceOfPerformanceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PerformanceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
       <rdfs:comment xml:lang="en">Connects a Performance Relation to a performed
@@ -11582,12 +10651,9 @@
       <rdfs:label xml:lang="en">performance relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfPerformanceRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfPerformanceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PerformanceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Performance Relation to a performing
@@ -11597,16 +10663,13 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#performsOrPerformed -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#performsOrPerformed">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasParticipantIn"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasParticipantIn"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasPerformedBy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfPerformanceRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfPerformanceRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is or was performed by' object
          property.</rdfs:comment>
@@ -11631,12 +10694,9 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personHasCorrespondenceRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#personHasCorrespondenceRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personHasCorrespondenceRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#CorrespondenceRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person to a Correspondence Relation.</rdfs:comment>
@@ -11644,12 +10704,9 @@
       <rdfs:label xml:lang="en">person has correspondence relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#FamilyRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person to a Family Relation.</rdfs:comment>
@@ -11657,12 +10714,9 @@
       <rdfs:label xml:lang="en">person has family relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#KnowingRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person to a Knowing Relation.</rdfs:comment>
@@ -11670,12 +10724,9 @@
       <rdfs:label xml:lang="en">person has knowing relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personHasSiblingRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSiblingRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#siblingRelationConnects"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSiblingRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#siblingRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#SiblingRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person to a Sibling Relation.</rdfs:comment>
@@ -11683,12 +10734,9 @@
       <rdfs:label xml:lang="en">person has sibling relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personHasSpouseRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSpouseRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#spouseRelationConnects"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personHasSpouseRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#spouseRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#SpouseRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person to a Spouse Relation.</rdfs:comment>
@@ -11696,12 +10744,9 @@
       <rdfs:label xml:lang="en">person has spouse relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsSourceOfChildRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfChildRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#childRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfChildRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#childRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ChildRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (as a parent) to a Child
@@ -11710,14 +10755,10 @@
       <rdfs:label xml:lang="en">person is source of child relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfDescendanceRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentTemporalRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#DescendanceRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (as an ancestor) to a Descendance
@@ -11726,14 +10767,10 @@
       <rdfs:label xml:lang="en">person is source of descendance relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsSourceOfKnowingOfRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfKnowingOfRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfKnowingOfRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#KnowingOfRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (who has some knowledge of another one) to a
@@ -11742,12 +10779,9 @@
       <rdfs:label xml:lang="en">person is source of knowing of relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsSourceOfLeadershipRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfLeadershipRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfLeadershipRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfAgentControlRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#LeadershipRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (as a leader) to a Leadership
@@ -11756,14 +10790,10 @@
       <rdfs:label xml:lang="en">person is source of leadership relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsSourceOfPositionHoldingRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfPositionHoldingRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfPositionHoldingRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PositionHoldingRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (who occupies a Position) to a Position Holding
@@ -11772,14 +10802,10 @@
       <rdfs:label xml:lang="en">person is source of position holding relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsSourceOfTeachingRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfTeachingRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsSourceOfTeachingRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#TeachingRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (as a teacher) to a Teaching
@@ -11788,12 +10814,9 @@
       <rdfs:label xml:lang="en">person is source of teaching relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsTargetOfChildRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfChildRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#childRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfChildRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#childRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ChildRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (as a child) to a Child Relation.</rdfs:comment>
@@ -11801,14 +10824,10 @@
       <rdfs:label xml:lang="en">person is target of child relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfDescendanceRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsTargetOfAgentTemporalRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasFamilyRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#DescendanceRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (as a descendant) to a Descendance
@@ -11817,14 +10836,10 @@
       <rdfs:label xml:lang="en">person is target of descendance relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsTargetOfKnowingOfRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfKnowingOfRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfKnowingOfRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#KnowingOfRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (of which another Person has some knowledge) to
@@ -11833,14 +10848,10 @@
       <rdfs:label xml:lang="en">person is target of knowing of relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsTargetOfMembershipRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfMembershipRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfMembershipRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#MembershipRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (as a member of a Group) to a Membership
@@ -11849,14 +10860,10 @@
       <rdfs:label xml:lang="en">person is target of membership relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#personIsTargetOfTeachingRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfTeachingRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#personIsTargetOfTeachingRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasKnowingRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#TeachingRelation"/>
       <rdfs:comment xml:lang="en">Connects a Person (as a student) to a Teaching
@@ -11865,12 +10872,9 @@
       <rdfs:label xml:lang="en">person is target of teaching relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#placeIsSourceOfPlaceRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#placeIsSourceOfPlaceRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#placeRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#placeIsSourceOfPlaceRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#placeRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PlaceRelation"/>
       <rdfs:comment xml:lang="en">Connects a Place (as associated to a Thing) to a Place
@@ -11880,10 +10884,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#placeRelationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#placeRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#placeIsSourceOfPlaceRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#placeIsSourceOfPlaceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PlaceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:comment xml:lang="en">Connects a Place Relation to the Place concerned.</rdfs:comment>
@@ -11892,10 +10894,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#placeRelationHasTarget -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#placeRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfPlaceRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfPlaceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PlaceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Place Relation to a Thing that is associated to the
@@ -11904,14 +10904,10 @@
       <rdfs:label xml:lang="en">place relation has target</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfPositionHoldingRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfPositionHoldingRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PositionHoldingRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Position Holding Relation to a Person (who occupies a
@@ -11920,14 +10916,10 @@
       <rdfs:label xml:lang="en">position holding relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#positionIsTargetOfPositionHoldingRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#positionIsTargetOfPositionHoldingRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PositionHoldingRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:comment xml:lang="en">Connects a Position Holding Relation to a Position (that is
@@ -11936,12 +10928,9 @@
       <rdfs:label xml:lang="en">position holding relation has target</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionIsContextOfLeadershipRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsContextOfLeadershipRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipWithPosition"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsContextOfLeadershipRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipWithPosition"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#LeadershipRelation"/>
       <rdfs:comment xml:lang="en">Connects a Position to a Leadership Relation (the leading Person
@@ -11950,12 +10939,9 @@
       <rdfs:label xml:lang="en">position is context of leadership relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionIsContextOfMembershipRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsContextOfMembershipRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipWithPosition"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsContextOfMembershipRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipWithPosition"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#MembershipRelation"/>
       <rdfs:comment xml:lang="en">Connects a Position to a Membership Relation (the member Person
@@ -11964,14 +10950,10 @@
       <rdfs:label xml:lang="en">position is context of membership relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionIsSourceOfPositionToGroupRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsSourceOfPositionToGroupRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsSourceOfPositionToGroupRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PositionToGroupRelation"/>
       <rdfs:comment xml:lang="en">Connects a Position (that exists within a Group) to a Position to
@@ -11980,14 +10962,10 @@
       <rdfs:label xml:lang="en">position is source of position to group relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionIsTargetOfPositionHoldingRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsTargetOfPositionHoldingRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionIsTargetOfPositionHoldingRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsConnectedToAgentRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PositionHoldingRelation"/>
       <rdfs:comment xml:lang="en">Connects a Position (that is occupied by a Person) to a Position
@@ -11996,14 +10974,10 @@
       <rdfs:label xml:lang="en">position is target of position holding relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#positionIsSourceOfPositionToGroupRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#positionIsSourceOfPositionToGroupRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PositionToGroupRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
       <rdfs:comment xml:lang="en">Connects a Position to Group Relation to a Position (that exists
@@ -12012,14 +10986,10 @@
       <rdfs:label xml:lang="en">position to group relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfPositionToGroupRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#groupIsTargetOfPositionToGroupRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#PositionToGroupRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
       <rdfs:comment xml:lang="en">Connects a Position to Group Relation to a Group (in which a
@@ -12029,8 +10999,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#precededInSequence -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#precededInSequence">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesOrPreceded"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesOrPreceded"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followedInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
@@ -12054,13 +11023,10 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#precedesInSequenceTransitive -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#precedesInSequenceTransitive">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesOrPreceded"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#precedesInSequenceTransitive">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesOrPreceded"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInSequenceTransitive"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInSequenceTransitive"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Thing to a Thing that follows it directly or indirectly
@@ -12084,17 +11050,14 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#precedesInTime -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#precedesInTime">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesOrPreceded"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesOrPreceded"/>
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInTime"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Thing to a Thing that follows it in chronological
          order. This is a transitive relation.</rdfs:comment>
@@ -12132,10 +11095,8 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Thing to a Thing that follows or followed it in some
          sequence.</rdfs:comment>
@@ -12165,19 +11126,15 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ProvenanceRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
@@ -12187,12 +11144,9 @@
       <rdfs:label xml:lang="en">provenance relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOrActivityIsTargetOfProvenanceRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#ProvenanceRelation"/>
       <rdfs:range>
          <owl:Class>
@@ -12242,12 +11196,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordIsSourceOfAuthorshipRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordIsSourceOfAuthorshipRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfCreationRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorshipRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordIsSourceOfAuthorshipRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfCreationRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorshipRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Record"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorshipRelation"/>
       <rdfs:comment xml:lang="en">Connects a Record and an Authorship Relation.</rdfs:comment>
@@ -12262,14 +11213,10 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceGeneticRelationConnects -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceGeneticRelationConnects">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceGeneticRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceGeneticRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceGeneticRelationConnects">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceGeneticRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceGeneticRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource Genetic Relation to one of the
          associated Record Resources.</rdfs:comment>
@@ -12277,14 +11224,10 @@
       <rdfs:label xml:lang="en">record resource genetic relation connects</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfRecordResourceHoldingRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentIsSourceOfRecordResourceHoldingRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource Holding Relation to an Agent (as the
          holder of a Record Resource or Instantiation).</rdfs:comment>
@@ -12292,20 +11235,15 @@
       <rdfs:label xml:lang="en">record resource holding relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfRecordResourceHoldingRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfRecordResourceHoldingRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
@@ -12315,15 +11253,11 @@
       <rdfs:label xml:lang="en">record resource holding relation has target</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceGeneticRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceGeneticRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceGeneticRelationConnects"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceGeneticRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceGeneticRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-      <rdfs:range
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceGeneticRelation"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceGeneticRelation"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource to a Record Resource Genetic
          Relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -12331,15 +11265,11 @@
       </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-      <rdfs:range
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource to a Record Resource
          Relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -12347,15 +11277,11 @@
       </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceIsSourceOfRecordResourceToInstantiationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsSourceOfRecordResourceToInstantiationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceIsSourceOfRecordResourceToInstantiationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-      <rdfs:range
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource (that was instantiated) to a Record
          Resource To Instantiation Relation</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -12363,18 +11289,14 @@
          relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAccumulationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAccumulationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAccumulationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -12386,23 +11308,18 @@
          relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfActivityDocumentationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfActivityDocumentationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfActivityDocumentationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasSource"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
-      <rdfs:range
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityDocumentationRelation"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource or Instantiation (that documents an
          Activity) to an Activity Documentation Relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -12410,18 +11327,14 @@
          relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -12433,18 +11346,14 @@
          relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfCreationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfCreationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfCreationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfAgentOriginationRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -12456,18 +11365,14 @@
       </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsSourceOfProvenanceRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -12479,23 +11384,18 @@
       </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfIntellectualPropertyRightsRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfIntellectualPropertyRightsRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfIntellectualPropertyRightsRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
-      <rdfs:range
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource or Instantiation (on which some
          intellectual property rights are held) to an Intellectual Property Rights
          Relation.</rdfs:comment>
@@ -12504,18 +11404,14 @@
          rights relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -12527,23 +11423,18 @@
       </rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfRecordResourceHoldingRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfRecordResourceHoldingRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfRecordResourceHoldingRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceOrInstantiationIsTargetOfManagementRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
-      <rdfs:range
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceHoldingRelation"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource or Instantiation (that is held by an
          Agent) to a Record Resource Holding Relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -12551,13 +11442,10 @@
          holding relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationConnects"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceIsConnectedToRecordResourceRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource relation to one of the related Record
          Resources.</rdfs:comment>
@@ -12565,14 +11453,10 @@
       <rdfs:label xml:lang="en">record resource relation connects</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceIsSourceOfRecordResourceToInstantiationRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceIsSourceOfRecordResourceToInstantiationRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource To Instantiation Relation to the Record
          Resource (that was instantiated). </rdfs:comment>
@@ -12580,14 +11464,10 @@
       <rdfs:label xml:lang="en">record resource to instantiation relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfRecordResourceToInstantiationRelation"/>
-      <rdfs:domain
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationIsTargetOfRecordResourceToInstantiationRelation"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:comment xml:lang="en">Connects a Record Resource To Instantiation Relation to an
          Instantiation of the involved Record Resource. </rdfs:comment>
@@ -12596,8 +11476,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#regulatesOrRegulated -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#regulatesOrRegulated">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRuleAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasRegulatedBy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
@@ -12626,8 +11505,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#relationConnects -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#relationConnects">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an n-ary Relation to any of the Things
@@ -12645,8 +11523,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#relationHasContext -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasContext">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationConnects"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an n-ary Relation to a Thing that is a secondary,
@@ -12666,8 +11543,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#relationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasSource">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationConnects"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an n-ary Relation to a Thing that is its
@@ -12685,8 +11561,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#relationHasTarget -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasTarget">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationConnects"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects an n-ary Relation to a Thing that is its
@@ -12702,8 +11577,7 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#resultedFromTheMergerOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#resultedFromTheMergerOf">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#resultedFromTheMergerOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isSuccessorOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasMergedInto"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#CorporateBody"/>
@@ -12739,8 +11613,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#resultsOrResultedFrom -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#resultsOrResultedFrom">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithEvent"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#resultsOrResultedIn"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
@@ -12768,8 +11641,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#resultsOrResultedIn -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#resultsOrResultedIn">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isEventAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#resultsOrResultedFrom"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
@@ -12796,10 +11668,8 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#roleIsContextOfCreationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#roleIsContextOfCreationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#roleIsContextOfCreationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#creationWithRole"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RoleType"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#CreationRelation"/>
@@ -12817,10 +11687,8 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RuleRelation"/>
@@ -12830,10 +11698,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleIsSourceOfRuleRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RuleRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
       <rdfs:comment xml:lang="en">Connects a Rule Relation to a Rule.</rdfs:comment>
@@ -12842,10 +11708,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RuleRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Rule Relation to a Thing (that is associated to a
@@ -12854,12 +11718,9 @@
       <rdfs:label xml:lang="en">rule relation has target</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#SequentialRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Sequential Relation to a Thing that precedes other
@@ -12868,12 +11729,9 @@
       <rdfs:label xml:lang="en">sequential relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#SequentialRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Sequential Relation to a Thing that follows other
@@ -12882,12 +11740,9 @@
       <rdfs:label xml:lang="en">sequential relation has target</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#siblingRelationConnects -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#siblingRelationConnects">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasSiblingRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#siblingRelationConnects">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasSiblingRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#SiblingRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Sibling Relation to one of the siblings
@@ -12897,10 +11752,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#spouseRelationConnects -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#spouseRelationConnects">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasSpouseRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personHasSpouseRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#SpouseRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Sibling Relation to one of the spouses
@@ -12909,14 +11762,10 @@
       <rdfs:label xml:lang="en">spouse relation connects</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfTeachingRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsSourceOfTeachingRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#TeachingRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Teaching Relation to a Person (who is a
@@ -12925,14 +11774,10 @@
       <rdfs:label xml:lang="en">teaching relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfTeachingRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#personIsTargetOfTeachingRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#TeachingRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:comment xml:lang="en">Connects a Teaching Relation to a Person (who is a
@@ -12941,12 +11786,9 @@
       <rdfs:label xml:lang="en">teaching relation has target</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#TemporalRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Temporal Relation to a Thing that precedes other
@@ -12955,12 +11797,9 @@
       <rdfs:label xml:lang="en">temporal relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#TemporalRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Temporal Relation to a Thing that follows other
@@ -12969,8 +11808,7 @@
       <rdfs:label xml:lang="en">temporal relation has target</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationConnects"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
@@ -12980,10 +11818,8 @@
       <rdfs:label xml:lang="en">thing is connected to relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
@@ -12993,10 +11829,8 @@
       <rdfs:label xml:lang="en">thing is context of relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
@@ -13006,12 +11840,9 @@
       <rdfs:label xml:lang="en">thing is source of relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#SequentialRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing to a Sequential Relation, when this Thing
@@ -13020,12 +11851,9 @@
       <rdfs:label xml:lang="en">thing is source of sequential relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfTemporalRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfSequentialRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#TemporalRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing to a Temporal Relation, when this Thing precedes
@@ -13034,12 +11862,9 @@
       <rdfs:label xml:lang="en">thing is source of temporal relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#WholePartRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing to a Whole Part Relation, when this Thing has
@@ -13048,12 +11873,9 @@
       <rdfs:label xml:lang="en">thing is source of whole part relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAppellationRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAppellationRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAppellationRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AppellationRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing (that is designated by an Appellation) to an
@@ -13062,12 +11884,9 @@
       <rdfs:label xml:lang="en">thing is target of appellation relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorityRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing (that is under authority of an Agent) to an
@@ -13076,12 +11895,9 @@
       <rdfs:label xml:lang="en">thing is target of authority relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfEventRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfEventRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#eventRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfEventRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#eventRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#EventRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing (that is associated with an Event) to an Event
@@ -13090,12 +11906,9 @@
       <rdfs:label xml:lang="en">thing is target of event relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfOwnershipRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfOwnershipRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfOwnershipRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfAuthorityRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#OwnershipRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing (that is owned by a Group, a Person or a
@@ -13104,12 +11917,9 @@
       <rdfs:label xml:lang="en">thing is target of ownership relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfPlaceRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfPlaceRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#placeRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfPlaceRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#placeRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#PlaceRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing (that is associated with a Place) to a Place
@@ -13118,10 +11928,8 @@
       <rdfs:label xml:lang="en">thing is target of place relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsConnectedToRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
@@ -13130,10 +11938,8 @@
       <rdfs:label xml:lang="en">thing is target of relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRuleRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RuleRelation"/>
@@ -13143,12 +11949,9 @@
       <rdfs:label xml:lang="en">thing is target of rule relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#SequentialRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing (that follows other Thing(s) in a sequence) to a
@@ -13157,12 +11960,9 @@
       <rdfs:label xml:lang="en">thing is target of sequential relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTemporalRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfSequentialRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#TemporalRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing (that follows other Thing(s) in time) to a
@@ -13171,10 +11971,8 @@
       <rdfs:label xml:lang="en">thing is target of temporal relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTypeRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTypeRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTypeRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#typeRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#TypeRelation"/>
@@ -13184,12 +11982,9 @@
       <rdfs:label xml:lang="en">thing is target of type relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfRelation"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#WholePartRelation"/>
       <rdfs:comment xml:lang="en">Connects a Thing to a Whole Part Relation, when this Thing is Part
@@ -13198,10 +11993,8 @@
       <rdfs:label xml:lang="en">thing is target of whole part relation</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#typeIsSourceOfTypeRelation -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#typeIsSourceOfTypeRelation">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#typeIsSourceOfTypeRelation">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#typeRelationHasSource"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#TypeRelation"/>
@@ -13211,10 +12004,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#typeRelationHasSource -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#typeRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#typeIsSourceOfTypeRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#typeIsSourceOfTypeRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#TypeRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:comment xml:lang="en">Connects a Type Relation to the Type (that categorizes the
@@ -13224,10 +12015,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#typeRelationHasTarget -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#typeRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTypeRelation"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfTypeRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#TypeRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Type Relation to a Thing (that is categorized by the
@@ -13237,8 +12026,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#wasComponentOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#wasComponentOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasComponentOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasComponentOf"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasPartOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hadComponent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
@@ -13258,8 +12046,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#wasConstituentOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#wasConstituentOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasConstituentOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasConstituentOf"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasPartOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hadConstituent"/>
       <rdfs:domain>
@@ -13299,8 +12086,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#wasContainedBy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#wasContainedBy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasContainedBy"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasContainedBy"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasPartOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#contained"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
@@ -13319,8 +12105,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#wasIncludedIn -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#wasIncludedIn">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasIncludedIn"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasIncludedIn"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasPartOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#included"/>
       <rdfs:domain>
@@ -13347,8 +12132,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#wasLastUpdatedAtDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#wasLastUpdatedAtDate">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasModificationDate"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasModificationDate"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isLastUpdateDateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
@@ -13367,8 +12151,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#wasMergedInto -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#wasMergedInto">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSuccessor"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#resultedFromTheMergerOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#resultedFromTheMergerOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#CorporateBody"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#CorporateBody"/>
       <rdfs:comment xml:lang="en">Connects a Corporate Body to another Corporate Body that is the
@@ -13405,8 +12188,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#wasSplitInto -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#wasSplitInto">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasSuccessor"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#resultedFromTheSplitOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#resultedFromTheSplitOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#CorporateBody"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#CorporateBody"/>
       <rdfs:comment xml:lang="en">Connects a Corporate Body to one of the Corporate Bodies that
@@ -13425,8 +12207,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#wasSubdivisionOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#wasSubdivisionOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubdivisionOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubdivisionOf"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasPartOf"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasSubordinateTo"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hadSubdivision"/>
@@ -13446,8 +12227,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#wasSubeventOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#wasSubeventOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubeventOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubeventOf"/>
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#wasPartOf"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hadSubevent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
@@ -13467,8 +12247,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#wasSubordinateTo -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#wasSubordinateTo">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubordinateTo"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasSubordinateTo"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hadSubordinate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
@@ -13533,12 +12312,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfWholePartRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#WholePartRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Whole Part Relation to the Thing that has some
@@ -13547,12 +12323,9 @@
       <rdfs:label xml:lang="en">whole part relation has source</rdfs:label>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasTarget"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsTargetOfWholePartRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#WholePartRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Connects a Whole Part Relation to a Thing that is a
@@ -13562,8 +12335,7 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#workRelationConnects -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#workRelationConnects">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHasWorkRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#WorkRelation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
@@ -13587,6 +12359,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">accroissement</rdfs:label>
       <rdfs:label xml:lang="en">accrual</rdfs:label>
+      <rdfs:label xml:lang="es">ingreso</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -13605,6 +12384,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">accrual status</rdfs:label>
       <rdfs:label xml:lang="fr">statut de l’accroissement</rdfs:label>
+      <rdfs:label xml:lang="es">estado del ingreso</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-11-01</dc:date>
@@ -13635,6 +12421,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">altimetric system</rdfs:label>
       <rdfs:label xml:lang="fr">système altimétrique</rdfs:label>
+      <rdfs:label xml:lang="es">sistema altimétrico</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -13652,6 +12445,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">altitude</rdfs:label>
       <rdfs:label xml:lang="fr">altitude</rdfs:label>
+      <rdfs:label xml:lang="es">altitud</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -13667,8 +12467,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -13679,6 +12478,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">authenticity note</rdfs:label>
       <rdfs:label xml:lang="fr">note sur l’authenticité</rdfs:label>
+      <rdfs:label xml:lang="es">nota de autenticidad</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -13716,6 +12522,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">authorizing mandate</rdfs:label>
       <rdfs:label xml:lang="fr">mandat</rdfs:label>
+      <rdfs:label xml:lang="es">norma de control</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -13735,6 +12548,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">beginning date</rdfs:label>
       <rdfs:label xml:lang="fr">date de début</rdfs:label>
+      <rdfs:label xml:lang="es">fecha de inicio</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -13755,6 +12575,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">birth date</rdfs:label>
       <rdfs:label xml:lang="fr">date de naissance</rdfs:label>
+      <rdfs:label xml:lang="es">fecha de nacimiento</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -13768,8 +12595,7 @@
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#carrierExtent -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#carrierExtent">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Number of physical units and/or physical dimensions of the carrier
@@ -13780,6 +12606,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">carrier extent</rdfs:label>
       <rdfs:label xml:lang="fr">mesure du support</rdfs:label>
+      <rdfs:label xml:lang="es">extensión del soporte</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -13823,6 +12656,13 @@
          Relation.</rdfs:comment>
       <rdfs:label xml:lang="en">certainty</rdfs:label>
       <rdfs:label xml:lang="fr">degré de certitude</rdfs:label>
+      <rdfs:label xml:lang="es">certeza</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-10-14</dc:date>
@@ -13847,6 +12687,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">classification</rdfs:label>
       <rdfs:label xml:lang="fr">classification</rdfs:label>
+      <rdfs:label xml:lang="es">clasificación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -13879,8 +12726,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -13894,6 +12740,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">conditions d’accès</rdfs:label>
       <rdfs:label xml:lang="en">conditions of access</rdfs:label>
+      <rdfs:label xml:lang="es">condiciones de acceso</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -13927,8 +12780,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -13940,6 +12792,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">conditions d’utilisation</rdfs:label>
       <rdfs:label xml:lang="en">conditions of use</rdfs:label>
+      <rdfs:label xml:lang="es">condiciones de uso</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-11-01</dc:date>
@@ -13970,6 +12829,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">creation date</rdfs:label>
       <rdfs:label xml:lang="fr">date de création</rdfs:label>
+      <rdfs:label xml:lang="es">fecha de creación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -13990,6 +12856,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">date</rdfs:label>
       <rdfs:label xml:lang="fr">date</rdfs:label>
+      <rdfs:label xml:lang="es">fecha</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14011,6 +12884,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">date qualifier</rdfs:label>
       <rdfs:label xml:lang="fr">qualificatif de la date</rdfs:label>
+      <rdfs:label xml:lang="es">calificador de fecha</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14052,6 +12932,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">date de décès</rdfs:label>
       <rdfs:label xml:lang="en">death date</rdfs:label>
+      <rdfs:label xml:lang="es">fecha de muerte</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14072,6 +12959,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">descriptive note</rdfs:label>
       <rdfs:label xml:lang="fr">note descriptive</rdfs:label>
+      <rdfs:label xml:lang="es">nota descriptiva</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14116,6 +13010,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">date de fin</rdfs:label>
       <rdfs:label xml:lang="en">end date</rdfs:label>
+      <rdfs:label xml:lang="es">fecha final</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14141,6 +13042,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">date en langage naturel</rdfs:label>
       <rdfs:label xml:lang="en">expressed date</rdfs:label>
+      <rdfs:label xml:lang="es">fecha expresada</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-10-10</dc:date>
@@ -14189,6 +13097,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">geodesic system</rdfs:label>
       <rdfs:label xml:lang="fr">système géodésique</rdfs:label>
+      <rdfs:label xml:lang="es">sistema geodésico</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14197,8 +13112,7 @@
       </skos:changeNote>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#geographicalCoordinates -->
-   <owl:DatatypeProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#geographicalCoordinates">
+   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#geographicalCoordinates">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Longitudinal and latitudinal information of a
@@ -14206,6 +13120,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">coordonnées géographiques</rdfs:label>
       <rdfs:label xml:lang="en">geographical coordinates</rdfs:label>
+      <rdfs:label xml:lang="es">coordenadas geográficas</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-11-01</dc:date>
@@ -14244,6 +13165,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">hauteur</rdfs:label>
       <rdfs:label xml:lang="en">height</rdfs:label>
+      <rdfs:label xml:lang="es">altura</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14261,8 +13189,7 @@
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Event"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Place"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Rule"/>
             </owl:unionOf>
          </owl:Class>
@@ -14273,6 +13200,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">histoire</rdfs:label>
       <rdfs:label xml:lang="en">history</rdfs:label>
+      <rdfs:label xml:lang="es">historia</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-11-01</dc:date>
@@ -14312,6 +13246,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">identifiant</rdfs:label>
       <rdfs:label xml:lang="en">identifier</rdfs:label>
+      <rdfs:label xml:lang="es">identificador</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14344,8 +13285,7 @@
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationExtent -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationExtent">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Countable characteristics of the Instantiation expressed as a
@@ -14353,6 +13293,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Instantiation extent</rdfs:label>
       <rdfs:label xml:lang="fr">mesure de l’instanciation</rdfs:label>
+      <rdfs:label xml:lang="es">soporte de instanciación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14378,8 +13325,7 @@
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#instantiationStructure -->
-   <owl:DatatypeProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationStructure">
+   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#instantiationStructure">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#structure"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
@@ -14388,6 +13334,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Instantiation structure</rdfs:label>
       <rdfs:label xml:lang="fr">structure de l’instanciation</rdfs:label>
+      <rdfs:label xml:lang="es">estructura de la instanciación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14410,8 +13363,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -14421,6 +13373,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">integrity</rdfs:label>
       <rdfs:label xml:lang="fr">intégrité</rdfs:label>
+      <rdfs:label xml:lang="es">integridad</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14453,6 +13412,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">date de dernière modification</rdfs:label>
       <rdfs:label xml:lang="en">last modification date</rdfs:label>
+      <rdfs:label xml:lang="es">fecha de última modificación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14473,6 +13439,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">latitude</rdfs:label>
       <rdfs:label xml:lang="fr">latitude</rdfs:label>
+      <rdfs:label xml:lang="es">latitud</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14510,6 +13483,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">localisation</rdfs:label>
       <rdfs:label xml:lang="en">location</rdfs:label>
+      <rdfs:label xml:lang="es">localización</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-11-01</dc:date>
@@ -14542,6 +13522,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">longitude</rdfs:label>
       <rdfs:label xml:lang="fr">longitude</rdfs:label>
+      <rdfs:label xml:lang="es">longitud</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14560,6 +13547,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">measure</rdfs:label>
       <rdfs:label xml:lang="fr">mesure</rdfs:label>
+      <rdfs:label xml:lang="es">medida</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14576,6 +13570,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">date de modification</rdfs:label>
       <rdfs:label xml:lang="en">modification date</rdfs:label>
+      <rdfs:label xml:lang="es">fecha de modificación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14598,6 +13599,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">name</rdfs:label>
       <rdfs:label xml:lang="fr">nom</rdfs:label>
+      <rdfs:label xml:lang="es">nombre</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-11-01</dc:date>
@@ -14636,6 +13644,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">normalized date value</rdfs:label>
       <rdfs:label xml:lang="fr">valeur normalisée de la date</rdfs:label>
+      <rdfs:label xml:lang="es">valor normalizado de fecha</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-10-10</dc:date>
@@ -14657,25 +13672,16 @@
          </rdf:Description>
       </skos:changeNote>
       <skos:example>1948-03-03</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >1948-03</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >1948-03-08</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >1948-03~</skos:example>
+      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">1948-03</skos:example>
+      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">1948-03-08</skos:example>
+      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">1948-03~</skos:example>
       <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">1948/</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >1948/..</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >2012-02-14/2015-03-08</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >2012/2015-03</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >[1550,1551,1553,1555]</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >{1550,1151,1553,1555}</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >{1805,1815..1820}</skos:example>
+      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">1948/..</skos:example>
+      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">2012-02-14/2015-03-08</skos:example>
+      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">2012/2015-03</skos:example>
+      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">[1550,1551,1553,1555]</skos:example>
+      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">{1550,1151,1553,1555}</skos:example>
+      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">{1805,1815..1820}</skos:example>
       <skos:scopeNote xml:lang="en">Used to represent the date in a standardized format that can be
          processed programmatically. The main standard used today is ISO 8601, which is based on the
          Gregorian calendar. See also the Extended Date Time Format (EDTF), which is an extension of
@@ -14701,6 +13707,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">normalized value</rdfs:label>
       <rdfs:label xml:lang="fr">valeur normalisée</rdfs:label>
+      <rdfs:label xml:lang="es">valor normalizado</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14709,8 +13722,7 @@
       </skos:changeNote>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#physicalCharacteristics -->
-   <owl:DatatypeProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#physicalCharacteristics">
+   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#physicalCharacteristics">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Information about the physical features of the Instantiation.
@@ -14719,6 +13731,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">caractéristiques physiques</rdfs:label>
       <rdfs:label xml:lang="en">physical characteristics</rdfs:label>
+      <rdfs:label xml:lang="es">característifcas físicas</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14740,14 +13759,12 @@
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent -->
-   <owl:DatatypeProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent">
+   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent">
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -14757,6 +13774,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">importance physique ou logique</rdfs:label>
       <rdfs:label xml:lang="en">physical or logical extent</rdfs:label>
+      <rdfs:label xml:lang="es">soporte físico o lógico</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14776,6 +13800,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">production technique</rdfs:label>
       <rdfs:label xml:lang="fr">technique de production</rdfs:label>
+      <rdfs:label xml:lang="es">técnica de produccióon</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14808,6 +13839,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">date de publication</rdfs:label>
       <rdfs:label xml:lang="en">publication date</rdfs:label>
+      <rdfs:label xml:lang="es">fecha de publicación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14820,8 +13858,7 @@
          RiC-E18 (Date entity)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#qualityOfRepresentation -->
-   <owl:DatatypeProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#qualityOfRepresentation">
+   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#qualityOfRepresentation">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Conditions of an Instantiation that impact the legibility or
@@ -14832,6 +13869,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">quality of representation</rdfs:label>
       <rdfs:label xml:lang="fr">qualité de la représentation</rdfs:label>
+      <rdfs:label xml:lang="es">calidad de representación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14862,6 +13906,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">quantity</rdfs:label>
       <rdfs:label xml:lang="fr">quantité</rdfs:label>
+      <rdfs:label xml:lang="es">cantidad</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -14888,14 +13939,12 @@
             <rdf:value xml:lang="en">Added a scope note.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-
       <skos:scopeNote xml:lang="en">Use if you use the Extent class and its properties for handling
          an accurate description of the extent of a resource..</skos:scopeNote>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceExtent -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceExtent">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">The quantity of information content as human experienced
@@ -14909,6 +13958,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Record Resource extent</rdfs:label>
       <rdfs:label xml:lang="fr">mesure de la ressource archivistique</rdfs:label>
+      <rdfs:label xml:lang="es">soporte de recurso documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-11-21</dc:date>
@@ -14946,8 +14002,7 @@
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceStructure -->
-   <owl:DatatypeProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceStructure">
+   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceStructure">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#structure"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
@@ -14960,6 +14015,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Record Resource structure</rdfs:label>
       <rdfs:label xml:lang="fr">structure de la ressource archivistique</rdfs:label>
+      <rdfs:label xml:lang="es">estructura de recurso documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14993,6 +14055,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">reference system</rdfs:label>
       <rdfs:label xml:lang="fr">système de référence</rdfs:label>
+      <rdfs:label xml:lang="es">sistema de referencia</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15009,6 +14078,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Relation state</rdfs:label>
       <rdfs:label xml:lang="fr">statut de la relation</rdfs:label>
+      <rdfs:label xml:lang="es">estado de la relación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15025,6 +14101,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">rule followed</rdfs:label>
       <rdfs:label xml:lang="fr">règle suivie</rdfs:label>
+      <rdfs:label xml:lang="es">regla aplicada</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15049,6 +14132,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">portée et contenu</rdfs:label>
       <rdfs:label xml:lang="en">scope and content</rdfs:label>
+      <rdfs:label xml:lang="es">alcance y contenido</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15087,8 +14177,7 @@
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Relation"/>
             </owl:unionOf>
          </owl:Class>
@@ -15099,6 +14188,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">source</rdfs:label>
       <rdfs:label xml:lang="fr">source</rdfs:label>
+      <rdfs:label xml:lang="es">fuente</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15115,8 +14211,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
@@ -15132,6 +14227,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">structure</rdfs:label>
       <rdfs:label xml:lang="fr">structure</rdfs:label>
+      <rdfs:label xml:lang="es">estructura</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-11-01</dc:date>
@@ -15152,8 +14254,7 @@
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#technicalCharacteristics -->
-   <owl:DatatypeProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#technicalCharacteristics">
+   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#technicalCharacteristics">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Mechanism"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Describes any relevant physical or software feature of any device
@@ -15161,6 +14262,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">caractéristiques techniques</rdfs:label>
       <rdfs:label xml:lang="en">technical characteristics</rdfs:label>
+      <rdfs:label xml:lang="es">características técnicas</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-11-01</dc:date>
@@ -15205,6 +14313,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">textual value</rdfs:label>
       <rdfs:label xml:lang="fr">valeur textuelle</rdfs:label>
+      <rdfs:label xml:lang="es">valor textual</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15219,8 +14334,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Rule"/>
             </owl:unionOf>
          </owl:Class>
@@ -15231,6 +14345,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">intitulé</rdfs:label>
       <rdfs:label xml:lang="en">title</rdfs:label>
+      <rdfs:label xml:lang="es">título</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15250,6 +14371,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">type</rdfs:label>
       <rdfs:label xml:lang="fr">type</rdfs:label>
+      <rdfs:label xml:lang="es">tipo</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15272,6 +14400,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">unit of measurement</rdfs:label>
       <rdfs:label xml:lang="fr">unité de mesure</rdfs:label>
+      <rdfs:label xml:lang="es">unidad de medida</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-28</dc:date>
@@ -15310,6 +14445,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">used from date</rdfs:label>
       <rdfs:label xml:lang="fr">utilisé à partir de</rdfs:label>
+      <rdfs:label xml:lang="es">usado desde la fecha</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15330,6 +14472,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">used to date</rdfs:label>
       <rdfs:label xml:lang="fr">utilisé jusqu’à</rdfs:label>
+      <rdfs:label xml:lang="es">usado hasta la fecha</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15350,6 +14499,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">largeur</rdfs:label>
       <rdfs:label xml:lang="en">width</rdfs:label>
+      <rdfs:label xml:lang="es">anchura</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15372,22 +14528,16 @@
    <owl:Class rdf:about="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
    <!-- https://www.ica.org/standards/RiC/ontology#AccumulationRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#AccumulationRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -15395,11 +14545,8 @@
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#accumulationRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -15465,18 +14612,13 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ProvenanceRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -15484,11 +14626,8 @@
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#activityDocumentationRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -15586,26 +14725,19 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#AgentControlRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#AgentControlRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorityRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentControlRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -15625,25 +14757,18 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentHierarchicalRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -15683,18 +14808,13 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ProvenanceRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -15702,11 +14822,8 @@
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentOriginationRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -15727,26 +14844,19 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#TemporalRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentTemporalRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -15776,11 +14886,8 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >2</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#agentRelationConnects"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -15817,21 +14924,15 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource"/>
-            <owl:qualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:qualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#appellationRelationHasSource"/>
+            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -15852,21 +14953,15 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#authorityRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -15891,28 +14986,21 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#CreationRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#authorshipRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#authorshipRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Record"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#authorshipRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#authorshipRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
                      <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Group"/>
                      <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Person"/>
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#Position"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Position"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -15967,8 +15055,6 @@
                notes.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-
-
       <skos:scopeNote xml:lang="en">Countable characteristics of a record resource carrier expressed
          as a quantity.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-A04 (Carrier Extent)
@@ -16016,21 +15102,15 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#DescendanceRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#childRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#childRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#childRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#childRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -16186,11 +15266,8 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#KnowingRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >2</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#correspondenceRelationConnects"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -16210,22 +15287,16 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#CreationRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#CreationRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentOriginationRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -16233,11 +15304,8 @@
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#creationRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -16351,26 +15419,19 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#DerivationRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#DerivationRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation"/>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#TemporalRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource"/>
-            <owl:qualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:qualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#derivationRelationHasSource"/>
+            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -16390,26 +15451,19 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#DescendanceRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#DescendanceRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentTemporalRelation"/>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#FamilyRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#descendanceRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -16503,21 +15557,15 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#eventRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#eventRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#eventRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#eventRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -16654,15 +15702,11 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#FamilyRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#FamilyRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >2</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#familyRelationConnects"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -16712,15 +15756,11 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#FunctionalEquivalenceRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#FunctionalEquivalenceRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >2</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelationConnects"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -16776,26 +15816,19 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#GroupSubdivisionRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#GroupSubdivisionRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentHierarchicalRelation"/>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#WholePartRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource"/>
-            <owl:qualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:qualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#groupSubdivisionRelationHasSource"/>
+            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -16970,16 +16003,12 @@
          Extent attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation -->
-   <owl:Class
-      rdf:about="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation">
+   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#InstantiationToInstantiationRelation">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >2</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#instantiationToInstantiationRelationConnects"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -16995,23 +16024,18 @@
       </skos:changeNote>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation -->
-   <owl:Class
-      rdf:about="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation">
+   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#IntellectualPropertyRightsRelation">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorityRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
                      <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Group"/>
                      <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Person"/>
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#Position"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Position"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -17019,18 +16043,13 @@
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#intellectualPropertyRightsRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -17054,25 +16073,18 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#KnowingOfRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#KnowingOfRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingOfRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -17092,15 +16104,11 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#KnowingRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#KnowingRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >2</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#knowingRelationConnects"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -17150,35 +16158,25 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#LeadershipRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#LeadershipRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentControlRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentControlRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipWithPosition"/>
-            <owl:maxQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:maxQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#leadershipWithPosition"/>
+            <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -17217,28 +16215,20 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorityRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#managementRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -17306,31 +16296,22 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#RuleRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#asConcernsActivity"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#asConcernsActivity"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Mandate"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#mandateRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -17387,35 +16368,25 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#MembershipRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#MembershipRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource"/>
-            <owl:qualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:qualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipRelationHasSource"/>
+            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipWithPosition"/>
-            <owl:maxQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:maxQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#membershipWithPosition"/>
+            <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:maxQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -17438,21 +16409,15 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#DerivationRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#migrationRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource"/>
-            <owl:qualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:qualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#migrationRelationHasSource"/>
+            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -17519,7 +16484,6 @@
          in an agency. Occupation Type is related to, but should not be confused with the domain or
          field of Activity (Actvitity Type), such as an archivist who works in the domain of
          archival science. Occupation Type is a kind of Demographic Group.</skos:scopeNote>
-
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A30 (Occupation Type
          attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -17528,18 +16492,14 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AuthorityRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
                      <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Group"/>
                      <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Person"/>
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#Position"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Position"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -17547,11 +16507,8 @@
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#ownershipRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -17577,21 +16534,15 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#EventRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#performanceRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Activity"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#performanceRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -17711,7 +16662,6 @@
                paragraphs. Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17751,21 +16701,15 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#placeRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#placeRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#placeRelationHasSource"/>
-            <owl:qualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:qualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#placeRelationHasSource"/>
+            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -17845,25 +16789,18 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#PositionHoldingRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#PositionHoldingRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#positionHoldingRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -17883,25 +16820,18 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#PositionToGroupRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#PositionToGroupRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget"/>
-            <owl:qualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:qualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#positionToGroupRelationHasTarget"/>
+            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -17954,18 +16884,13 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -17973,16 +16898,12 @@
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#provenanceRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#Activity"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Activity"/>
                      <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Agent"/>
                   </owl:unionOf>
                </owl:Class>
@@ -18010,18 +16931,14 @@
       <rdfs:subClassOf>
          <owl:Restriction>
             <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
-            <owl:qualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:qualifiedCardinality>
+            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
             <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIn"/>
-            <owl:qualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:qualifiedCardinality>
+            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -18208,15 +17125,11 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RecordResourceGeneticRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResourceGeneticRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceGeneticRelationConnects"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >2</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceGeneticRelationConnects"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -18240,28 +17153,20 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ManagementRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceHoldingRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass>
                <owl:Class>
                   <owl:unionOf rdf:parseType="Collection">
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-                     <rdf:Description
-                        rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
+                     <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                   </owl:unionOf>
                </owl:Class>
             </owl:onClass>
@@ -18283,26 +17188,19 @@
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation -->
-   <owl:Class
-      rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation">
+   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResourceToInstantiationRelation">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource"/>
-            <owl:qualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:qualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceToInstantiationRelationHasSource"/>
+            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -18321,16 +17219,12 @@
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation -->
-   <owl:Class
-      rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation">
+   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResourceToRecordResourceRelation">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >2</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#recordResourceRelationConnects"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -18616,21 +17510,15 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#ruleRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -18682,21 +17570,15 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#sequentialRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -18719,11 +17601,8 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#FamilyRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#siblingRelationConnects"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >2</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#siblingRelationConnects"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -18746,11 +17625,8 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#FamilyRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#spouseRelationConnects"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >2</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#spouseRelationConnects"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -18773,21 +17649,15 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#KnowingRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#teachingRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#teachingRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -18810,21 +17680,15 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#SequentialRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasSource"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#temporalRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -18906,21 +17770,15 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#typeRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#typeRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#typeRelationHasSource"/>
-            <owl:qualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:qualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#typeRelationHasSource"/>
+            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -18974,21 +17832,15 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasTarget"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource"/>
-            <owl:qualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >1</owl:qualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#wholePartRelationHasSource"/>
+            <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -19008,15 +17860,11 @@
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#WorkRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#WorkRelation">
-      <rdfs:subClassOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#AgentToAgentRelation"/>
       <rdfs:subClassOf>
          <owl:Restriction>
-            <owl:onProperty
-               rdf:resource="https://www.ica.org/standards/RiC/ontology#workRelationConnects"/>
-            <owl:minQualifiedCardinality
-               rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-               >2</owl:minQualifiedCardinality>
+            <owl:onProperty rdf:resource="https://www.ica.org/standards/RiC/ontology#workRelationConnects"/>
+            <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
@@ -19046,8 +17894,7 @@
       <rdf:type rdf:resource="http://purl.org/vocommons/voaf#Vocabulary"/>
    </owl:NamedIndividual>
    <!-- https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes -->
-   <owl:NamedIndividual
-      rdf:about="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes">
+   <owl:NamedIndividual rdf:about="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes">
       <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
       <dc:creator xml:lang="en">International Coucil on Archives Expert Group on Archival
          Description (ICA EGAD)</dc:creator>
@@ -19082,8 +17929,7 @@
       <skos:definition xml:lang="en">A vocabulary on Record Set types</skos:definition>
    </owl:NamedIndividual>
    <!-- https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes#AuthorityRecord -->
-   <owl:NamedIndividual
-      rdf:about="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes#AuthorityRecord">
+   <owl:NamedIndividual rdf:about="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes#AuthorityRecord">
       <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <rdf:type rdf:resource="https://www.ica.org/standards/RiC/ontology#DocumentaryFormType"/>
       <rdfs:label xml:lang="en">Authority record</rdfs:label>
@@ -19096,13 +17942,11 @@
       </skos:changeNote>
       <skos:definition xml:lang="en">This category can be used for records that describe an
          entity.</skos:definition>
-      <skos:inScheme
-         rdf:resource="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes"/>
+      <skos:inScheme rdf:resource="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes"/>
       <skos:prefLabel xml:lang="en">Authority record</skos:prefLabel>
    </owl:NamedIndividual>
    <!-- https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes#FindingAid -->
-   <owl:NamedIndividual
-      rdf:about="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes#FindingAid">
+   <owl:NamedIndividual rdf:about="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes#FindingAid">
       <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <rdf:type rdf:resource="https://www.ica.org/standards/RiC/ontology#DocumentaryFormType"/>
       <rdfs:label xml:lang="en">Finding aid</rdfs:label>
@@ -19115,12 +17959,10 @@
       </skos:changeNote>
       <skos:definition xml:lang="en">This documentary form type can be used for records that
          aggregate and organizes metadata on some record(s) or record set(s).</skos:definition>
-      <skos:inScheme
-         rdf:resource="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes"/>
+      <skos:inScheme rdf:resource="https://www.ica.org/standards/RiC/vocabularies/documentaryFormTypes"/>
    </owl:NamedIndividual>
    <!-- https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Collection -->
-   <owl:NamedIndividual
-      rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Collection">
+   <owl:NamedIndividual rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Collection">
       <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <rdf:type rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSetType"/>
       <rdfs:label xml:lang="en">collection</rdfs:label>
@@ -19138,8 +17980,7 @@
       <skos:prefLabel xml:lang="en">collection</skos:prefLabel>
    </owl:NamedIndividual>
    <!-- https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#File -->
-   <owl:NamedIndividual
-      rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#File">
+   <owl:NamedIndividual rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#File">
       <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <rdf:type rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSetType"/>
       <rdfs:label xml:lang="fr">dossier</rdfs:label>
@@ -19158,8 +17999,7 @@
       <skos:prefLabel xml:lang="en">file</skos:prefLabel>
    </owl:NamedIndividual>
    <!-- https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Fonds -->
-   <owl:NamedIndividual
-      rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Fonds">
+   <owl:NamedIndividual rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Fonds">
       <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <rdf:type rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSetType"/>
       <rdfs:label xml:lang="en">fonds</rdfs:label>
@@ -19178,8 +18018,7 @@
       <skos:prefLabel xml:lang="en">fonds</skos:prefLabel>
    </owl:NamedIndividual>
    <!-- https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Series -->
-   <owl:NamedIndividual
-      rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Series">
+   <owl:NamedIndividual rdf:about="https://www.ica.org/standards/RiC/vocabularies/recordSetTypes#Series">
       <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <rdf:type rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSetType"/>
       <rdfs:label xml:lang="en">series</rdfs:label>

--- a/ontology/current-version/RiC-O_v1-0.rdf
+++ b/ontology/current-version/RiC-O_v1-0.rdf
@@ -14556,6 +14556,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Accumulation Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation d’accumulation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de Acumulación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14572,6 +14579,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Activity</rdfs:label>
       <rdfs:label xml:lang="fr">Activité</rdfs:label>
+      <rdfs:label xml:lang="es">Actividad</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-23</dc:date>
@@ -14637,6 +14651,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Activity Documentation Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation entre activités et ressources archivistiques</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de procedencia funcional</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14653,6 +14674,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Activity Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type d’activité</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de actividad</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-23</dc:date>
@@ -14688,6 +14716,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Agent</rdfs:label>
       <rdfs:label xml:lang="fr">Agent</rdfs:label>
+      <rdfs:label xml:lang="es">Agente</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-02-08</dc:date>
@@ -14746,6 +14781,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Agent Control Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de contrôle entre agents</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de control entre agentes</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14777,6 +14819,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Agent Hierarchical Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation hiérarchique entre agents</rdfs:label>
+      <rdfs:label xml:lang="es">Relación jerárquica entre agentes</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14794,6 +14843,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Agent Name</rdfs:label>
       <rdfs:label xml:lang="fr">Nom d’agent</rdfs:label>
+      <rdfs:label xml:lang="es">Nombre de Agente</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14833,6 +14889,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Agent Origination Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de provenance organique</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de procedencia orgánica</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14866,6 +14929,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Agent Temporal Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation temporelle entre agents</rdfs:label>
+      <rdfs:label xml:lang="es">Relación temporal entre agentes</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-04-19</dc:date>
@@ -14895,6 +14965,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Agent Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation entre agents</rdfs:label>
+      <rdfs:label xml:lang="es">Relación entre agentes</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14912,6 +14989,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Appellation</rdfs:label>
       <rdfs:label xml:lang="fr">Appellation</rdfs:label>
+      <rdfs:label xml:lang="es">Denominación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14941,6 +15025,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Appellation Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation d’appellation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de denominación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -14970,6 +15061,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Authority Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation d’autorité</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de control por parte de agentes</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15012,6 +15110,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Authorship Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de responsabilité intellectuelle</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de autoría</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-12-29</dc:date>
@@ -15035,6 +15140,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Carrier Extent</rdfs:label>
       <rdfs:label xml:lang="fr">Mesure d’un support</rdfs:label>
+      <rdfs:label xml:lang="es">Extensión del soporte</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-28</dc:date>
@@ -15068,6 +15180,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Carrier Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type de support</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de soporte</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-04-19</dc:date>
@@ -15119,6 +15238,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Child Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de filiation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de filiación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15136,6 +15262,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Concept</rdfs:label>
       <rdfs:label xml:lang="fr">Concept</rdfs:label>
+      <rdfs:label xml:lang="es">Concepto</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15151,6 +15284,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Content Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type de contenu</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de contenido</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15186,6 +15326,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Coordinates</rdfs:label>
       <rdfs:label xml:lang="fr">Coordonnées géographiques</rdfs:label>
+      <rdfs:label xml:lang="es">Coordenadas de lugar</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-04-19</dc:date>
@@ -15216,6 +15363,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Collectivité</rdfs:label>
       <rdfs:label xml:lang="en">Corporate Body</rdfs:label>
+      <rdfs:label xml:lang="es">Institución</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15246,6 +15400,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Corporate Body Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type de collectivité</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de institución</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15276,6 +15437,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Correspondence Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation épistolaire</rdfs:label>
+      <rdfs:label xml:lang="es">Relación entre personas por correspondencia</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15316,6 +15484,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Creation Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de création</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de creación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-04-19</dc:date>
@@ -15339,6 +15514,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Date</rdfs:label>
       <rdfs:label xml:lang="fr">Date</rdfs:label>
+      <rdfs:label xml:lang="es">Fecha</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-23</dc:date>
@@ -15392,6 +15574,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Catégorie démographique</rdfs:label>
       <rdfs:label xml:lang="en">Demographic Group</rdfs:label>
+      <rdfs:label xml:lang="es">Categoría demográfica</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-23</dc:date>
@@ -15440,6 +15629,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Derivation Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de dérivation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de derivación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15472,6 +15668,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Descendance Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de descendance</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de descendencia</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15490,6 +15693,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Documentary Form Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type de document</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15523,6 +15733,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Event</rdfs:label>
       <rdfs:label xml:lang="fr">Événement</rdfs:label>
+      <rdfs:label xml:lang="es">Evento</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-23</dc:date>
@@ -15574,6 +15791,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Event Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation impliquant un événement</rdfs:label>
+      <rdfs:label xml:lang="es">Relación con un evento</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15590,6 +15814,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Event Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type d’événement</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de evento</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15623,6 +15854,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Extent</rdfs:label>
       <rdfs:label xml:lang="fr">Mesure</rdfs:label>
+      <rdfs:label xml:lang="es">Extensión</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-28</dc:date>
@@ -15646,6 +15884,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Extent Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type de mesure</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de Extensión</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -15675,6 +15920,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Famille</rdfs:label>
       <rdfs:label xml:lang="en">Family</rdfs:label>
+      <rdfs:label xml:lang="es">Familia</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-23</dc:date>
@@ -15715,6 +15967,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Family Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation familiale</rdfs:label>
+      <rdfs:label xml:lang="es">Relación familiar</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15731,6 +15990,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Family Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type de famille</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de familia</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-23</dc:date>
@@ -15769,6 +16035,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Functional Equivalence Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation d’équivalence fonctionnelle</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de equivalencia funcional</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15792,6 +16065,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Group</rdfs:label>
       <rdfs:label xml:lang="fr">Groupe d’agents</rdfs:label>
+      <rdfs:label xml:lang="es">Grupo de agentes</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15837,6 +16117,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Group Subdivision Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de subdivision entre groupes d’agents</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de subdivisión entre grupos de agentes</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15855,6 +16142,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Identifiant</rdfs:label>
       <rdfs:label xml:lang="en">Identifier</rdfs:label>
+      <rdfs:label xml:lang="es">Identificador</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-04-19</dc:date>
@@ -15877,6 +16171,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Identifier Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type d’identifiant</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de identificador</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15908,6 +16209,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Instanciation</rdfs:label>
       <rdfs:label xml:lang="en">Instantiation</rdfs:label>
+      <rdfs:label xml:lang="es">Instanciación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-23</dc:date>
@@ -15977,6 +16285,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Instantiation Extent</rdfs:label>
       <rdfs:label xml:lang="fr">Mesure d’une instanciation</rdfs:label>
+      <rdfs:label xml:lang="es">Extensión de la instanciación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16016,6 +16331,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Instantiation to Instantiation Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation entre instanciations</rdfs:label>
+      <rdfs:label xml:lang="es">Relación entre instanciaciones</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16060,6 +16382,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Intellectual Property Rights Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de propriété intellectuelle</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de propiedad intelectual</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16093,6 +16422,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Knowing Of Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de connaissance à propos d’une personne</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de conocimieto indirecto entre personas</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16117,6 +16453,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Knowing Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de connaissance entre personnes</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de conocimiento directo entre personas</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16134,6 +16477,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Language</rdfs:label>
       <rdfs:label xml:lang="fr">Langue</rdfs:label>
+      <rdfs:label xml:lang="es">Lengua</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-12-28</dc:date>
@@ -16185,6 +16535,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Leadership Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de direction</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de liderazgo</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16201,6 +16558,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Legal Status</rdfs:label>
       <rdfs:label xml:lang="fr">Statut légal</rdfs:label>
+      <rdfs:label xml:lang="es">Status jurídico</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16239,6 +16603,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Management Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de gestion</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de gestión</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16256,6 +16627,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Mandat</rdfs:label>
       <rdfs:label xml:lang="en">Mandate</rdfs:label>
+      <rdfs:label xml:lang="es">Norma</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16321,6 +16699,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Mandate Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation impliquant un mandat</rdfs:label>
+      <rdfs:label xml:lang="es">Relación normativa</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-04-19</dc:date>
@@ -16346,6 +16731,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Mechanism</rdfs:label>
       <rdfs:label xml:lang="fr">Système</rdfs:label>
+      <rdfs:label xml:lang="es">Mecanismo</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-23</dc:date>
@@ -16395,6 +16787,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Membership Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation d’appartenance</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de membresía</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16426,6 +16825,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Migration Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de migration</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de migración entre instanciaciones</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16443,6 +16849,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Name</rdfs:label>
       <rdfs:label xml:lang="fr">Nom</rdfs:label>
+      <rdfs:label xml:lang="es">Nombre</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16461,6 +16874,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Occupation Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type d’occupation</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de ocupación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-23</dc:date>
@@ -16517,6 +16937,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Ownership Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de propriété</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de posesión</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16551,6 +16978,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Performance Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relations entre activités et agents</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de desarrollo funcional</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16568,6 +17002,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Person</rdfs:label>
       <rdfs:label xml:lang="fr">Personne</rdfs:label>
+      <rdfs:label xml:lang="es">Persona</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-23</dc:date>
@@ -16624,6 +17065,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Localisation physique</rdfs:label>
       <rdfs:label xml:lang="en">Physical Location</rdfs:label>
+      <rdfs:label xml:lang="es">Localización física de lugar</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-04-19</dc:date>
@@ -16649,6 +17097,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Lieu</rdfs:label>
       <rdfs:label xml:lang="en">Place</rdfs:label>
+      <rdfs:label xml:lang="es">Lugar</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-04-19</dc:date>
@@ -16687,6 +17142,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Nom de lieu</rdfs:label>
       <rdfs:label xml:lang="en">Place Name</rdfs:label>
+      <rdfs:label xml:lang="es">Nombre de lugar</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16718,6 +17180,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Place Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation impliquant un lieu</rdfs:label>
+      <rdfs:label xml:lang="es">Relación con lugar</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16734,6 +17203,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Place Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type de lieu</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de lugar</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-04-19</dc:date>
@@ -16759,6 +17235,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Position</rdfs:label>
       <rdfs:label xml:lang="fr">Poste occupé</rdfs:label>
+      <rdfs:label xml:lang="es">Puesto</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-23</dc:date>
@@ -16809,6 +17292,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Position Holding Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation entre une personne et un poste</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de ocupación entre una persona y un puesto</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16840,6 +17330,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Position to Group Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation entre un poste et un groupe</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de ocupación entre un grupo y un puesto</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16857,6 +17354,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Production Technique Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type de technique de production</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de técnica de producción</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-04-19</dc:date>
@@ -16916,6 +17420,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Provenance Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de provenance</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de producción</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16947,6 +17458,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Proxy</rdfs:label>
       <rdfs:label xml:lang="fr">Proxy</rdfs:label>
+      <rdfs:label xml:lang="es">Proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16968,6 +17486,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Objet informationnel</rdfs:label>
       <rdfs:label xml:lang="en">Record</rdfs:label>
+      <rdfs:label xml:lang="es">Documento</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-02-08</dc:date>
@@ -17004,6 +17529,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Partie d’objet informationnel</rdfs:label>
       <rdfs:label xml:lang="en">Record Part</rdfs:label>
+      <rdfs:label xml:lang="es">Componente documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-02-08</dc:date>
@@ -17036,6 +17568,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Record Resource</rdfs:label>
       <rdfs:label xml:lang="fr">Ressource archivistique</rdfs:label>
+      <rdfs:label xml:lang="es">Recurso documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-23</dc:date>
@@ -17098,6 +17637,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Mesure d’une ressource archivistique</rdfs:label>
       <rdfs:label xml:lang="en">Record Resource Extent</rdfs:label>
+      <rdfs:label xml:lang="es">Extensión de recurso documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-28</dc:date>
@@ -17139,6 +17685,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Record Resource Genetic Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation génétique entre des ressources archivistiques</rdfs:label>
+      <rdfs:label xml:lang="es">Relación genética entre recursos documentales</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17178,6 +17731,13 @@
       <rdfs:label xml:lang="en">Record Resource Holding Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation entre agents et ressources archivistiques ou instantiations
          conservées</rdfs:label>
+      <rdfs:label xml:lang="es">Relación entre agentes y recursos documentales que conservan</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17209,6 +17769,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Record Resource to Instantiation Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation d’instanciation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de recurso documental a instanciación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17232,6 +17799,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Record Resource to Record Resource Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation entre ressources archivistiques</rdfs:label>
+      <rdfs:label xml:lang="es">Relación entre recursos documentales</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17249,6 +17823,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Ensemble d’objets informationnels</rdfs:label>
       <rdfs:label xml:lang="en">Record Set</rdfs:label>
+      <rdfs:label xml:lang="es">Agrupación documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-04-19</dc:date>
@@ -17302,6 +17883,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Record Set Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type d’ensemble d’objets informationnels</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de agrupación documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17336,6 +17924,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Record State</rdfs:label>
       <rdfs:label xml:lang="fr">État d’un objet informationnel</rdfs:label>
+      <rdfs:label xml:lang="es">Estado de documento</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-23</dc:date>
@@ -17378,6 +17973,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2021-02-08</dc:date>
@@ -17405,6 +18007,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Representation Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type de représentation</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de grabación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-04-19</dc:date>
@@ -17445,6 +18054,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Role Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type de rôle</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de rol</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17461,6 +18077,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Rule</rdfs:label>
       <rdfs:label xml:lang="fr">Règle</rdfs:label>
+      <rdfs:label xml:lang="es">Regla</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-23</dc:date>
@@ -17527,6 +18150,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Relation impliquant une règle</rdfs:label>
       <rdfs:label xml:lang="en">Rule Relation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación con regla</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17543,6 +18173,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Rule Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type de règle</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de regla</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17587,6 +18224,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Relation séquentielle</rdfs:label>
       <rdfs:label xml:lang="en">Sequential Relation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación secuencial</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17611,6 +18255,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Relation de fratrie</rdfs:label>
       <rdfs:label xml:lang="en">Sibling Relation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación familiar entre hermanos</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17635,6 +18286,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Relation matrimoniale</rdfs:label>
       <rdfs:label xml:lang="en">Spouse Relation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación matrimonial entre personas</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17666,6 +18324,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Relation entre enseignants et étudiants</rdfs:label>
       <rdfs:label xml:lang="en">Teaching Relation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación académica entre profesor y alumno</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17697,6 +18362,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Relation temporelle</rdfs:label>
       <rdfs:label xml:lang="en">Temporal Relation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación temporal</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17713,6 +18385,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Chose</rdfs:label>
       <rdfs:label xml:lang="en">Thing</rdfs:label>
+      <rdfs:label xml:lang="es">Cosa</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17741,6 +18420,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Intitulé</rdfs:label>
       <rdfs:label xml:lang="en">Title</rdfs:label>
+      <rdfs:label xml:lang="es">Título</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17758,6 +18444,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17787,6 +18480,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Relation de catégorisation</rdfs:label>
       <rdfs:label xml:lang="en">Type Relation</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de relación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17807,6 +18507,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Unit Of Measurement</rdfs:label>
       <rdfs:label xml:lang="fr">Unité de mesure</rdfs:label>
+      <rdfs:label xml:lang="es">Unidad de medida</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -17849,6 +18556,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Relation partitive</rdfs:label>
       <rdfs:label xml:lang="en">Whole Part Relation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación entre todo y parte</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17873,6 +18587,13 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">Relation de travail</rdfs:label>
       <rdfs:label xml:lang="en">Work Relation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación profesional</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>


### PR DESCRIPTION
Added Spanish labels to the 103 classes defined in RiC-O, to 59 datatype properties and to 277 object properties.