### PR TITLE
Made the datatype properties compliant with RiC-C 1.0

### DIFF
--- a/ontology/current-version/RiC-O_1-0.rdf
+++ b/ontology/current-version/RiC-O_1-0.rdf
@@ -10,8 +10,7 @@
    xmlns:rico="https://www.ica.org/standards/RiC/ontology#"
    xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:vann="http://purl.org/vocab/vann/"
    xmlns:voaf="http://purl.org/vocommons/voaf#" xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
-   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-   xml:base="https://www.ica.org/standards/RiC/ontology">
+   xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:base="https://www.ica.org/standards/RiC/ontology">
    <owl:Ontology rdf:about="https://www.ica.org/standards/RiC/ontology">
       <cc:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
       <dc:contributor xml:lang="en">Aaron Rubinstein (University of Massachusetts Amherst, USA),
@@ -650,6 +649,7 @@
                   shortcuts. Fixed the range of isExtentOf.</html:li>
                <html:li>2023, November 8, later: rolifying the Relation classes, step 2: deleted 166
                   object properties that had become unnecessary.</html:li>
+               <html:li>2023, November 12: updated the datatype properties in order to make them compliant with RiC-CM 1.0 attributes. Changed the IRIS of accrual (to accruals), accrualStatus (to accrualsStatus), descriptiveNote (to generalDescription), integrity (to integrityNote), physicalCharacteristics (to physicalCharacteristicsNote), qualityOfRepresentation (to qualityOfRepresentationNote). Made scopeAndContent a subproperty of generalDescription, and expressedDate a subproperty of name. Updated or added a few domains and many rdfs:comment, skos:scopeNote, skos:example. Also made usedFromDate a subproperty of beginningDate, and usedToDate a subproperty of endDate.</html:li>
             </html:ul>
          </html:div>
       </skos:historyNote>
@@ -15132,16 +15132,24 @@
          shortcuts corresponding to this n-ary class.</skos:scopeNote>
    </owl:ObjectProperty>
    <!-- /////////////////////////////////////////////////////////////////////////////////////// // // Data properties // /////////////////////////////////////////////////////////////////////////////////////// -->
-   <!-- https://www.ica.org/standards/RiC/ontology#accrual -->
-   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#accrual">
+   <!-- https://www.ica.org/standards/RiC/ontology#accruals -->
+   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#accruals">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Information on the anticipated accession(s) to the Record
          Set.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="fr">accroissement</rdfs:label>
-      <rdfs:label xml:lang="en">accrual</rdfs:label>
-      <rdfs:label xml:lang="es">ingreso</rdfs:label>
+      <rdfs:label xml:lang="en">accruals</rdfs:label>
+      <rdfs:label xml:lang="fr">accroissements</rdfs:label>
+      <rdfs:label xml:lang="es">ingresos</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the IRI, mapping to RiC-CM
+               (rico:RiCCMCorrespondingComponent), labels, skos:scopeNote, examples
+               (skos:example).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -15154,19 +15162,37 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">See also accrualStatus</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">corresponds to RiC-A01 (Accrual
-         attribute)</RiCCMCorrespondingComponent>
+      <skos:example xml:lang="en">Accruing - there is an agreement with the creator that additional
+         snapshots of their email directory will be accessioned at yearly intervals</skos:example>
+      <skos:example xml:lang="en">Non-accruing</skos:example>
+      <skos:example xml:lang="en">Unknown</skos:example>
+      <skos:scopeNote xml:lang="en">See also accrualsStatus</skos:scopeNote>
+      <rico:RiCCMCorrespondingComponent xml:lang="en">corresponds to RiC-A01 (Accruals
+         attribute)</rico:RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
-   <!-- https://www.ica.org/standards/RiC/ontology#accrualStatus -->
-   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#accrualStatus">
+   <!-- https://www.ica.org/standards/RiC/ontology#accrualsStatus -->
+   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#accrualsStatus">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Information on the status of an Accrual</rdfs:comment>
+      <rdfs:comment xml:lang="en">Information on the status of possible accruals</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="en">accrual status</rdfs:label>
-      <rdfs:label xml:lang="es">estado del ingreso</rdfs:label>
-      <rdfs:label xml:lang="fr">statut de l’accroissement</rdfs:label>
+      <rdfs:label xml:lang="en">accruals status</rdfs:label>
+      <rdfs:label xml:lang="fr">statut des accroissements</rdfs:label>
+      <rdfs:label xml:lang="es">estado de los ingresos</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the IRI, mapping to RiC-CM
+               (rico:RiCCMCorrespondingComponent), labels, description (rdfs:comment),
+               skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15180,19 +15206,13 @@
                RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
       <skos:scopeNote xml:lang="en">A text statement or single words such as “Closed” to indicate
          that no additional Record Resource will (or is anticipated to) be added to the Record Set;
          “Open” to indicate that additional records or record sets will (or are expected to) be
          added to the Record Set; or “Unknown” to indicate that this information is not available,
-         for example. See also accrual</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">corresponds to RiC-A01 (Accrual
-         attribute)</RiCCMCorrespondingComponent>
+         for example. See also accruals</skos:scopeNote>
+      <rico:RiCCMCorrespondingComponent xml:lang="en">specialization of RiC-A01 (Accruals
+         attribute)</rico:RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#altimetricSystem -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#altimetricSystem">
@@ -15202,8 +15222,8 @@
       <rdfs:comment xml:lang="en">Reference system used for altitude</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">altimetric system</rdfs:label>
-      <rdfs:label xml:lang="es">sistema altimétrico</rdfs:label>
       <rdfs:label xml:lang="fr">système altimétrique</rdfs:label>
+      <rdfs:label xml:lang="es">sistema altimétrico</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -15225,19 +15245,19 @@
       <rdfs:comment xml:lang="en">The height of a Place above a reference level, especially above
          sea level.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">altitud</rdfs:label>
       <rdfs:label xml:lang="en">altitude</rdfs:label>
       <rdfs:label xml:lang="fr">altitude</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="es">altitud</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Property of the Coordinates class. If you don't use this class,
@@ -15255,17 +15275,18 @@
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Description of evidences that the Record Resource or Instantiation
-         is what it purports to be, was created or sent by the said Agent, at the said time and has
-         not been tampered or corrupted.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Description of the evidence that a Record Resource or
+         Instantiation is what it purports to be, was created or sent by the said Agent at the said
+         time, and has not been tampered with, corrupted, or forged. </rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">authenticity note</rdfs:label>
-      <rdfs:label xml:lang="es">nota de autenticidad</rdfs:label>
       <rdfs:label xml:lang="fr">note sur l’authenticité</rdfs:label>
+      <rdfs:label xml:lang="es">nota de autenticidad</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote, examples (skos:example).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -15276,22 +15297,28 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
             <dc:date>2020-11-01</dc:date>
             <rdf:value xml:lang="en">examples added. Objective: to make RiC-O compliant with RiC-CM
                v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:example xml:lang="en">The charter is missing the seal of the King.</skos:example>
-      <skos:example xml:lang="en">The electronic signature validity cannot by assessed, but the
-         content was not modified from the moment of signing.</skos:example>
-      <skos:example xml:lang="en">The record bears no signature.</skos:example>
-      <skos:example xml:lang="en">The record bears signatures and it was preserved.</skos:example>
-      <skos:example xml:lang="en">The record is digitally signed by the Notary.</skos:example>
+      <skos:example xml:lang="en">The letter is unsigned.</skos:example>
+      <skos:example xml:lang="en">The deed is digitally signed by the Notary. The electronic
+         signature validity cannot be assessed, but the content was not modified from the moment of
+         signing.</skos:example>
       <skos:example xml:lang="en">The timestamp exists but cannot be verified.</skos:example>
-      <skos:example xml:lang="en">The whole collection consists of copies of the charters issued by
-         Vlad the Impaler.</skos:example>
-      <skos:scopeNote xml:lang="en">For electronic records, it may include results from automated
-         means of checking the validity of signatures and timestamp.</skos:scopeNote>
+      <skos:example xml:lang="en">The record bears signatures.</skos:example>
+      <skos:scopeNote xml:lang="en">May be used in a Record Set description when its value
+         is shared by some or all members of the Record Set. For digital records, it may include
+         results from automated means of checking the validity of signatures and timestamp. In
+         particular cases it may be contextually related to the state attribute, for example, a
+         document can be an original or a copy, either of which can be authentic or a forgery. </skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A03 (Authenticity Note
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -15308,14 +15335,14 @@
       <rdfs:label xml:lang="es">norma de control</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
@@ -15361,14 +15388,14 @@
       <rdfs:label xml:lang="es">fecha de nacimiento</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
@@ -15383,18 +15410,31 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Number of physical units and/or physical dimensions of the carrier
-         of a record resource instantiation. Various carriers, depending on specific needs, may have
-         more than one relevant dimension. In some cases, indicating the number of physical units
-         may be sufficient, while in other case, relevant dimensions should be used in order to
-         characterize the carrier.</rdfs:comment>
+         of an Instantiation. In order to manage an Instantiation of a record resource it is
+         necessary to note the extent of the carrier as well as that of the Instantiation itself.
+         Whether it is necessary to note dimensions, the number of relevant units, or both, depends on
+         the nature of the carrier and particular business needs.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">carrier extent</rdfs:label>
-      <rdfs:label xml:lang="es">extensión del soporte</rdfs:label>
       <rdfs:label xml:lang="fr">mesure du support</rdfs:label>
+      <rdfs:label xml:lang="es">extensión del soporte</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote, examples (skos:example).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -15404,24 +15444,17 @@
                Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
       <skos:example xml:lang="en">1 page</skos:example>
-      <skos:example xml:lang="en">17 x 34.5 cm</skos:example>
-      <skos:example xml:lang="en">2 pieces of parchment, 30 x 50 cm and 32,5 x 49 cm</skos:example>
-      <skos:example xml:lang="en">3GB USB key</skos:example>
-      <skos:scopeNote xml:lang="en">For electronic resources, it indicates the size of storage
-         capacity (disk, tape, film etc.). Carrier Extent should not be confused with Record
-         Resource Extent or Instantiation Extent. For a given Record Resource, the Instantiation
-         Extent may vary, based on format, density of information on the carrier, etc. For example,
-         1500 words (Record Resource Extent) may have Instantiation Extent 3kb as a Word document
-         and 5kb as a PDF file, and instantiations may be represented on a CD of 700mb (Carrier
-         Extent). Use if you don't use CarrierExtent class and its properties for handling such
-         information.</skos:scopeNote>
+      <skos:example xml:lang="en">32.5 x 49 cm (piece of parchment)</skos:example>
+      <skos:example xml:lang="en">3 GB (1 USB key)</skos:example>
+      <skos:scopeNote xml:lang="en">For digital resources, it may be used to indicate the size of
+         storage capacity (disk, tape, film, etc.). Carrier extent should not be confused with
+         instantiation extent or record resource extent. For a given Record Resource, the
+         instantiation extent may vary, based on format, density of information on the carrier, etc.
+         For example, a CD with a storage capacity of 700 MB (carrier extent) might hold a record of
+         1500 words (record resource extent) represented in two versions, one a Word document with
+         an instantiation extent of 3 KB and the other a PDF file with an instantiation extent of 5
+         KB. </skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A04 (Carrier Extent
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -15438,9 +15471,10 @@
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Qualifies the level of certitude of the accuracy of an Event or a
          Relation.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">certainty</rdfs:label>
-      <rdfs:label xml:lang="es">certeza</rdfs:label>
       <rdfs:label xml:lang="fr">degré de certitude</rdfs:label>
+      <rdfs:label xml:lang="es">certeza</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -15466,17 +15500,22 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">A term, number or alphanumeric string that is usually taken from
-         an external classification vocabulary or scheme that qualifies the Record
-         Resource.</rdfs:comment>
+         an external classification vocabulary or scheme that qualifies a Record Resource. </rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">clasificación</rdfs:label>
       <rdfs:label xml:lang="en">classification</rdfs:label>
       <rdfs:label xml:lang="fr">classification</rdfs:label>
+      <rdfs:label xml:lang="es">clasificación</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-11-01</dc:date>
-            <rdf:value xml:lang="en">Text definition and scope note updated. Examples added.
-               Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote, examples (skos:example).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -15487,20 +15526,21 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2020-11-01</dc:date>
+            <rdf:value xml:lang="en">Text definition and scope note updated. Examples added.
+               Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:example xml:lang="en">BUD-01-F002 [example of a classification number from a corporate
-         file plan]</skos:example>
-      <skos:example xml:lang="en">digitized items</skos:example>
-      <skos:example xml:lang="en">financial affairs</skos:example>
+      <skos:example xml:lang="en">BUD-01-F002 (classification number from a corporate file
+         plan)</skos:example>
       <skos:example xml:lang="en">human resource management</skos:example>
       <skos:example xml:lang="en">student registration</skos:example>
-      <skos:scopeNote xml:lang="en">No further statement is made here about the nature of the
-         qualifier, nor about the relation it has with the Record Resource or with the management of
-         the Record Resource. The value of this property may in turn be used as a criterion for
-         identifying the qualified Record Resource as a member of a Record Set.</skos:scopeNote>
+      <skos:example xml:lang="en">financial affairs</skos:example>
+      <skos:example xml:lang="en">digitized items</skos:example>
+      <skos:scopeNote xml:lang="en">May be used in a Record Set description when its value
+         is shared by some or all members of the record set. This datatype property is not to be confused
+         with Identifier although, in some cases, the information may be the
+         same.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A07 (Classification
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -15517,15 +15557,18 @@
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Terms and circumstances affecting the availability of a Record
-         Resource for consultation. Such conditions may originate in laws, regulations and policies,
-         including those pertaining to privacy and security concerns or restrictions; they may
-         concern a specific Instantiation of a Record Resource, for example, conditions that require
-         preservation treatment; or they may specify the software or hardware necessary to access
-         the Instantiation.</rdfs:comment>
+         Resource or an Instantiation for consultation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">condiciones de acceso</rdfs:label>
-      <rdfs:label xml:lang="fr">conditions d’accès</rdfs:label>
       <rdfs:label xml:lang="en">conditions of access</rdfs:label>
+      <rdfs:label xml:lang="fr">conditions d’accès</rdfs:label>
+      <rdfs:label xml:lang="es">condiciones de acceso</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote, examples (skos:example).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -15545,17 +15588,19 @@
                Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:example xml:lang="en">Open</skos:example>
+      <skos:example xml:lang="en">Closed under data protection legislation</skos:example>
+      <skos:example xml:lang="en">Closed as awaiting conservation treatment</skos:example>
       <skos:example xml:lang="es">Acceso libre a través de los terminales de consulta</skos:example>
+      <skos:example xml:lang="en">The Archives cannot provide VHS reader to access the content of
+         the tape</skos:example>
       <skos:example xml:lang="en">Recognita software, min. version 3.0, is needed in order to open
-         the file.</skos:example>
-      <skos:example xml:lang="en">closed as awaiting conservation treatment</skos:example>
-      <skos:example xml:lang="en">closed under data protection legislation</skos:example>
-      <skos:example xml:lang="en">open</skos:example>
-      <skos:example xml:lang="en">the Archives cannot provide VHS reader to access the content of
-         the tape.</skos:example>
-      <skos:scopeNote xml:lang="en">This property provides information about the accessibility of a
-         Record Resource, as well as the physical, technical or legal limitations that exist for
-         providing access to it.</skos:scopeNote>
+         the file</skos:example>
+      <skos:example xml:lang="en">Closed for 30 years</skos:example>
+      <skos:scopeNote xml:lang="en">May be used in a Record Set description when its value
+         is shared by some or all members of the Record Set. The attribute provides information
+         about the accessibility of a Record Resource, as well as the physical, technical or legal
+         limitations that exist for providing access to it.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A08 (Conditions of Access
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -15571,14 +15616,27 @@
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Terms and circumstances affecting the use of a Record Resource
-         after access has been provided. Includes conditions governing reproduction of the Record
-         Resource under applicable copyright (intellectual property) and/or property legislation,
-         and of the Instantiation, due to conservation status.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Terms and circumstances affecting the use of a Record Resource or
+         an Instantiation after access has been provided. Includes conditions governing reproduction
+         of the Record Resource under applicable copyright (intellectual property) and/or property
+         legislation or due to conservation status.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">condiciones de uso</rdfs:label>
-      <rdfs:label xml:lang="fr">conditions d’utilisation</rdfs:label>
       <rdfs:label xml:lang="en">conditions of use</rdfs:label>
+      <rdfs:label xml:lang="fr">conditions d’utilisation</rdfs:label>
+      <rdfs:label xml:lang="es">condiciones de uso</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote, examples (skos:example).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -15592,17 +15650,12 @@
                RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:example xml:lang="en">Freely usable without restrictions</skos:example>
-      <skos:example xml:lang="en">The permission of the owner of the Record must be obtained before
-         use.</skos:example>
-      <skos:example xml:lang="en">The record cannot be copied using warm light copying machines or
-         photographed using flashlight.</skos:example>
+      <skos:example xml:lang="en">Permission of the copyright owner must be obtained before
+         use</skos:example>
+      <skos:example xml:lang="en">Cannot be copied using warm light copying machines or photographed
+         using flashlight</skos:example>
+      <skos:scopeNote xml:lang="en">May be used in a Record Set description when its value
+         is shared by some or all members of the Record Set.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A09 (Conditions of Use
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -15618,14 +15671,14 @@
       <rdfs:label xml:lang="es">fecha de creación</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
@@ -15645,14 +15698,14 @@
       <rdfs:label xml:lang="es">fecha</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Provided for usability reasons, like its subproperties. May be
@@ -15665,17 +15718,17 @@
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#dateQualifier">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">A human readable qualification of the date, when it is necessary
-         to indicate its level of precision or say if it is an estimation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">A human readable qualification of a Date to indicate the level of
+         precision or certainty.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">calificador de fecha</rdfs:label>
       <rdfs:label xml:lang="en">date qualifier</rdfs:label>
       <rdfs:label xml:lang="fr">qualificatif de la date</rdfs:label>
+      <rdfs:label xml:lang="es">calificador de fecha</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-10-10</dc:date>
-            <rdf:value xml:lang="en">Updated the rdfs:comment, skos:scopeNote and examples, in order
-               to make this datatype property fully compliant with RiC-CM 1.0</rdf:value>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -15686,9 +15739,9 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-11-01</dc:date>
-            <rdf:value xml:lang="en">examples added. Objective: to make RiC-O compliant with RiC-CM
-               v0.2.</rdf:value>
+            <dc:date>2023-10-10</dc:date>
+            <rdf:value xml:lang="en">Updated the rdfs:comment, skos:scopeNote and examples, in order
+               to make this datatype property fully compliant with RiC-CM 1.0</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -15697,15 +15750,20 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2020-11-01</dc:date>
+            <rdf:value xml:lang="en">examples added. Objective: to make RiC-O compliant with RiC-CM
+               v0.2.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:example xml:lang="en">approximate</skos:example>
       <skos:example xml:lang="en">circa</skos:example>
       <skos:example xml:lang="en">end unknown</skos:example>
       <skos:scopeNote xml:lang="en">Most often, this human readable expression of the accuracy of
          the date is used along with an ISO 8601 representation of the date. The qualifier can also
-         be expressed as a machine-readable value, using the EDTF standard (thus, using the
-         normalizedDateValue datatype property). An uncertain date (e.g. when you state that a
-         person was possibly born at some date) should be specified using the relationCertainty
-         datatype property, whose domain is the Relation class).</skos:scopeNote>
+         be expressed as a machine-readable value, using the EDTF standard (thus, a specialization
+         of the normalizedDateValue datatype property).</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A13 (Date Qualifier
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -15716,19 +15774,19 @@
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Date at which a Person died.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="fr">date de décès</rdfs:label>
       <rdfs:label xml:lang="en">death date</rdfs:label>
+      <rdfs:label xml:lang="fr">date de décès</rdfs:label>
       <rdfs:label xml:lang="es">fecha de muerte</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
@@ -15736,16 +15794,30 @@
       <RiCCMCorrespondingComponent xml:lang="en">Datatype property specialized implementation of
          RiC-E18 (Date entity)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
-   <!-- https://www.ica.org/standards/RiC/ontology#descriptiveNote -->
-   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#descriptiveNote">
+   <!-- https://www.ica.org/standards/RiC/ontology#generalDescription -->
+   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#generalDescription">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Descriptive information about an entity that is not otherwise
-         addressed.</rdfs:comment>
+      <rdfs:comment xml:lang="en">General information about an entity. General description may be
+         used to describe any entity. There are different appropriate uses for general description.
+         First, while it is recommended that more specific properties be used in describing an
+         entity, it may be desirable, for economic or other reasons, to describe two or more
+         specific properties together. Second, general description may be used to describe one or
+         more characteristics that are not otherwise accommodated in RiC-O. Third, it may be used to
+         provide a succinct summary or abstract description in addition to more detailed specific
+         description.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="en">descriptive note</rdfs:label>
-      <rdfs:label xml:lang="es">nota descriptiva</rdfs:label>
-      <rdfs:label xml:lang="fr">note descriptive</rdfs:label>
+      <rdfs:label xml:lang="en">general description</rdfs:label>
+      <rdfs:label xml:lang="fr">description générale</rdfs:label>
+      <rdfs:label xml:lang="es">descripción general</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the IRI, mapping to RiC-CM
+               (rico:RiCCMCorrespondingComponent), labels, description (rdfs:comment), examples
+               (skos:example).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -15758,8 +15830,26 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A16 (Descriptive Note
-         attribute)</RiCCMCorrespondingComponent>
+      <skos:example xml:lang="fr">Le massif du Mont-Blanc est un massif des Alpes partagé entre la
+         France, l'Italie et la Suisse. Il abrite le mont Blanc, plus haut sommet d'Europe
+         occidentale qui culmine à 4 809 mètres (altitude relevée en 2015). Il est traversé par le
+         tunnel du Mont-Blanc, entre Chamonix dans la vallée de l'Arve et Courmayeur dans la vallée
+         d'Aoste.</skos:example>
+      <skos:example xml:lang="fr">Thomas Blaikie (1750-1838) est un botaniste et jardinier écossais. Il a
+         dessiné notamment les jardins de Malmaison et Bagatelle.</skos:example>
+      <skos:example xml:lang="en">The Senate is the academic governing body of the University of
+         Strathclyde and is responsible for all academic matters including academic standards and
+         quality. Meetings of the Senate are chaired by the Principal and the membership is drawn
+         entirely from within the University, comprising academic and research staff. (about a
+         corporate body, University of Strathclyde Senate)</skos:example>
+      <skos:example xml:lang="en">This activity involves regulating the nursing profession by
+         conducting examinations and on-going education for nurses, maintaining rolls of those
+         qualified as enrolled or registered nurses, midwives, psychiatric, and other specialised
+         nurses. It also covers hearing disciplinary charges against nurses (and where necessary,
+         removing them temporarily or permanently from the registers), as well as promoting the
+         nursing profession. (about an activity, Nursing Profession Regulation)</skos:example>
+      <rico:RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A43 (General Description
+         attribute)</rico:RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#destructionDate -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#destructionDate">
@@ -15768,8 +15858,15 @@
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Date at which an entity was deleted.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="fr">date de destruction</rdfs:label>
       <rdfs:label xml:lang="en">destruction date</rdfs:label>
+      <rdfs:label xml:lang="fr">date de destruction</rdfs:label>
+      <rdfs:label xml:lang="es">fecha de destrucción</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-10-12</dc:date>
@@ -15794,19 +15891,19 @@
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Date at which something ended.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="fr">date de fin</rdfs:label>
       <rdfs:label xml:lang="en">end date</rdfs:label>
+      <rdfs:label xml:lang="fr">date de fin</rdfs:label>
       <rdfs:label xml:lang="es">fecha final</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
@@ -15820,19 +15917,19 @@
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#textualValue"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Natural language expression of a Date. This datatype property is a
-         specialization of the name datatype property. Whenever this attribute is used to store
-         dates, it is recommended that the value comes along with the information needed to
-         understand it; in particular, when needed, it should mention the calendar used or the
-         specific context it is referring to.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Natural language expression of a date. This property is a
+         specialization of the name property. In order that the precise meaning of the date can be
+         understood, information such as the calendar used or other specific context should be
+         included.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="fr">date en langage naturel</rdfs:label>
       <rdfs:label xml:lang="en">expressed date</rdfs:label>
+      <rdfs:label xml:lang="fr">date en langage naturel</rdfs:label>
       <rdfs:label xml:lang="es">fecha expresada</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), examples (skos:example).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -15851,26 +15948,31 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
             <dc:date>2020-11-01</dc:date>
             <rdf:value xml:lang="en">examples added. Objective: to make RiC-O compliant with RiC-CM
                v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:example xml:lang="en">October 24, 1999 (month day, year)</skos:example>
+      <skos:example xml:lang="en">1925-1966 (date range)</skos:example>
       <skos:example xml:lang="fr">15 thermidor an IV (calendrier révolutionnaire
          français)</skos:example>
-      <skos:example xml:lang="en">1925-1966</skos:example>
       <skos:example xml:lang="fr">8 avril 1258 (a. st., style de Pâques)</skos:example>
-      <skos:example xml:lang="en">All of the years 1550, 1151, 1553, 1555</skos:example>
+      <skos:example xml:lang="fr">XVIIe siècle</skos:example>
+      <skos:example xml:lang="en">The Middle Ages</skos:example>
       <skos:example xml:lang="la">Die jovis ultima mensis martii anno domini millesimo quingentesimo
          quadragesimo ante Pascha</skos:example>
-      <skos:example xml:lang="en">October 24th, 1999</skos:example>
+      <skos:example xml:lang="en">1550-1553, 1555 (date range)</skos:example>
       <skos:example xml:lang="en">One of the years 1550, 1551, 1553, 1555</skos:example>
-      <skos:example xml:lang="en">The Middle Ages</skos:example>
+      <skos:example xml:lang="en">All of the years 1550, 1551, 1553, 1555</skos:example>
       <skos:example xml:lang="en">The second semester of 1951 to 1952 (academic reference
          system)</skos:example>
-      <skos:example xml:lang="fr">XVIIe siècle</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">1550-1553,
-         1555</skos:example>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A19 (Expressed Date
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -15882,18 +15984,18 @@
       <rdfs:comment xml:lang="en">Reference system used for geographical coordinates.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">geodesic system</rdfs:label>
-      <rdfs:label xml:lang="es">sistema geodésico</rdfs:label>
       <rdfs:label xml:lang="fr">système géodésique</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="es">sistema geodésico</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
    </owl:DatatypeProperty>
@@ -15902,12 +16004,18 @@
       rdf:about="https://www.ica.org/standards/RiC/ontology#geographicalCoordinates">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Longitudinal and latitudinal information of a
-         Place.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Longitudinal and latitudinal information about a Place. </rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">coordenadas geográficas</rdfs:label>
-      <rdfs:label xml:lang="fr">coordonnées géographiques</rdfs:label>
       <rdfs:label xml:lang="en">geographical coordinates</rdfs:label>
+      <rdfs:label xml:lang="fr">coordonnées géographiques</rdfs:label>
+      <rdfs:label xml:lang="es">coordenadas geográficas</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), examples (skos:example).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -15933,9 +16041,10 @@
                Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:example xml:lang="en">Latitude 35.89421911, Longitude 139.94637467</skos:example>
-      <skos:example xml:lang="en">Latitude 50°40′46,461″N, Longitude 95°48′26,533″W, Height
-         123,45m</skos:example>
+      <skos:example xml:lang="en">Latitude 50°40′46,461″N, Longitude 95°48′26,533″W,
+         Height 123,45m (ISO 6709/D)</skos:example>
+      <skos:example xml:lang="en">Latitude 35.89421911, Longitude 139.94637467 (ISO
+         6709/F)</skos:example>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
          later on. Use only if you don't use PhysicalLocation and Coordinates classes with Place.
          Coordinates may be based on ISO 6709 Standard representation of geographic point location
@@ -15950,9 +16059,9 @@
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Vertical dimension of an entity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">altura</rdfs:label>
-      <rdfs:label xml:lang="fr">hauteur</rdfs:label>
       <rdfs:label xml:lang="en">height</rdfs:label>
+      <rdfs:label xml:lang="fr">hauteur</rdfs:label>
+      <rdfs:label xml:lang="es">altura</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -15971,24 +16080,36 @@
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Activity"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#Record Resource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Agent"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Event"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Place"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Rule"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Place"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Summary of the development of an entity, since its origin until
-         present time.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Summary of the development of an entity throughout its
+         existence.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">history</rdfs:label>
       <rdfs:label xml:lang="fr">histoire</rdfs:label>
       <rdfs:label xml:lang="es">historia</rdfs:label>
-      <rdfs:label xml:lang="en">history</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote, domain, examples (skos:example).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16002,24 +16123,19 @@
                compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:example xml:lang="es">El primer sorteo de lotería se celebró el 13 de mayo de 1771,
-         siendo desarrollado por la Real Lotería General de Nueva España… (Activity)</skos:example>
-      <skos:example xml:lang="es">Nacido en Barbastro en 1892, donde realizó sus primeros estudios
-         con los escolapios. Licenciado en Derecho por la Universidad de Zaragoza, aprobó las
-         oposiciones al cuerpo nacional de notarios…(Person)</skos:example>
       <skos:example xml:lang="en">The manuscripts are part of the collections of Robert Harley (d
          1724) and Edward Harley (d 1741), 1st and 2nd Earls of Oxford, that were brought by
          Parliament and transferred to the British Museum in 1753. Those materials were then
          separated into this collection and those for Harley Charters and Harley Rolls and became
-         part of the collections of the British Library in 1972. (Record Set)</skos:example>
-      <skos:scopeNote xml:lang="en">History can alternatively be represented by a series of related
-         Events.</skos:scopeNote>
+         part of the collections of the British Library in 1972. (about a Record Set)</skos:example>
+      <skos:example xml:lang="es">Nacido en Barbastro en 1892, donde realizó sus primeros estudios
+         con los escolapios. Licenciado en Derecho por la Universidad de Zaragoza, aprobó las
+         oposiciones al cuerpo nacional de notarios… (sobre una persona)</skos:example>
+      <skos:example xml:lang="es">El primer sorteo de lotería se celebró el 13 de mayo de 1771,
+         siendo desarrollado por la Real Lotería General de Nueva España… (sobre una actividad)</skos:example>
+      <skos:scopeNote xml:lang="en">For a record set, may be used to summarize the history of the
+         Record Set itself, or additionally to summarize the history of some or all members of the
+         Record Set. Should not be confused with the scope and content property.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A21 (History
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -16029,22 +16145,31 @@
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">A word, number, letter, symbol, or any combination of these used
          to uniquely identify or reference an individual instance of an entity within a specific
-         information domain. Includes Global Persistent Identifiers (globally unique and
-         persistently resolvable identifier for the entity) and/or Local Identifiers.</rdfs:comment>
+         information domain. Can include Global Persistent Identifiers (globally unique and
+         persistently resolvable identifier for the entity) and/or Local Identifiers. Both the
+         domain within which the identifier is unique, and the rules used in forming the identifier
+         value should be provided with the identifier value.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">identifier</rdfs:label>
       <rdfs:label xml:lang="fr">identifiant</rdfs:label>
       <rdfs:label xml:lang="es">identificador</rdfs:label>
-      <rdfs:label xml:lang="en">identifier</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote, examples (skos:example).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -16054,20 +16179,34 @@
                Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:example xml:lang="en">Ark ID: w6tz44ht</skos:example>
-      <skos:example xml:lang="en">BUD-01-F002 [example of a classification number from a corporate
-         file plan]</skos:example>
-      <skos:example xml:lang="en">F 1204 [example of a local identifier for a Record Set assigned by
-         a repository]</skos:example>
-      <skos:example xml:lang="en">ISNI : 0000000073572182</skos:example>
-      <skos:example xml:lang="en">NAS1/A/1.1 [example of local identifier for a
-         Record]</skos:example>
-      <skos:example xml:lang="en">SNAC ID: 83847206</skos:example>
+      <skos:example xml:lang="en">http://n2t.net/ark:/99166/w6v1266v (example of an Archival
+         Resource Key for a record)</skos:example>
+      <skos:example xml:lang="en">http://n2t.net/ark:/99166/w6tz44ht (example of an Archival
+         Resource Key for a person)</skos:example>
+      <skos:example xml:lang="en">http://isni.org/0000000073572182 (example of a persistent
+         International Standard Name Identifier for a person)</skos:example>
+      <skos:example xml:lang="en">BUD-01-F002 (example of a classification number from a corporate
+         file plan)</skos:example>
+      <skos:example xml:lang="en">NAS1/A/1.1 (example of a local identifier for a
+         record)</skos:example>
+      <skos:example xml:lang="en">F 1204 (example of a local identifier for a record set assigned by
+         a repository)</skos:example>
+      <skos:example xml:lang="en">B-000091 (example of a unique identifier for an instantiation
+         assigned by a repository)</skos:example>
       <skos:scopeNote xml:lang="en">Use only if you don't use Identifier class for handling
          identifiers. Within a given domain (a closed system), identifiers are used to uniquely
          reference instances of an entity. Identifiers are instruments of control that facilitate
          management of the entities within the domain. The formulation of identifiers commonly is
-         based on rules.</skos:scopeNote>
+         based on rules. In addition to an identifier needing to be unique within a domain, it is
+         also highly desirable that it be persistent, that is, that the identifier uniquely
+         identifies the entity over time. A variety of organizations provide rules for the formation
+         of identifiers, and services designed to facilitate the persistence of identifiers. Such
+         identifiers are commonly referred to as Persistent Identifiers (or PIDs). PIDs conform to
+         RFC 3986, but impose additional rules. Common examples are Archival Resource Keys (ARKs)
+         and Digital Object Identifiers (DOIs). Within the global environment of the Internet, there
+         are special rules for the formation of identifiers to ensure that they are unique within
+         the domain of the Internet. Such identifiers must conform to the Internet Engineering Task
+         Force (IETF) Uniform Resource Identifier rules (RFC 3986).</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A22 (Identifier
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -16077,7 +16216,7 @@
          rdf:resource="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Countable characteristics of the Instantiation expressed as a
+      <rdfs:comment xml:lang="en">Countable characteristics of an Instantiation expressed as a
          quantity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Instantiation extent</rdfs:label>
@@ -16085,9 +16224,15 @@
       <rdfs:label xml:lang="es">soporte de instanciación</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-11-01</dc:date>
-            <rdf:value xml:lang="en">Scope note updated. Examples added. Objective: to make RiC-O
-               compliant with RiC-CM v0.2.</rdf:value>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote, examples (skos:example).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -16098,18 +16243,21 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2020-11-01</dc:date>
+            <rdf:value xml:lang="en">Scope note updated. Examples added. Objective: to make RiC-O
+               compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:example xml:lang="en">Size of PDF-file: 1.5 MB</skos:example>
-      <skos:example xml:lang="en">The book register has 345 written leaves.</skos:example>
-      <skos:scopeNote xml:lang="en">For a given Record Resource, the Instantiation Extent may vary,
-         based on format, density of information on the carrier, etc. For example, a file of 1500
-         words (Record Resource Extent) may have Instantiation Extent 3kb as a Word document and 5kb
-         as a PDF file, and instantiations may be represented on a CD of 700mb (Carrier Extent). Use
-         if you don't use InstantiationExtent class and its properties for handling such
-         information.</skos:scopeNote>
+      <skos:example xml:lang="en">The register has 345 written folios</skos:example>
+      <skos:example xml:lang="en">Size of PDF file: 1.5 MB</skos:example>
+      <skos:example xml:lang="en">234 linear metres</skos:example>
+      <skos:scopeNote xml:lang="en">Instantiation extent should not be confused with record resource
+         extent or carrier extent. For a given Record Resource, the instantiation extent may vary,
+         based on format, density of information on the carrier, etc. For example, a CD with a
+         storage capacity of 700 MB (carrier extent) might hold a record of 1500 words (record
+         resource extent) represented in two versions, one a Word document with an instantiation
+         extent of 3 KB and the other a PDF file with an instantiation extent of 5
+         KB.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A23 (Instantiation Extent
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -16123,8 +16271,14 @@
          Instantiation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Instantiation structure</rdfs:label>
-      <rdfs:label xml:lang="es">estructura de la instanciación</rdfs:label>
       <rdfs:label xml:lang="fr">structure de l’instanciation</rdfs:label>
+      <rdfs:label xml:lang="es">estructura de la instanciación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16138,43 +16292,37 @@
                RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Specialization of RiC-A40 (Structure
+         attribute)</RiCCMCorrespondingComponent>
+   </owl:DatatypeProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#integrityNote -->
+   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#integrityNote">
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+      <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+      <rdfs:comment xml:lang="en">Information about the known intellectual completeness of a Record
+         Resource.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">integrity note</rdfs:label>
+      <rdfs:label xml:lang="fr">note sur l'intégrité</rdfs:label>
+      <rdfs:label xml:lang="es">nota de integridad</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the IRI, mapping to RiC-CM
+               (rico:RiCCMCorrespondingComponent), labels, description (rdfs:comment),
+               skos:scopeNote, domain, examples (skos:example).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Specialization of RiC-A40 (Structure
-         attribute)</RiCCMCorrespondingComponent>
-   </owl:DatatypeProperty>
-   <!-- https://www.ica.org/standards/RiC/ontology#integrity -->
-   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#integrity">
-      <rdfs:domain>
-         <owl:Class>
-            <owl:unionOf rdf:parseType="Collection">
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-            </owl:unionOf>
-         </owl:Class>
-      </rdfs:domain>
-      <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Information about the completeness of a Record Resource or
-         Instantiation.</rdfs:comment>
-      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">integridad</rdfs:label>
-      <rdfs:label xml:lang="en">integrity</rdfs:label>
-      <rdfs:label xml:lang="fr">intégrité</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -16184,15 +16332,24 @@
                compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:example xml:lang="en">The book register’s last pages are missing, which affects the
-         completeness of the record.</skos:example>
-      <skos:example xml:lang="en">The charter is missing the seal.</skos:example>
-      <skos:example xml:lang="en">The database (DBF) file has the checksum SHA-1:
-         99f9d780e441785016dea545b72dad700305535a.</skos:example>
-      <skos:scopeNote xml:lang="en">The information about integrity may be generated manually or
-         automatically.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A24 (Integrity
-         attribute)</RiCCMCorrespondingComponent>
+      <skos:example xml:lang="en">For record set: series of letters, one is missing so the integrity
+         is compromised.</skos:example>
+      <skos:example xml:lang="en">A web page (HTML, 15 images, 2 CSS, 1 javascript), with 5 images
+         missing.</skos:example>
+      <skos:example xml:lang="en">Part of the text is missing (because a corner on the instantiation
+         was cut out, which is a physical characteristic). See also the examples of
+         physicalCharacteristics.</skos:example>
+      <skos:example xml:lang="en">Line three of a hand-written letter was cut out and a replacement
+         text was inserted by an unknown person.</skos:example>
+      <skos:scopeNote xml:lang="en">May be used in a Record Set description when its value
+         is shared by some or all members of the Record Set. The information about integrity may be
+         generated manually or automatically. Not to be confused with the physical completeness of
+         the instantiation, which is covered by the physical characteristics note attribute. The
+         integrity of a Record Resource and the physical characteristics note of an Instantiation
+         may be complementary. This attribute also covers any additions to or removal of original
+         information.</skos:scopeNote>
+      <rico:RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A24 (Integrity Note
+         attribute)</rico:RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#lastModificationDate -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#lastModificationDate">
@@ -16201,19 +16358,19 @@
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Date at which an entity was last updated.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">last modification date</rdfs:label>
       <rdfs:label xml:lang="fr">date de dernière modification</rdfs:label>
       <rdfs:label xml:lang="es">fecha de última modificación</rdfs:label>
-      <rdfs:label xml:lang="en">last modification date</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
@@ -16228,19 +16385,19 @@
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Distance in degrees north or south of the equator.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">latitud</rdfs:label>
       <rdfs:label xml:lang="en">latitude</rdfs:label>
       <rdfs:label xml:lang="fr">latitude</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="es">latitud</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Property of the Coordinates class. If you don't use this class,
@@ -16254,6 +16411,14 @@
       <rdfs:comment xml:lang="en">Length of an entity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">length</rdfs:label>
+      <rdfs:label xml:lang="fr">longueur</rdfs:label>
+      <rdfs:label xml:lang="es">longitud</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -16268,13 +16433,26 @@
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#location">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">A delimitation of the physical territory of a place. This datatype
-         property is used to describe basic human-readable text such as an address, a cadastral
-         reference, or less precise information found in a record.</rdfs:comment>
+      <rdfs:comment xml:lang="en">A delimitation of the physical territory of a Place. Used to
+         describe basic human-readable text such as an address, a cadastral reference, or less
+         precise information found in a Record.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">location</rdfs:label>
       <rdfs:label xml:lang="fr">localisation</rdfs:label>
       <rdfs:label xml:lang="es">localización</rdfs:label>
-      <rdfs:label xml:lang="en">location</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote, examples (skos:example).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16288,18 +16466,12 @@
                Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
       <skos:example xml:lang="fr">25 rue Saint-Denis à Paris</skos:example>
-      <skos:example xml:lang="en">near the church</skos:example>
-      <skos:example xml:lang="en">« Montreal »</skos:example>
+      <skos:example xml:lang="en">Montreal (city in Canada)</skos:example>
       <skos:scopeNote xml:lang="en">Use only if you don't use PhysicalLocation class with Place. Use
-         the geographicalCoordinates property, or the Coordinates class, record the geographical
-         coordinates of the Place.s</skos:scopeNote>
+         the geographicalCoordinates property, or the Coordinates class, to record the geographical
+         coordinates of the Place. Use the spatial relations (particularly 'has or had location') to
+         capture a relation between two places.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A27 (Location
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -16311,19 +16483,19 @@
       <rdfs:comment xml:lang="en">Distance in degrees east or west of a prime
          meridian.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">longitud</rdfs:label>
       <rdfs:label xml:lang="en">longitude</rdfs:label>
       <rdfs:label xml:lang="fr">longitude</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="es">longitud</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Property of the Coordinates class. If you don't use this class,
@@ -16337,8 +16509,8 @@
          determined by measurement or calculation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">measure</rdfs:label>
-      <rdfs:label xml:lang="es">medida</rdfs:label>
       <rdfs:label xml:lang="fr">mesure</rdfs:label>
+      <rdfs:label xml:lang="es">medida</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -16359,19 +16531,19 @@
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Date of the modification of an entity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">modification date</rdfs:label>
       <rdfs:label xml:lang="fr">date de modification</rdfs:label>
       <rdfs:label xml:lang="es">fecha de modificación</rdfs:label>
-      <rdfs:label xml:lang="en">modification date</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
@@ -16383,18 +16555,29 @@
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#name">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">A label, title or term designating the entity in order to make it
-         distinguishable from other similar entities. For Record Resource or Instantiation, the Name
-         is generally assigned by an Agent as most do not have a Name given when
-         created.</rdfs:comment>
+      <rdfs:comment xml:lang="en">A label, title or term designating an entity in order to make it
+         distinguishable from other similar entities.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">name</rdfs:label>
       <rdfs:label xml:lang="fr">nom</rdfs:label>
       <rdfs:label xml:lang="es">nombre</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote, examples (skos:example).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -16404,24 +16587,25 @@
                RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:example xml:lang="en">4 March 1842</skos:example>
-      <skos:example xml:lang="en">Digital copy of the Pomarius archival inventory from
-         1575</skos:example>
-      <skos:example xml:lang="en">Nelson Mandela</skos:example>
-      <skos:example xml:lang="en">Papers of the Earls of Liverpool</skos:example>
-      <skos:example xml:lang="en">Sketch Map of the Qatar Peninsula</skos:example>
-      <skos:example xml:lang="en">The Letter of Neacsu from Campulung to the Mayor of
-         Brasov</skos:example>
-      <skos:example xml:lang="en">fundraising, University of Glasgow</skos:example>
-      <skos:example xml:lang="en">hearing services</skos:example>
-      <skos:scopeNote xml:lang="en">Use only if you don't use Name class for handling
-         names.</skos:scopeNote>
+      <skos:example xml:lang="en">The Letter of Neacsu from Campulung to the Mayor of Brasov (about
+         a Record)</skos:example>
+      <skos:example xml:lang="en">Digital copy of the Pomarius archival inventory from 1575 (about
+         an Instantiation)</skos:example>
+      <skos:example xml:lang="en">D-Day (about a Date or Event)</skos:example>
+      <skos:example xml:lang="en">Halloween 2016 (about a Date)</skos:example>
+      <skos:example xml:lang="en">Fundraising, University of Glasgow (about an
+         Activity)</skos:example>
+      <skos:example xml:lang="en">Providing hearing services (about an Activity)</skos:example>
+      <skos:example xml:lang="en">Nelson Mandela (about a Person)</skos:example>
+      <skos:example xml:lang="en">Papers of the Earls of Liverpool (about a Record
+         Set)</skos:example>
+      <skos:example xml:lang="en">Paris (about a Place)</skos:example>
+      <skos:example xml:lang="en">Prime Minister (about a Position)</skos:example>
+      <skos:example xml:lang="en">Sketch Map of the Qatar Peninsula (about a Record)</skos:example>
+      <skos:scopeNote xml:lang="en">Use only if you don't use Name class for handling names.
+         Provides brief information about the content or other individual characteristics of the
+         entity being described, necessary to distinguish it from other perhaps similar
+         entities.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corrresponds to RiC-A28 (Name
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -16438,16 +16622,9 @@
       <rdfs:label xml:lang="es">valor normalizado de fecha</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-10-10</dc:date>
-            <rdf:value xml:lang="en">Updated the rdfs:comment and examples, and added a scopeNote,
-               in order to make this property fully compliant with RiC-CM 1.0.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2020-11-01</dc:date>
-            <rdf:value xml:lang="en">Examples added. Objective: to make RiC-O compliant with RiC-CM
-               v0.2.</rdf:value>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the examples
+               (skos:example).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -16458,30 +16635,34 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
+            <dc:date>2023-10-10</dc:date>
+            <rdf:value xml:lang="en">Updated the rdfs:comment and examples, and added a scopeNote,
+               in order to make this property fully compliant with RiC-CM 1.0.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
             <dc:date>2023-08-25</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:example>1948-03-03</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >1948-03</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >1948-03-08</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >1948-03~</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">1948/</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >1948/..</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >2012-02-14/2015-03-08</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >2012/2015-03</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >[1550,1551,1553,1555]</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >{1550,1151,1553,1555}</skos:example>
-      <skos:example rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal"
-         >{1805,1815..1820}</skos:example>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2020-11-01</dc:date>
+            <rdf:value xml:lang="en">Examples added. Objective: to make RiC-O compliant with RiC-CM
+               v0.2.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:example xml:lang="en">2012-02-14/2015-03-08 (an ISO 8601 form of a date range)</skos:example>
+      <skos:example xml:lang="en">2012/2015-03 (an ISO 8601 form of a date range)</skos:example>
+      <skos:example xml:lang="en">1948-03 (an ISO 8601 form of a single date)</skos:example>
+      <skos:example xml:lang="en">1948-03-08 (an ISO 8601 form of a single date)</skos:example>
+      <skos:example xml:lang="en">1948-03~ (a single date in ETDF, meaning March 1948 approximately)</skos:example>
+      <skos:example xml:lang="en">1948/.. (an open date range in EDTF, starting in 1948)</skos:example>
+      <skos:example xml:lang="en">1948/ (a date range in EDTF, starting in 1948, end unknown)</skos:example>
+      <skos:example xml:lang="en">1550,1551,1553,1555 (a date set in EDTF, meaning one of the years 1550, 1151, 1553, 1555)</skos:example>
+      <skos:example xml:lang="en">{1550,1151,1553,1555} (a date set in EDTF, meaning all of the years 1550, 1151, 1553, 1555)</skos:example>
+      <skos:example xml:lang="en">{1805,1815..1820} (a date set in EDTF, meaning all of the years 1805, 1815, 1816, 1817, 1818, 1819, 1820)</skos:example>
       <skos:scopeNote xml:lang="en">Used to represent the date in a standardized format that can be
          processed programmatically. The main standard used today is ISO 8601, which is based on the
          Gregorian calendar. See also the Extended Date Time Format (EDTF), which is an extension of
@@ -16510,29 +16691,38 @@
       <rdfs:label xml:lang="es">valor normalizado</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:DatatypeProperty>
-   <!-- https://www.ica.org/standards/RiC/ontology#physicalCharacteristics -->
+   <!-- https://www.ica.org/standards/RiC/ontology#physicalCharacteristicsNote -->
    <owl:DatatypeProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#physicalCharacteristics">
+      rdf:about="https://www.ica.org/standards/RiC/ontology#physicalCharacteristicsNote">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Information about the physical features of the Instantiation.
-         Includes information about the physical nature and condition such as conservation
-         status.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Information about the physical features, completeness, or
+         conservation status of an Instantiation. Includes information about the physical nature and
+         condition such as conservation status or the deterioration of an Instantiation (for example
+         its carrier) affecting the ability to recover information. </rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">característifcas físicas</rdfs:label>
-      <rdfs:label xml:lang="fr">caractéristiques physiques</rdfs:label>
-      <rdfs:label xml:lang="en">physical characteristics</rdfs:label>
+      <rdfs:label xml:lang="en">physical characteristics note</rdfs:label>
+      <rdfs:label xml:lang="fr">note sur les caractéristiques physiques</rdfs:label>
+      <rdfs:label xml:lang="es">nota sobre las características físicas</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the IRI, mapping to RiC-CM
+               (rico:RiCCMCorrespondingComponent), labels, description (rdfs:comment),
+               skos:scopeNote, examples (skos:example).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -16552,12 +16742,23 @@
                RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:example xml:lang="en">British Library binding</skos:example>
       <skos:example xml:lang="en">carrier heavily foxed</skos:example>
-      <skos:example xml:lang="en">emulsion flaking</skos:example>
-      <skos:example xml:lang="en">watermarked</skos:example>
-      <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A31 (Physical Characteristics
-         attribute)</RiCCMCorrespondingComponent>
+      <skos:example xml:lang="en">some loss of text due to rodent damage</skos:example>
+      <skos:example xml:lang="en">The charter is missing the seal.</skos:example>
+      <skos:example xml:lang="en">Letter physical characteristics: corner without text missing – the
+         carrier is damaged, but no information of the content is missing</skos:example>
+      <skos:example xml:lang="en">British Library binding</skos:example>
+      <skos:example xml:lang="en">Watermarked</skos:example>
+      <skos:example xml:lang="en">A web page (HTML, 15 images, 2 CSS, 1 JavaScript), with 1 CSS
+         missing.</skos:example>
+      <skos:example xml:lang="en">For carrier: hard drives on which the author wrote physically
+         (using a pen).</skos:example>
+      <skos:example xml:lang="en">Digital file format: JPEG-2000</skos:example>
+      <skos:scopeNote xml:lang="en">Not to be confused with the intellectual completeness of a
+         Record Resource and its sub-entities, which is covered by the Integrity attribute. May
+         include digital file fixity. </skos:scopeNote>
+      <rico:RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A31 (Physical
+         Characteristics Note attribute)</rico:RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent -->
    <owl:DatatypeProperty
@@ -16575,19 +16776,19 @@
       <rdfs:comment xml:lang="en">Countable characteristics of the content of an entity expressed as
          a quantity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="fr">importance physique ou logique</rdfs:label>
       <rdfs:label xml:lang="en">physical or logical extent</rdfs:label>
+      <rdfs:label xml:lang="fr">importance physique ou logique</rdfs:label>
       <rdfs:label xml:lang="es">soporte físico o lógico</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. Use only if you cannot use the
@@ -16598,12 +16799,25 @@
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#productionTechnique">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Method used in the representation of information on the
+      <rdfs:comment xml:lang="en">The method used in the representation of information on an
          Instantiation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">production technique</rdfs:label>
       <rdfs:label xml:lang="fr">technique de production</rdfs:label>
       <rdfs:label xml:lang="es">técnica de produccióon</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -16615,12 +16829,6 @@
             <dc:date>2020-11-01</dc:date>
             <rdf:value xml:lang="en">Examples added. Objective: to make RiC-O compliant with RiC-CM
                v0.2.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:example xml:lang="en">engraving</skos:example>
@@ -16640,9 +16848,9 @@
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Date of the publication of a Record Resource.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">publication date</rdfs:label>
       <rdfs:label xml:lang="fr">date de publication</rdfs:label>
       <rdfs:label xml:lang="es">fecha de publicación</rdfs:label>
-      <rdfs:label xml:lang="en">publication date</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -16660,25 +16868,32 @@
       <RiCCMCorrespondingComponent xml:lang="en">Datatype property specialized implementation of
          RiC-E18 (Date entity)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
-   <!-- https://www.ica.org/standards/RiC/ontology#qualityOfRepresentation -->
+   <!-- https://www.ica.org/standards/RiC/ontology#qualityOfRepresentationNote -->
    <owl:DatatypeProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#qualityOfRepresentation">
+      rdf:about="https://www.ica.org/standards/RiC/ontology#qualityOfRepresentationNote">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#physicalCharacteristicsNote"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">Conditions of an Instantiation that impact the legibility or
-         completeness of Record Resource, and thus the viability of its use. Conditions may be
-         associated with deficiencies in the processes of Record (re)creation or capture, or the
-         deterioration of the Instantiation (e.g. its carrier) causing loss of information of the
-         record over time</rdfs:comment>
+      <rdfs:comment xml:lang="en">Characteristics of an Instantiation that affect the ability to
+         recover the intellectual content. Such characteristics may be related to the methods used
+         in creating the Instantiation or introduced subsequent to the creation through
+         accident.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">calidad de representación</rdfs:label>
-      <rdfs:label xml:lang="en">quality of representation</rdfs:label>
-      <rdfs:label xml:lang="fr">qualité de la représentation</rdfs:label>
+      <rdfs:label xml:lang="en">quality of representation note</rdfs:label>
+      <rdfs:label xml:lang="fr">note sur la qualité de la représentation</rdfs:label>
+      <rdfs:label xml:lang="es">nota sobre la calidad de representación</rdfs:label><skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the IRI, mapping to RiC-CM
+               (rico:RiCCMCorrespondingComponent), labels, description (rdfs:comment),
+               skos:scopeNote, rdfs:subpropertyOf.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-11-01</dc:date>
-            <rdf:value xml:lang="en">Text definition updated. Examples added. Objective: to make
-               RiC-O compliant with RiC-CM v0.2.</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -16689,8 +16904,9 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2020-11-01</dc:date>
+            <rdf:value xml:lang="en">Text definition updated. Examples added. Objective: to make
+               RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:example xml:lang="en">Black and white digitization may have led to loss of some
@@ -16698,8 +16914,12 @@
       <skos:example xml:lang="en">some loss of information due to poor quality of image
          capture</skos:example>
       <skos:example xml:lang="en">some loss of text due to rodent damage</skos:example>
-      <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A34 (Quality of Representation
-         attribute)</RiCCMCorrespondingComponent>
+      <skos:scopeNote xml:lang="en">Quality of representation note is a specialization of physical
+         characteristics note. Quality of representation note should be used in conjunction with
+         physical characteristics note when the physical characteristics impact the ability to
+         recover the intellectual content.</skos:scopeNote>
+      <rico:RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A34 (Quality of
+         Representation Note attribute)</rico:RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#quantity -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#quantity">
@@ -16708,15 +16928,9 @@
       <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
       <rdfs:comment xml:lang="en">Machine-readable quantity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">cantidad</rdfs:label>
       <rdfs:label xml:lang="en">quantity</rdfs:label>
       <rdfs:label xml:lang="fr">quantité</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="es">cantidad</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -16725,10 +16939,14 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-10-28</dc:date>
-            <rdf:value xml:lang="en">Datatype property created along with unitOfMeasurement, Extent
-               and UnitOfMeasurement classes, in order to provide methods for handling extent
-               accurately.</rdf:value>
+            <dc:date>2023-08-28</dc:date>
+            <rdf:value xml:lang="en">Added an xml:lang attribute to the rdfs:comment.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -16739,8 +16957,10 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-28</dc:date>
-            <rdf:value xml:lang="en">Added an xml:lang attribute to the rdfs:comment.</rdf:value>
+            <dc:date>2020-10-28</dc:date>
+            <rdf:value xml:lang="en">Datatype property created along with unitOfMeasurement, Extent
+               and UnitOfMeasurement classes, in order to provide methods for handling extent
+               accurately.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Use if you use the Extent class and its properties for handling
@@ -16752,23 +16972,22 @@
          rdf:resource="https://www.ica.org/standards/RiC/ontology#physicalOrLogicalExtent"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-      <rdfs:comment xml:lang="en">The quantity of information content as human experienced
-         represented in the Record Resource. The method and precision of expressing the quantity of
-         information represented in a Record Resource will vary by the kind of Record Resource being
-         described as well as by processing economy constraints. For record sets, quantity may be
-         expressed as number of records, or, for analogue records in particular, by the physical
-         storage dimensions of the Record members. For individual records or record parts, quantity
-         may be expressed in more precise terms. Use if you don't use RecordResourceExtent class and
-         its properties for handling such information.</rdfs:comment>
+      <rdfs:comment xml:lang="en">The quantity of information content, as human experienced,
+         contained in a Record Resource. The method and precision of expressing the quantity of
+         information represented in a Record Resource will vary according to the kind of Record
+         Resource being described, processing economy constraints, etc. For record sets, quantity
+         may be expressed as number of records, or, for analogue records in particular, by the
+         physical storage dimensions of the members of the Record Set. For individual records or
+         record parts, quantity may be expressed in more precise terms. </rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Record Resource extent</rdfs:label>
       <rdfs:label xml:lang="fr">mesure de la ressource archivistique</rdfs:label>
       <rdfs:label xml:lang="es">soporte de recurso documental</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-11-01</dc:date>
-            <rdf:value xml:lang="en">Text definition and scope note updated. Examples added.
-               Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote, examples (skos:example).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -16790,19 +17009,27 @@
                been created.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:example xml:lang="en">1,500 words</skos:example>
-      <skos:example xml:lang="en">2 films</skos:example>
-      <skos:example xml:lang="en">2.065.735 characters</skos:example>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2020-11-01</dc:date>
+            <rdf:value xml:lang="en">Text definition and scope note updated. Examples added.
+               Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:example xml:lang="en">3 minutes and 24 seconds</skos:example>
-      <skos:example xml:lang="en">34 poems</skos:example>
       <skos:example xml:lang="en">6 maps</skos:example>
       <skos:example xml:lang="en">6 photographs</skos:example>
-      <skos:scopeNote xml:lang="en">The number, size or duration of the information content unit(s)
-         remains the same even if the information is instantiated in various carriers. For example,
-         a file of 1500 words (Record Resource Extent) may have Instantiation Extent 3kb as a Word
-         document and 5kb as a PDF file, and instantiations may be represented on a CD of 700mb
-         (Carrier Extent). Use if you don't use RecordResourceExtent class and its properties for
-         handling such information.</skos:scopeNote>
+      <skos:example xml:lang="en">2 films</skos:example>
+      <skos:example xml:lang="en">1,500 words</skos:example>
+      <skos:example xml:lang="en">2.065.735 characters</skos:example>
+      <skos:scopeNote xml:lang="en">Use if you don't use RecordResourceExtent class and its
+         properties for handling such information. Record resource extent should not be confused
+         with instantiation extent or carrier extent. The number, size or duration of the
+         information content unit(s) remains the same even if the information is instantiated in
+         various carriers. For example, a CD with a storage capacity of 700 MB (carrier extent)
+         might hold a record of 1,500 words (record resource extent) represented in two versions,
+         one a Word document with an instantiation extent of 3 KB and the other a PDF file with an
+         instantiation extent of 5 KB.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A35 (Record Resource extent
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -16820,13 +17047,12 @@
          Set</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Record Resource structure</rdfs:label>
-      <rdfs:label xml:lang="es">estructura de recurso documental</rdfs:label>
       <rdfs:label xml:lang="fr">structure de la ressource archivistique</rdfs:label>
+      <rdfs:label xml:lang="es">estructura de recurso documental</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-11-01</dc:date>
-            <rdf:value xml:lang="en">Text definition updated. Examples added. Objective: to make
-               RiC-O compliant with RiC-CM v0.2.</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -16837,8 +17063,9 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2020-11-01</dc:date>
+            <rdf:value xml:lang="en">Text definition updated. Examples added. Objective: to make
+               RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:example xml:lang="en">Inside each file, the records are arranged
@@ -16860,8 +17087,8 @@
          information.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">reference system</rdfs:label>
-      <rdfs:label xml:lang="es">sistema de referencia</rdfs:label>
       <rdfs:label xml:lang="fr">système de référence</rdfs:label>
+      <rdfs:label xml:lang="es">sistema de referencia</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -16883,18 +17110,18 @@
          ongoing, unknown).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Relation state</rdfs:label>
-      <rdfs:label xml:lang="es">estado de la relación</rdfs:label>
       <rdfs:label xml:lang="fr">statut de la relation</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="es">estado de la relación</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
    </owl:DatatypeProperty>
@@ -16905,19 +17132,19 @@
       <rdfs:comment xml:lang="en">The rule or conditions that govern the existence or lifecycle of a
          Thing.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">regla aplicada</rdfs:label>
       <rdfs:label xml:lang="en">rule followed</rdfs:label>
       <rdfs:label xml:lang="fr">règle suivie</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="es">regla aplicada</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
@@ -16925,25 +17152,26 @@
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#scopeAndContent -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#scopeAndContent">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#generalDescription"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Summary of the scope (such as time periods, geography) and content
-         (such as subject matter, administrative processes) of the Record Resource. It should
-         highlight the information conveyed in the Record Resource, why it was created, received,
-         and/or maintained, and the Agents connected to it. Scope and Content provides a more
-         complete summary of the informational content of the Record Resource. It may include
-         description of relations with agents, activities, dates and places, or with other record
-         resources. It is not to be confused with the History attribute which focuses on the
-         origination and subsequence changes to a Record Resource.</rdfs:comment>
+         (such as subject matter, administrative processes) of a Record Resource. Provides a more
+         complete summary of the informational content of the Record Resource highlighting the
+         information conveyed in the Record Resource, why it was created, received, and/or
+         maintained, and the agents connected to it. It may include description of relations with
+         agents, activities, dates and places, or with other record resources.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">alcance y contenido</rdfs:label>
-      <rdfs:label xml:lang="fr">portée et contenu</rdfs:label>
       <rdfs:label xml:lang="en">scope and content</rdfs:label>
+      <rdfs:label xml:lang="fr">portée et contenu</rdfs:label>
+      <rdfs:label xml:lang="es">alcance y contenido</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-11-01</dc:date>
-            <rdf:value xml:lang="en">Text definition updated. Examples added. Objective: to make
-               RiC-O compliant with RiC-CM v0.2.</rdf:value>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote, rdfs:subpropertyOf, examples
+               (skos:example).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -16964,17 +17192,29 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:example xml:lang="en">Among the witnesses, the duke of Normandy.</skos:example>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2020-11-01</dc:date>
+            <rdf:value xml:lang="en">Text definition updated. Examples added. Objective: to make
+               RiC-O compliant with RiC-CM v0.2.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:example xml:lang="en">Includes a detailed list of the lands and villages given by the
          King to the Abbey.</skos:example>
+      <skos:example xml:lang="en">Among the witnesses, the Duke of Normandy.</skos:example>
+      <skos:example xml:lang="en">The author explains why he does not agree with the decision made
+         and adds that it cannot be applied.</skos:example>
       <skos:example xml:lang="en">Letter from Vlad the Impaler (Dracula) to the Council of Kronstadt
          asking them to send military support against the Ottomans, within the framework of their
          alliance treaty.</skos:example>
       <skos:example xml:lang="es">Se hace referencia a construcción del Gran Hotel, iniciada en 1899
          bajo el nombre de Casa Celestino. Tras su interrupción en 1902, continuó la obra ya con su
          nombre actual.</skos:example>
-      <skos:example xml:lang="en">The author explains why he does not agree with the decision made
-         and adds that it cannot be applied.</skos:example>
+      <skos:scopeNote xml:lang="en">Scope and content is a specialization of general description.
+         For a Record Set, may be used to summarize the scope and content of the Record Set itself,
+         or additionally to summarize the scope and content of some or all members of the Record
+         Set. It is not to be confused with the history dataytpe property which focuses on the origination
+         and subsequent changes to a Record Resource. </skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A38 (Scope and Content
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -16993,19 +17233,19 @@
       <rdfs:comment xml:lang="en">Information about a source used to identify or describe an
          entity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">fuente</rdfs:label>
       <rdfs:label xml:lang="en">source</rdfs:label>
       <rdfs:label xml:lang="fr">source</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="es">fuente</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Can be used, in particular, for Records having documentary form
@@ -17033,9 +17273,22 @@
          comprise information about the composition of the physical elements of the
          instantiation</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">estructura</rdfs:label>
       <rdfs:label xml:lang="en">structure</rdfs:label>
       <rdfs:label xml:lang="fr">structure</rdfs:label>
+      <rdfs:label xml:lang="es">estructura</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the skos:scopeNote, examples
+               (skos:example).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17049,15 +17302,21 @@
                with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <skos:example xml:lang="en">The record has two appendices, comprising a full account of the
+         income from car taxes and real estate taxes</skos:example>
+      <skos:example xml:lang="en">The series have the files arranged according to the alphabetical
+         order of the places concerned</skos:example>
+      <skos:example xml:lang="en">Inside each file, the records are arranged chronologically (about
+         a record set)</skos:example>
+      <skos:example xml:lang="en">The database has three related tables: names, addresses, and
+         passport numbers (about a record)</skos:example>
       <skos:scopeNote xml:lang="en">Use only if you cannot use the subproperties (particularly if
          the same free text is being used in your current metadata for describing the record
-         resource and the instantiation structure).</skos:scopeNote>
+         resource and the instantiation structure). For a Record Set, may be used to summarize the
+         structure of the Record Set itself, or additionally to summarize the structure of some or
+         all members of the Record Set. Should not be confused with the classification datatype property,
+         which provides information about the category which the Record Set belongs to within a
+         classification scheme. </skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A40 (Structure
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -17069,13 +17328,14 @@
       <rdfs:comment xml:lang="en">Describes any relevant physical or software feature of any device
          involved in the creation or management of a Record Resource.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">características técnicas</rdfs:label>
-      <rdfs:label xml:lang="fr">caractéristiques techniques</rdfs:label>
       <rdfs:label xml:lang="en">technical characteristics</rdfs:label>
+      <rdfs:label xml:lang="fr">caractéristiques techniques</rdfs:label>
+      <rdfs:label xml:lang="es">características técnicas</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-11</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -17086,23 +17346,22 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
             <dc:date>2020-11-01</dc:date>
             <rdf:value xml:lang="en">Scope note and examples added. Objective: to make RiC-O
                compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
       <skos:example xml:lang="en">Hubble Space Telescope had until 2002 a flawed mirror that
          introduced severe spherical aberration for the images.</skos:example>
       <skos:scopeNote xml:lang="en">Does not include references to the workflow that the Mechanism
-         is involved in which is described under the Activity entity. It emphasizes those features
-         that provide a better understanding of the impact of the Mechanism on the
-         records.</skos:scopeNote>
+         is involved in, which is described under the Activity entity. It emphasizes those features
+         that provide a better understanding of the impact of the Mechanism on the records.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A41 (Technical Characteristics
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -17125,14 +17384,14 @@
       <rdfs:label xml:lang="es">valor textual</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
    </owl:DatatypeProperty>
@@ -17153,19 +17412,19 @@
       <rdfs:comment xml:lang="en">An identifying name of a Record Resource, Instantiation or
          Rule.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="fr">intitulé</rdfs:label>
       <rdfs:label xml:lang="en">title</rdfs:label>
+      <rdfs:label xml:lang="fr">intitulé</rdfs:label>
       <rdfs:label xml:lang="es">título</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Use only if you don't use Title class for handling
@@ -17179,19 +17438,19 @@
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">A term used to characterize an entity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">tipo</rdfs:label>
       <rdfs:label xml:lang="en">type</rdfs:label>
       <rdfs:label xml:lang="fr">type</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="es">tipo</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
@@ -17208,9 +17467,21 @@
          more informal units used in the archival context like number of boxes, pages or
          words.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">unidad de medida</rdfs:label>
       <rdfs:label xml:lang="en">unit of measurement</rdfs:label>
       <rdfs:label xml:lang="fr">unité de mesure</rdfs:label>
+      <rdfs:label xml:lang="es">unidad de medida</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-28</dc:date>
+            <rdf:value xml:lang="en">Added an xml:lang attribute to the rdfs:comment.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -17231,31 +17502,25 @@
                accurately.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-28</dc:date>
-            <rdf:value xml:lang="en">Added an xml:lang attribute to the rdfs:comment.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
       <skos:scopeNote xml:lang="en">Use if you do not use the UnitOfMeasurement class for handling
          units of measurement along with Extent.</skos:scopeNote>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#usedFromDate -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#usedFromDate">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#date"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#beginningDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Date at which an Appellation was first used.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">usado desde la fecha</rdfs:label>
       <rdfs:label xml:lang="en">used from date</rdfs:label>
       <rdfs:label xml:lang="fr">utilisé à partir de</rdfs:label>
+      <rdfs:label xml:lang="es">usado desde la fecha</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Made this property a subproperty of beginningDate.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -17275,24 +17540,30 @@
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#usedToDate -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#usedToDate">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#date"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#endDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Date until an Appellation was used.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">usado hasta la fecha</rdfs:label>
       <rdfs:label xml:lang="en">used to date</rdfs:label>
       <rdfs:label xml:lang="fr">utilisé jusqu’à</rdfs:label>
+      <rdfs:label xml:lang="es">usado hasta la fecha</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Made this property a subproperty of endDate.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
@@ -17307,19 +17578,19 @@
       <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
       <rdfs:comment xml:lang="en">Horizontal dimension of an entity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">anchura</rdfs:label>
-      <rdfs:label xml:lang="fr">largeur</rdfs:label>
       <rdfs:label xml:lang="en">width</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="fr">largeur</rdfs:label>
+      <rdfs:label xml:lang="es">anchura</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
    </owl:DatatypeProperty>


### PR DESCRIPTION
Updated the datatype properties in order to make them compliant with RiC-CM 1.0 attributes. Changed the IRIS of accrual (to accruals), accrualStatus (to accrualsStatus), descriptiveNote (to generalDescription), integrity (to integrityNote), physicalCharacteristics (to physicalCharacteristicsNote), qualityOfRepresentation (to qualityOfRepresentationNote). Made scopeAndContent a subproperty of generalDescription, and expressedDate a subproperty of name. Updated or added a few domains and many rdfs:comment, skos:scopeNote, skos:example. Also made usedFromDate a subproperty of beginningDate, and usedToDate a subproperty of endDate.