### PR TITLE
74 check and update the classes that correspond to ric cm 10 entities

### DIFF
--- a/ontology/current-version/RiC-O_1-0.rdf
+++ b/ontology/current-version/RiC-O_1-0.rdf
@@ -649,7 +649,22 @@
                   shortcuts. Fixed the range of isExtentOf.</html:li>
                <html:li>2023, November 8, later: rolifying the Relation classes, step 2: deleted 166
                   object properties that had become unnecessary.</html:li>
-               <html:li>2023, November 12: updated the datatype properties in order to make them compliant with RiC-CM 1.0 attributes. Changed the IRIS of accrual (to accruals), accrualStatus (to accrualsStatus), descriptiveNote (to generalDescription), integrity (to integrityNote), physicalCharacteristics (to physicalCharacteristicsNote), qualityOfRepresentation (to qualityOfRepresentationNote). Made scopeAndContent a subproperty of generalDescription, and expressedDate a subproperty of name. Updated or added a few domains and many rdfs:comment, skos:scopeNote, skos:example. Also made usedFromDate a subproperty of beginningDate, and usedToDate a subproperty of endDate.</html:li>
+               <html:li>2023, November 12: updated the datatype properties in order to make them
+                  compliant with RiC-CM 1.0 attributes. Changed the IRIS of accrual (to accruals),
+                  accrualStatus (to accrualsStatus), descriptiveNote (to generalDescription),
+                  integrity (to integrityNote), physicalCharacteristics (to
+                  physicalCharacteristicsNote), qualityOfRepresentation (to
+                  qualityOfRepresentationNote). Made scopeAndContent a subproperty of
+                  generalDescription, and expressedDate a subproperty of name. Updated or added a
+                  few domains and many rdfs:comment, skos:scopeNote, skos:example. Also made
+                  usedFromDate a subproperty of beginningDate, and usedToDate a subproperty of
+                  endDate.</html:li>
+               <html:li>2023, November 12: updated the classes in order to make them compliant with
+                  RiC-CM 1.0 attributes. Updated or added many rdfs:comment and skos:scopeNote,
+                  taking into account, as concerns the Relation classes, the fact that they are
+                  n-ary. Created a new MandateType class, corresponding to RiC-A44 attribute in
+                  RiC-CM 1.0. Also added a rdfs:isDefinedBy to skos:Concept, skos:ConceptScheme and
+                  voaf:Vocabulary.</html:li>
             </html:ul>
          </html:div>
       </skos:historyNote>
@@ -15314,11 +15329,11 @@
          signing.</skos:example>
       <skos:example xml:lang="en">The timestamp exists but cannot be verified.</skos:example>
       <skos:example xml:lang="en">The record bears signatures.</skos:example>
-      <skos:scopeNote xml:lang="en">May be used in a Record Set description when its value
-         is shared by some or all members of the Record Set. For digital records, it may include
-         results from automated means of checking the validity of signatures and timestamp. In
-         particular cases it may be contextually related to the state attribute, for example, a
-         document can be an original or a copy, either of which can be authentic or a forgery. </skos:scopeNote>
+      <skos:scopeNote xml:lang="en">May be used in a Record Set description when its value is shared
+         by some or all members of the Record Set. For digital records, it may include results from
+         automated means of checking the validity of signatures and timestamp. In particular cases
+         it may be contextually related to the state attribute, for example, a document can be an
+         original or a copy, either of which can be authentic or a forgery. </skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A03 (Authenticity Note
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -15412,8 +15427,8 @@
       <rdfs:comment xml:lang="en">Number of physical units and/or physical dimensions of the carrier
          of an Instantiation. In order to manage an Instantiation of a record resource it is
          necessary to note the extent of the carrier as well as that of the Instantiation itself.
-         Whether it is necessary to note dimensions, the number of relevant units, or both, depends on
-         the nature of the carrier and particular business needs.</rdfs:comment>
+         Whether it is necessary to note dimensions, the number of relevant units, or both, depends
+         on the nature of the carrier and particular business needs.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">carrier extent</rdfs:label>
       <rdfs:label xml:lang="fr">mesure du support</rdfs:label>
@@ -15537,10 +15552,9 @@
       <skos:example xml:lang="en">student registration</skos:example>
       <skos:example xml:lang="en">financial affairs</skos:example>
       <skos:example xml:lang="en">digitized items</skos:example>
-      <skos:scopeNote xml:lang="en">May be used in a Record Set description when its value
-         is shared by some or all members of the record set. This datatype property is not to be confused
-         with Identifier although, in some cases, the information may be the
-         same.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">May be used in a Record Set description when its value is shared
+         by some or all members of the record set. This datatype property is not to be confused with
+         Identifier although, in some cases, the information may be the same.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A07 (Classification
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -15597,10 +15611,10 @@
       <skos:example xml:lang="en">Recognita software, min. version 3.0, is needed in order to open
          the file</skos:example>
       <skos:example xml:lang="en">Closed for 30 years</skos:example>
-      <skos:scopeNote xml:lang="en">May be used in a Record Set description when its value
-         is shared by some or all members of the Record Set. The attribute provides information
-         about the accessibility of a Record Resource, as well as the physical, technical or legal
-         limitations that exist for providing access to it.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">May be used in a Record Set description when its value is shared
+         by some or all members of the Record Set. The attribute provides information about the
+         accessibility of a Record Resource, as well as the physical, technical or legal limitations
+         that exist for providing access to it.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A08 (Conditions of Access
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -15654,8 +15668,8 @@
          use</skos:example>
       <skos:example xml:lang="en">Cannot be copied using warm light copying machines or photographed
          using flashlight</skos:example>
-      <skos:scopeNote xml:lang="en">May be used in a Record Set description when its value
-         is shared by some or all members of the Record Set.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">May be used in a Record Set description when its value is shared
+         by some or all members of the Record Set.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A09 (Conditions of Use
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -15835,8 +15849,8 @@
          occidentale qui culmine à 4 809 mètres (altitude relevée en 2015). Il est traversé par le
          tunnel du Mont-Blanc, entre Chamonix dans la vallée de l'Arve et Courmayeur dans la vallée
          d'Aoste.</skos:example>
-      <skos:example xml:lang="fr">Thomas Blaikie (1750-1838) est un botaniste et jardinier écossais. Il a
-         dessiné notamment les jardins de Malmaison et Bagatelle.</skos:example>
+      <skos:example xml:lang="fr">Thomas Blaikie (1750-1838) est un botaniste et jardinier écossais.
+         Il a dessiné notamment les jardins de Malmaison et Bagatelle.</skos:example>
       <skos:example xml:lang="en">The Senate is the academic governing body of the University of
          Strathclyde and is responsible for all academic matters including academic standards and
          quality. Meetings of the Senate are chaired by the Principal and the membership is drawn
@@ -16041,8 +16055,8 @@
                Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:example xml:lang="en">Latitude 50°40′46,461″N, Longitude 95°48′26,533″W,
-         Height 123,45m (ISO 6709/D)</skos:example>
+      <skos:example xml:lang="en">Latitude 50°40′46,461″N, Longitude 95°48′26,533″W, Height 123,45m
+         (ISO 6709/D)</skos:example>
       <skos:example xml:lang="en">Latitude 35.89421911, Longitude 139.94637467 (ISO
          6709/F)</skos:example>
       <skos:scopeNote xml:lang="en">Provided for usability reasons. May be deprecated and removed
@@ -16081,7 +16095,7 @@
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description
-                  rdf:about="https://www.ica.org/standards/RiC/ontology#Record Resource"/>
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Agent"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Event"/>
@@ -16132,7 +16146,8 @@
          con los escolapios. Licenciado en Derecho por la Universidad de Zaragoza, aprobó las
          oposiciones al cuerpo nacional de notarios… (sobre una persona)</skos:example>
       <skos:example xml:lang="es">El primer sorteo de lotería se celebró el 13 de mayo de 1771,
-         siendo desarrollado por la Real Lotería General de Nueva España… (sobre una actividad)</skos:example>
+         siendo desarrollado por la Real Lotería General de Nueva España… (sobre una
+         actividad)</skos:example>
       <skos:scopeNote xml:lang="en">For a record set, may be used to summarize the history of the
          Record Set itself, or additionally to summarize the history of some or all members of the
          Record Set. Should not be confused with the scope and content property.</skos:scopeNote>
@@ -16341,10 +16356,10 @@
          physicalCharacteristics.</skos:example>
       <skos:example xml:lang="en">Line three of a hand-written letter was cut out and a replacement
          text was inserted by an unknown person.</skos:example>
-      <skos:scopeNote xml:lang="en">May be used in a Record Set description when its value
-         is shared by some or all members of the Record Set. The information about integrity may be
-         generated manually or automatically. Not to be confused with the physical completeness of
-         the instantiation, which is covered by the physical characteristics note attribute. The
+      <skos:scopeNote xml:lang="en">May be used in a Record Set description when its value is shared
+         by some or all members of the Record Set. The information about integrity may be generated
+         manually or automatically. Not to be confused with the physical completeness of the
+         instantiation, which is covered by the physical characteristics note attribute. The
          integrity of a Record Resource and the physical characteristics note of an Instantiation
          may be complementary. This attribute also covers any additions to or removal of original
          information.</skos:scopeNote>
@@ -16653,16 +16668,23 @@
                v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:example xml:lang="en">2012-02-14/2015-03-08 (an ISO 8601 form of a date range)</skos:example>
+      <skos:example xml:lang="en">2012-02-14/2015-03-08 (an ISO 8601 form of a date
+         range)</skos:example>
       <skos:example xml:lang="en">2012/2015-03 (an ISO 8601 form of a date range)</skos:example>
       <skos:example xml:lang="en">1948-03 (an ISO 8601 form of a single date)</skos:example>
       <skos:example xml:lang="en">1948-03-08 (an ISO 8601 form of a single date)</skos:example>
-      <skos:example xml:lang="en">1948-03~ (a single date in ETDF, meaning March 1948 approximately)</skos:example>
-      <skos:example xml:lang="en">1948/.. (an open date range in EDTF, starting in 1948)</skos:example>
-      <skos:example xml:lang="en">1948/ (a date range in EDTF, starting in 1948, end unknown)</skos:example>
-      <skos:example xml:lang="en">1550,1551,1553,1555 (a date set in EDTF, meaning one of the years 1550, 1151, 1553, 1555)</skos:example>
-      <skos:example xml:lang="en">{1550,1151,1553,1555} (a date set in EDTF, meaning all of the years 1550, 1151, 1553, 1555)</skos:example>
-      <skos:example xml:lang="en">{1805,1815..1820} (a date set in EDTF, meaning all of the years 1805, 1815, 1816, 1817, 1818, 1819, 1820)</skos:example>
+      <skos:example xml:lang="en">1948-03~ (a single date in ETDF, meaning March 1948
+         approximately)</skos:example>
+      <skos:example xml:lang="en">1948/.. (an open date range in EDTF, starting in
+         1948)</skos:example>
+      <skos:example xml:lang="en">1948/ (a date range in EDTF, starting in 1948, end
+         unknown)</skos:example>
+      <skos:example xml:lang="en">1550,1551,1553,1555 (a date set in EDTF, meaning one of the years
+         1550, 1151, 1553, 1555)</skos:example>
+      <skos:example xml:lang="en">{1550,1151,1553,1555} (a date set in EDTF, meaning all of the
+         years 1550, 1151, 1553, 1555)</skos:example>
+      <skos:example xml:lang="en">{1805,1815..1820} (a date set in EDTF, meaning all of the years
+         1805, 1815, 1816, 1817, 1818, 1819, 1820)</skos:example>
       <skos:scopeNote xml:lang="en">Used to represent the date in a standardized format that can be
          processed programmatically. The main standard used today is ISO 8601, which is based on the
          Gregorian calendar. See also the Extended Date Time Format (EDTF), which is an extension of
@@ -16882,7 +16904,8 @@
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">quality of representation note</rdfs:label>
       <rdfs:label xml:lang="fr">note sur la qualité de la représentation</rdfs:label>
-      <rdfs:label xml:lang="es">nota sobre la calidad de representación</rdfs:label><skos:changeNote>
+      <rdfs:label xml:lang="es">nota sobre la calidad de representación</rdfs:label>
+      <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-11</dc:date>
             <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the IRI, mapping to RiC-CM
@@ -17213,8 +17236,8 @@
       <skos:scopeNote xml:lang="en">Scope and content is a specialization of general description.
          For a Record Set, may be used to summarize the scope and content of the Record Set itself,
          or additionally to summarize the scope and content of some or all members of the Record
-         Set. It is not to be confused with the history dataytpe property which focuses on the origination
-         and subsequent changes to a Record Resource. </skos:scopeNote>
+         Set. It is not to be confused with the history dataytpe property which focuses on the
+         origination and subsequent changes to a Record Resource. </skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A38 (Scope and Content
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -17314,9 +17337,9 @@
          the same free text is being used in your current metadata for describing the record
          resource and the instantiation structure). For a Record Set, may be used to summarize the
          structure of the Record Set itself, or additionally to summarize the structure of some or
-         all members of the Record Set. Should not be confused with the classification datatype property,
-         which provides information about the category which the Record Set belongs to within a
-         classification scheme. </skos:scopeNote>
+         all members of the Record Set. Should not be confused with the classification datatype
+         property, which provides information about the category which the Record Set belongs to
+         within a classification scheme. </skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A40 (Structure
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -17361,7 +17384,8 @@
          introduced severe spherical aberration for the images.</skos:example>
       <skos:scopeNote xml:lang="en">Does not include references to the workflow that the Mechanism
          is involved in, which is described under the Activity entity. It emphasizes those features
-         that provide a better understanding of the impact of the Mechanism on the records.</skos:scopeNote>
+         that provide a better understanding of the impact of the Mechanism on the
+         records.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A41 (Technical Characteristics
          attribute)</RiCCMCorrespondingComponent>
    </owl:DatatypeProperty>
@@ -17596,11 +17620,17 @@
    </owl:DatatypeProperty>
    <!-- /////////////////////////////////////////////////////////////////////////////////////// // // Classes // /////////////////////////////////////////////////////////////////////////////////////// -->
    <!-- http://purl.org/vocommons/voaf#Vocabulary -->
-   <owl:Class rdf:about="http://purl.org/vocommons/voaf#Vocabulary"/>
+   <owl:Class rdf:about="http://purl.org/vocommons/voaf#Vocabulary">
+      <rdfs:isDefinedBy rdf:resource="http://purl.org/vocommons/voaf"/>
+   </owl:Class>
    <!-- http://www.w3.org/2004/02/skos/core#Concept -->
-   <owl:Class rdf:about="http://www.w3.org/2004/02/skos/core#Concept"/>
+   <owl:Class rdf:about="http://www.w3.org/2004/02/skos/core#Concept">
+      <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+   </owl:Class>
    <!-- http://www.w3.org/2004/02/skos/core#ConceptScheme -->
-   <owl:Class rdf:about="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+   <owl:Class rdf:about="http://www.w3.org/2004/02/skos/core#ConceptScheme">
+      <rdfs:isDefinedBy rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+   </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#AccumulationRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#AccumulationRelation">
       <owl:equivalentClass>
@@ -17642,22 +17672,17 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Record Resource or Instantiation to at least
-         one Agent, when the Agent accumulates it, be it intentionally (collecting it) or not
-         (receiving it in the course of its activities).</rdfs:comment>
+         one Agent, when the Agent accumulates or accumulated it, be it intentionally (collecting
+         it) or not (receiving it in the course of its activities).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Accumulation Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de Acumulación</rdfs:label>
       <rdfs:label xml:lang="fr">Relation d’accumulation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de Acumulación</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -17668,6 +17693,18 @@
                generic ones in the subClassOf declarations.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R028 and RiC-R028i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -17676,13 +17713,13 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:comment xml:lang="en">The doing of something for some human purpose.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Actividad</rdfs:label>
       <rdfs:label xml:lang="en">Activity</rdfs:label>
       <rdfs:label xml:lang="fr">Activité</rdfs:label>
+      <rdfs:label xml:lang="es">Actividad</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-04-19</dc:date>
-            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -17693,8 +17730,8 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-04-19</dc:date>
+            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -17766,8 +17803,14 @@
          activity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Activity Documentation Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de procedencia funcional</rdfs:label>
       <rdfs:label xml:lang="fr">Relation entre activités et ressources archivistiques</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de procedencia funcional</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the .</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -17776,16 +17819,16 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
             <dc:date>2023-11-08</dc:date>
             <rdf:value xml:lang="en">In order to get a system of rolified Relation classes: added an
                equivalentClass object property; replaced the specific object properties by the
                generic ones in the subClassOf declarations.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -17803,14 +17846,8 @@
       <rdfs:comment xml:lang="en">Categorization of an Activity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Activity Type</rdfs:label>
-      <rdfs:label xml:lang="es">Tipo de actividad</rdfs:label>
       <rdfs:label xml:lang="fr">Type d’activité</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-04-19</dc:date>
-            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="es">Tipo de actividad</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -17821,6 +17858,12 @@
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-04-19</dc:date>
+            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -17849,15 +17892,8 @@
       <rdfs:label xml:lang="es">Agente</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2021-02-08</dc:date>
-            <rdf:value xml:lang="en">removed the Restrictions</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2020-10-23</dc:date>
-            <rdf:value xml:lang="en">Comment: updated. Scope note: updated and made several
-               paragraphs. Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -17868,8 +17904,15 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2021-02-08</dc:date>
+            <rdf:value xml:lang="en">removed the Restrictions</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2020-10-23</dc:date>
+            <rdf:value xml:lang="en">Comment: updated. Scope note: updated and made several
+               paragraphs. Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">An Agent may have one or more identities; an identity is a
@@ -17921,11 +17964,19 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Agent, to at least another Agent, when the
-         first one(s) control(s) in a way the activities of the second one(s).</rdfs:comment>
+         first one(s) control(s) or controlled in a way the activities of the second
+         one(s).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Agent Control Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de control entre agentes</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de contrôle entre agents</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de control entre agentes</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -17936,14 +17987,14 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R041 and RiC-R041i
@@ -17981,11 +18032,18 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Agent to at least another Agent, when the
-         first one is hierarchically superior to the second one.</rdfs:comment>
+         first one is or was hierarchically superior to the second one.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Agent Hierarchical Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación jerárquica entre agentes</rdfs:label>
       <rdfs:label xml:lang="fr">Relation hiérarchique entre agents</rdfs:label>
+      <rdfs:label xml:lang="es">Relación jerárquica entre agentes</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -18006,6 +18064,8 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:scopeNote xml:lang="en">The hierarchical relation can be an authority relation, or a
+         whole/part relation between two agents.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R045 and RiC-R045i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -18070,18 +18130,13 @@
          some activities.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Agent Temporal Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación temporal entre agentes</rdfs:label>
       <rdfs:label xml:lang="fr">Relation temporelle entre agents</rdfs:label>
+      <rdfs:label xml:lang="es">Relación temporal entre agentes</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-04-19</dc:date>
-            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the
+               skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -18098,6 +18153,21 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-04-19</dc:date>
+            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">There may be zero to many intermediate agents, ignored or
+         unknown, between the two connected agents. Can be used when there is a transfer of function
+         from the first agent to the second agent.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R016 and RiC-016i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -18124,8 +18194,15 @@
       <rdfs:comment xml:lang="en">Connects at least two Agents.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Agent Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación entre agentes</rdfs:label>
       <rdfs:label xml:lang="fr">Relation entre agents</rdfs:label>
+      <rdfs:label xml:lang="es">Relación entre agentes</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the
+               skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -18136,16 +18213,18 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">Use only if it is not possible to specify a narrower agent to
+         agent relation, for example a WorkRelation.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R044 and RiC-044i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -18202,15 +18281,16 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">The relation between an Appellation and at least one Thing that
-         the Appellation designates.</rdfs:comment>
+         the Appellation designates or designated.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Appellation Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de denominación</rdfs:label>
       <rdfs:label xml:lang="fr">Relation d’appellation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de denominación</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -18219,6 +18299,12 @@
             <rdf:value xml:lang="en">In order to get a system of rolified Relation classes: added an
                equivalentClass object property; replaced the specific object properties by the
                generic ones in the subClassOf declarations.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -18259,15 +18345,16 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Agent, and at least one Thing over which the
-         Agent has some authority.</rdfs:comment>
+         Agent has or had some authority.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Authority Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de control por parte de agentes</rdfs:label>
       <rdfs:label xml:lang="fr">Relation d’autorité</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de control por parte de agentes</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -18284,8 +18371,14 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Would probably rarely be used as such (use its
-         sub-categories)</skos:scopeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">Use only if it is not possible to specify a narrower authority
+         relation, for example OwnershipRelation.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R036 and RiC-R036i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -18329,29 +18422,17 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Record to at least one Person, Group or
-         Position that is responsible for conceiving and formulating the information contained in
-         the Record.</rdfs:comment>
+         Position that is or was responsible for conceiving and formulating the information
+         contained in the Record.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Authorship Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de autoría</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de responsabilité intellectuelle</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de autoría</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2020-12-29</dc:date>
-            <rdf:value xml:lang="en">Created following the addition of RiC-R079 relation in RiC-CM
-               0.2</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -18362,22 +18443,52 @@
                generic ones in the subClassOf declarations.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2020-12-29</dc:date>
+            <rdf:value xml:lang="en">Created following the addition of RiC-R079 relation in RiC-CM
+               0.2</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">To be used for a person, group or position that makes any
+         contribution to the content of a record. Includes the person, group or position in whose
+         name or by whose command the content may have been formulated and first instantiated (for
+         example the person who signed the record). </skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R079 and RiC-R079i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#CarrierExtent -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#CarrierExtent">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Extent"/>
-      <rdfs:comment xml:lang="en">The extent of a Record Resource carrier</rdfs:comment>
+      <rdfs:comment xml:lang="en">Number of physical units and/or physical dimensions of the carrier
+         of an Instantiation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Carrier Extent</rdfs:label>
-      <rdfs:label xml:lang="es">Extensión del soporte</rdfs:label>
       <rdfs:label xml:lang="fr">Mesure d’un support</rdfs:label>
+      <rdfs:label xml:lang="es">Extensión del soporte</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-10-28</dc:date>
-            <rdf:value xml:lang="en">Class added in order to handle an accurate description of a
-               carrier extent</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -18395,24 +18506,34 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2020-10-28</dc:date>
+            <rdf:value xml:lang="en">Class added in order to handle an accurate description of a
+               carrier extent</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Countable characteristics of a record resource carrier expressed
-         as a quantity.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">In order to manage an instantiation of a record resource it is
+         necessary to note the extent of the carrier as well as that of the instantiation itself.
+         Whether it is necessary to note dimensions, the number of relevant units or both depends on
+         the nature of the carrier and particular business needs.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-A04 (Carrier Extent)
          attribute</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#CarrierType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#CarrierType">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
-      <rdfs:comment xml:lang="en">Categorization of physical material in or on which information is
+      <rdfs:comment xml:lang="en">Categorization of physical material on which information is
          represented.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Carrier Type</rdfs:label>
-      <rdfs:label xml:lang="es">Tipo de soporte</rdfs:label>
       <rdfs:label xml:lang="fr">Type de support</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de soporte</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -18421,9 +18542,8 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-10-23</dc:date>
-            <rdf:value xml:lang="en">Scope note: updated (quite the same as RiC-CM definition).
-               Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -18434,17 +18554,15 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2020-10-23</dc:date>
+            <rdf:value xml:lang="en">Scope note: updated (quite the same as RiC-CM definition).
+               Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Carrier Type information is essential for assessing
-         authenticity, conservation needs and the availability, access and use of Record Resources.
-         Carrier Type determines the environmental conditions of storage and the prerequisites and
-         possible ways to access and use of the records. Should not be confused with Content Type,
-         that categorizes a Record Resource, nor with Representation Type that categorizes an
-         Instantiation. The Carrier Type depends on the media type that is required to access the
-         records and is independent of its content</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">In order to manage an instantiation of a record resource, it is
+         necessary to note the type of carrier on which the record resource is instantiated as its
+         nature will determine the environmental storage conditions and the prerequisites for and
+         possible ways of accessing and using the record resource.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A05 (Carrier Type
          attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -18478,16 +18596,17 @@
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at lest one Person, to at least another Person, when the
-         first has child the second one.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects at least one Person, to at least another Person, when the
+         first has(ave) child(s) the second one(s).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Child Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de filiación</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de filiation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de filiación</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -18502,6 +18621,12 @@
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R018 and RiC-R018i
@@ -18532,17 +18657,17 @@
    <!-- https://www.ica.org/standards/RiC/ontology#ContentType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#ContentType">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
-      <rdfs:comment xml:lang="en">The fundamental form of communication in which a Record is
-         expressed and the human sense through which it is intended to be perceived.</rdfs:comment>
+      <rdfs:comment xml:lang="en">The fundamental form of communication in which a Record or Record
+         Part is expressed.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Content Type</rdfs:label>
-      <rdfs:label xml:lang="es">Tipo de contenido</rdfs:label>
       <rdfs:label xml:lang="fr">Type de contenu</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de contenido</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-10-23</dc:date>
-            <rdf:value xml:lang="en">Scope note: added (quite the same as RiC-CM
-               definition).</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -18563,33 +18688,49 @@
             <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Should not be confused with Representation Type or Carrier Type
-         of a related Instantiation since the form of communication can be independent of the
-         representation or carrier, for example, a map (Content Type: cartographic image) can be
-         represented as a sketch (Representation Type: graphic) or as a GIS-coded elements
-         (Representation Type: computer).</skos:scopeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2020-10-23</dc:date>
+            <rdf:value xml:lang="en">Scope note: added (quite the same as RiC-CM
+               definition).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">Content Type should not be confused with Representation Type or
+         Carrier Type that would concern a related Instantiation since the form of communication can
+         be independent of the representation or carrier, for example a map (content type
+         "cartographic image") may be represented as a sketch (representation type "visual")
+         recorded as a physical document (carrier type "paper"). It also should not be confused with
+         the Documentary Form Type of a Record, or Record Part, which describes a specific document
+         form (for example a deed of sale).</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A10 (Content Type
          attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Coordinates -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Coordinates">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <rdfs:comment xml:lang="en">Longitudinal and latitudinal information of a
+      <rdfs:comment xml:lang="en">Longitudinal and latitudinal information about a
          Place.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Coordenadas de lugar</rdfs:label>
       <rdfs:label xml:lang="en">Coordinates</rdfs:label>
       <rdfs:label xml:lang="fr">Coordonnées géographiques</rdfs:label>
+      <rdfs:label xml:lang="es">Coordenadas de lugar</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -18614,13 +18755,26 @@
       <rdfs:comment xml:lang="en">An organized group of persons that act together as an Agent, and
          that has a recognized legal or social status.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="fr">Collectivité</rdfs:label>
       <rdfs:label xml:lang="en">Corporate Body</rdfs:label>
+      <rdfs:label xml:lang="fr">Collectivité</rdfs:label>
       <rdfs:label xml:lang="es">Institución</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -18636,13 +18790,14 @@
                RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Corporate Body is a kind of Group.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Corporate body is a kind of Group (RiC-E09). By exception,
+         within some legal contexts, a sole trader or sole proprietor may be recognized as a
+         corporate body, even when the economic enterprise does not have additional members.
+         Corporate bodies often have a mandate giving them the authority to act within their area(s)
+         of competence. They will also usually act within a particular jurisdiction being governed
+         by legal and other rule-based frameworks. A corporate body though may be constituted in a
+         more informal manner and exist as an entity by virtue of its recognition as such by its
+         members.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E11 (Corporate Body
          entity)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -18652,18 +18807,18 @@
       <rdfs:comment xml:lang="en">Categorization of a Corporate Body.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Corporate Body Type</rdfs:label>
-      <rdfs:label xml:lang="es">Tipo de institución</rdfs:label>
       <rdfs:label xml:lang="fr">Type de collectivité</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="es">Tipo de institución</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -18695,16 +18850,17 @@
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least two Persons, when they correspond to each
-         other.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects at least two Persons, when they correspond or
+         corresponded to each other.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Correspondence Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación entre personas por correspondencia</rdfs:label>
       <rdfs:label xml:lang="fr">Relation épistolaire</rdfs:label>
+      <rdfs:label xml:lang="es">Relación entre personas por correspondencia</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -18713,6 +18869,12 @@
             <rdf:value xml:lang="en">In order to get a system of rolified Relation classes: added an
                equivalentClass object property; replaced the specific object properties by the
                generic ones in the subClassOf declarations.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -18770,8 +18932,15 @@
          Instantiation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Creation Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de creación</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de création</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de creación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the
+               skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -18782,14 +18951,14 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -18798,6 +18967,11 @@
             <rdf:value xml:lang="en">Removed a 0.2 existing unnecessary restriction.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:scopeNote xml:lang="en">Covers the definition of "author" in diplomatics, and any agent
+         that makes a contribution to the intellectual content of a record resource. Can also be
+         used for any agent that was involved in the genesis (e.g. with the role of witness,
+         representative of the author etc.) or in the production (e.g. with the role of scribe,
+         secretary, notary, printer etc.) of the record resource or instantiation.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R027 and RiC-R027i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -18812,8 +18986,9 @@
       <rdfs:label xml:lang="es">Fecha</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the
+               skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -18824,26 +18999,36 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
             <dc:date>2020-10-23</dc:date>
             <rdf:value xml:lang="en">Scope note: made separate paragraphs.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Date includes both single dates, a date range, or a set of
-         non-contiguous single dates or date ranges. A date may be represented in natural language,
-         based on a digital standard, or both. Digital standard dates will typically be based on ISO
-         8601, or Extended Date-Time Format (EDTF).</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">A Date may be represented in natural language, based on a
+         digital standard, or both. Digital standard dates will typically be based on ISO 8601, or
+         Extended Date-Time Format (EDTF)</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E18 (Date
          entity)</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#DateType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#DateType">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
-      <rdfs:comment xml:lang="en">Categorization of a date. Used in particular in order to say
-         whether the date is a single one, a date range or a date set, or sub categories of these
-         broad ones.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Categorization of a Date.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Date Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type de date</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-10-10</dc:date>
@@ -18857,30 +19042,27 @@
             <rdf:value xml:lang="en">Added in RiC-O 1.0.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:scopeNote xml:lang="en">May be used to categorize a Date as a single date, a date range
+         or a date set or sub-categories of these broad types. This attribute should not be confused
+         with the date relations defined to connect a Date entity and any other entity (such as
+         RiC-R069 ‘is beginning date of’).</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A42 (Date Type attribute) (new
          in RiC-CM 1.0).</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#DemographicGroup -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#DemographicGroup">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
-      <rdfs:comment xml:lang="en">Categorization of a person according to characteristics such as
-         age, gender, education, place of origin, ethnic/cultural identification, religion,
-         etc.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Categorization of a Person or Group based on shared
+         characteristics.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Categoría demográfica</rdfs:label>
-      <rdfs:label xml:lang="fr">Catégorie démographique</rdfs:label>
       <rdfs:label xml:lang="en">Demographic Group</rdfs:label>
+      <rdfs:label xml:lang="fr">Catégorie démographique</rdfs:label>
+      <rdfs:label xml:lang="es">Categoría demográfica</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-10-23</dc:date>
-            <rdf:value xml:lang="en">Comment: updated. Scope note: updated and made several
-               paragraphs. Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -18891,13 +19073,26 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
             <dc:date xml:lang="en">2021-02-08</dc:date>
             <rdf:value xml:lang="en">Removed the Restriction.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Can be extended with any number of subclasses, e.g. Age or
-         Religion. A demographic group may be defined as a subset of the general population.
-         Individuals may belong to several demographic groups</skos:scopeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2020-10-23</dc:date>
+            <rdf:value xml:lang="en">Comment: updated. Scope note: updated and made several
+               paragraphs. Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">Can be extended with any number of specific subclasses. Among
+         possible specific demographic groups are gender, (biological) sex, education, identity,
+         place, ancestry, ethnic/cultural identification, and religion.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A15 (Demographic Group
          attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -18934,11 +19129,18 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects an Instantiation to at least one Instantiation that is
-         derived from it.</rdfs:comment>
+         derived from it, whether it exists or has been lost or destroyed.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Derivation Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de derivación</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de dérivation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de derivación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -18959,6 +19161,9 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:scopeNote xml:lang="en">In some situations, it may be useful or necessary to connect an
+         instantiation to an instantiation that was derived from it but no longer exists or has been
+         lost.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R014 and RiR014i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -18998,14 +19203,8 @@
          first has/have descendant the second one(s).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Descendance Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de descendencia</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de descendance</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="es">Relación de descendencia</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -19020,23 +19219,48 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R017 and RiC-R017i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#DocumentaryFormType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#DocumentaryFormType">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
-      <rdfs:comment xml:lang="en">Categorization of the document with respect to its extrinsic and
-         intrinsic elements that together communicate its content, administrative and documentary
-         context, and authority</rdfs:comment>
+      <rdfs:comment xml:lang="en">Categorization of a Record or Record Part with respect to its
+         extrinsic and intrinsic elements that together communicate its content, administrative and
+         documentary context, and authority.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Documentary Form Type</rdfs:label>
-      <rdfs:label xml:lang="es">Tipo documental</rdfs:label>
       <rdfs:label xml:lang="fr">Type de document</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-04-19</dc:date>
+            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -19046,10 +19270,26 @@
                Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:scopeNote xml:lang="en">Documentary Form Type plays an important role in determining the
+         type of information a Record may comprise, its status of perfection, and its authenticity
+         and reliability. Documentary form types exist in a specific social and cultural context,
+         and within that context, are subject to change over time.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A17 (Documentary Form Type
+         attribute)</RiCCMCorrespondingComponent>
+   </owl:Class>
+   <!-- https://www.ica.org/standards/RiC/ontology#Event -->
+   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Event">
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
+      <rdfs:comment xml:lang="en">Something that happens or occurs in time and space.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">Event</rdfs:label>
+      <rdfs:label xml:lang="fr">Événement</rdfs:label>
+      <rdfs:label xml:lang="es">Evento</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-04-19</dc:date>
-            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -19058,25 +19298,16 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Documentary Form Type plays an important role in determining the
-         type of information a Record may comprise, its status of perfection, and its authenticity
-         and reliability. Documentary form types exist in a specific social and cultural context,
-         and within that context, are subject to change over time</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A17 (Documentary Form Type
-         attribute)</RiCCMCorrespondingComponent>
-   </owl:Class>
-   <!-- https://www.ica.org/standards/RiC/ontology#Event -->
-   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Event">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <rdfs:comment xml:lang="en">Something that happens in time and space.</rdfs:comment>
-      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="en">Event</rdfs:label>
-      <rdfs:label xml:lang="es">Evento</rdfs:label>
-      <rdfs:label xml:lang="fr">Événement</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-04-19</dc:date>
+            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -19086,24 +19317,12 @@
                changes.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-04-19</dc:date>
-            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:scopeNote xml:lang="en">An event may be natural, human, or a combination of natural and
-         human. Events have temporal and spatial boundaries. An event may actively involve some
-         agent(s) and affect any entity. An event may be discrete, happening at a specific moment in
-         time, or may occur over an extended period of time. Events may have events as parts, and
-         events may precede or follow one another. Multiple agents may participate in the same
-         event, and in different roles. </skos:scopeNote>
+      <skos:scopeNote xml:lang="en">An event may be caused by nature, an agent, or a combination of
+         nature and agent. Events have temporal and spatial boundaries. An event may actively
+         involve some agent(s) and affect any entity. An event may be discrete, happening at a
+         specific moment in time, or may occur over an extended period of time. Events may have
+         events as parts, and events may precede or follow one another. Multiple agents may
+         participate in the same event, and in different roles.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E14 (Event
          entity)</RiCCMCorrespondingComponent>
       <closeTo xml:lang="en">LODE Event class (http://linkedevents.org/ontology/#Event)</closeTo>
@@ -19142,8 +19361,15 @@
          is associated with the existence and lifecycle of the second one.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Event Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación con un evento</rdfs:label>
       <rdfs:label xml:lang="fr">Relation impliquant un événement</rdfs:label>
+      <rdfs:label xml:lang="es">Relación con un evento</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the
+               skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -19164,6 +19390,8 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:scopeNote xml:lang="en">Use to connect an event and an entity only if it is not possible
+         to specify a narrower event relation, for example a PerformanceRelation.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R057 and RiC-R057i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -19173,12 +19401,13 @@
       <rdfs:comment xml:lang="en">Categorization of an Event.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Event Type</rdfs:label>
-      <rdfs:label xml:lang="es">Tipo de evento</rdfs:label>
       <rdfs:label xml:lang="fr">Type d’événement</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de evento</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-04-19</dc:date>
-            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the
+               skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -19191,6 +19420,12 @@
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-04-19</dc:date>
+            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -19212,14 +19447,13 @@
       <rdfs:comment xml:lang="en">Countable characteristics of the content of an entity expressed as
          a quantity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Extensión</rdfs:label>
       <rdfs:label xml:lang="en">Extent</rdfs:label>
       <rdfs:label xml:lang="fr">Mesure</rdfs:label>
+      <rdfs:label xml:lang="es">Extensión</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-10-28</dc:date>
-            <rdf:value xml:lang="en">Class added together with three subclasses and hasExtent and
-               isExtentOf Object properties</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -19230,8 +19464,9 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2020-10-28</dc:date>
+            <rdf:value xml:lang="en">Class added together with three subclasses and hasExtent and
+               isExtentOf Object properties</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Physical or logical extent of a resource</skos:scopeNote>
@@ -19243,14 +19478,8 @@
          measured.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Extent Type</rdfs:label>
-      <rdfs:label xml:lang="es">Tipo de Extensión</rdfs:label>
       <rdfs:label xml:lang="fr">Type de mesure</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-28</dc:date>
-            <rdf:value xml:lang="en">Added an xml:lang attribute to the rdfs:comment.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="es">Tipo de Extensión</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -19259,15 +19488,21 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-11-01</dc:date>
-            <rdf:value xml:lang="en">Added to specify the dimension that is being
-               measured</rdf:value>
+            <dc:date>2023-08-28</dc:date>
+            <rdf:value xml:lang="en">Added an xml:lang attribute to the rdfs:comment.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2020-11-01</dc:date>
+            <rdf:value xml:lang="en">Added to specify the dimension that is being
+               measured</rdf:value>
          </rdf:Description>
       </skos:changeNote>
    </owl:Class>
@@ -19278,16 +19513,9 @@
          adoption, civil union, or other social conventions that bind them together as a socially
          recognized familial group.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Familia</rdfs:label>
-      <rdfs:label xml:lang="fr">Famille</rdfs:label>
       <rdfs:label xml:lang="en">Family</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2020-10-23</dc:date>
-            <rdf:value xml:lang="en">Scope note: made separate paragraphs and some
-               changes.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="fr">Famille</rdfs:label>
+      <rdfs:label xml:lang="es">Familia</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -19298,6 +19526,13 @@
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2020-10-23</dc:date>
+            <rdf:value xml:lang="en">Scope note: made separate paragraphs and some
+               changes.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Family is a kind of Group. “Family” is used here as a general
@@ -19337,8 +19572,15 @@
          i.e. belong to the same family.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Family Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación familiar</rdfs:label>
       <rdfs:label xml:lang="fr">Relation familiale</rdfs:label>
+      <rdfs:label xml:lang="es">Relación familiar</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the
+               skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -19349,16 +19591,18 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">Use the MembershipRelation class for connecting a family and a
+         person.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R047 and RiC-R047i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -19368,12 +19612,13 @@
       <rdfs:comment xml:lang="en">Categorization of a Family.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Family Type</rdfs:label>
-      <rdfs:label xml:lang="es">Tipo de familia</rdfs:label>
       <rdfs:label xml:lang="fr">Type de famille</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de familia</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-04-19</dc:date>
-            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the
+               skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -19390,12 +19635,18 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
+            <dc:date>2023-04-19</dc:date>
+            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
             <dc:date>2020-10-23</dc:date>
             <rdf:value xml:lang="en">Comment: slighty changed.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Family Type encompasses a wide variety of familial groups
-         related by consanguinity, affinity, cohabitation or other social conventions. </skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Encompasses a wide variety of familial groups related by
+         consanguinity, affinity, cohabitation, or other social conventions.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A20 (Family Type
          attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -19424,8 +19675,15 @@
          equivalent.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Functional Equivalence Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de equivalencia funcional</rdfs:label>
       <rdfs:label xml:lang="fr">Relation d’équivalence fonctionnelle</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de equivalencia funcional</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the
+               skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -19436,20 +19694,20 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Use for Instantiations which, from some point of view, in some
-         context and for some users at least, may be considered as equivalent. This equivalence is
-         usually based upon the fact that the Instantiations have at least the same intellectual
-         content (they instantiate the same Record Resource).</skos:scopeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">Two instantiations, from some point of view, may be considered
+         as equivalent. This equivalence is usually based upon the fact that the instantiations have
+         at least the same intellectual content (they instantiate the same record
+         resource).</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R035 and RiC-R035i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -19466,6 +19724,12 @@
       <rdfs:label xml:lang="es">Grupo de agentes</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
             <dc:date>2023-08-25</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
@@ -19475,12 +19739,6 @@
             <dc:date>2020-10-23</dc:date>
             <rdf:value xml:lang="en">Scope note: made separate paragraphs plus very few changes.
                Disjoint with: enriched.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Group is a kind of Agent. A Group has a socially recognized
@@ -19524,16 +19782,17 @@
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects a Group and at least another Group, when the first one as
-         the second one(s) among its subdivisions.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Group and at least another Group, when the first one
+         has or had the second one(s) among its subdivisions.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Group Subdivision Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de subdivisión entre grupos de agentes</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de subdivision entre groupes d’agents</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de subdivisión entre grupos de agentes</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -19542,6 +19801,12 @@
             <rdf:value xml:lang="en">In order to get a system of rolified Relation classes: added an
                equivalentClass object property; replaced the specific object properties by the
                generic ones in the subClassOf declarations.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -19560,13 +19825,14 @@
          to uniquely identify or reference an individual instance of an entity within a specific
          information domain.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">Identifier</rdfs:label>
       <rdfs:label xml:lang="fr">Identifiant</rdfs:label>
       <rdfs:label xml:lang="es">Identificador</rdfs:label>
-      <rdfs:label xml:lang="en">Identifier</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the
+               skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -19577,10 +19843,20 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
             <dc:date>2023-04-19</dc:date>
             <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:scopeNote xml:lang="en">Can include Global Persistent Identifiers (globally unique and
+         persistently resolvable identifier for the entity) and/or Local Identifiers. Both the
+         domain within which the identifier is unique, and the rules used in forming the identifier
+         value should be provided with the identifier value.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-A22 (Identifier
          attribute) (see also the identifier datatype property)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -19590,8 +19866,8 @@
       <rdfs:comment xml:lang="en">Categorization of an Identifier.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Identifier Type</rdfs:label>
-      <rdfs:label xml:lang="es">Tipo de identificador</rdfs:label>
       <rdfs:label xml:lang="fr">Type d’identifiant</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de identificador</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -19627,20 +19903,13 @@
          carrier in any persistent, recoverable form as a means of communicating information through
          time and space.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Instanciación</rdfs:label>
-      <rdfs:label xml:lang="fr">Instanciation</rdfs:label>
       <rdfs:label xml:lang="en">Instantiation</rdfs:label>
+      <rdfs:label xml:lang="fr">Instanciation</rdfs:label>
+      <rdfs:label xml:lang="es">Instanciación</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2020-10-23</dc:date>
-            <rdf:value xml:lang="en">Comment: updated. Scope note: updated and made several
-               paragraphs. Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -19653,6 +19922,13 @@
          <rdf:Description>
             <dc:date>2023-04-19</dc:date>
             <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restrictions.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2020-10-23</dc:date>
+            <rdf:value xml:lang="en">Comment: updated. Scope note: updated and made several
+               paragraphs. Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">A Record or Record Part must have been instantiated at least
@@ -19701,11 +19977,19 @@
    <!-- https://www.ica.org/standards/RiC/ontology#InstantiationExtent -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#InstantiationExtent">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Extent"/>
-      <rdfs:comment xml:lang="en">The extent of an Instantiation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Countable characteristics of an Instantiation expressed as a
+         quantity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Extensión de la instanciación</rdfs:label>
       <rdfs:label xml:lang="en">Instantiation Extent</rdfs:label>
       <rdfs:label xml:lang="fr">Mesure d’une instanciation</rdfs:label>
+      <rdfs:label xml:lang="es">Extensión de la instanciación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -19732,8 +20016,6 @@
                instantiation extent</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Countable characteristics of an Instantiation expressed as a
-         quantity.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-A23 (Instantiation
          Extent attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -19761,14 +20043,8 @@
       <rdfs:comment xml:lang="en">Connects at least two instantiations</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Instantiation to Instantiation Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación entre instanciaciones</rdfs:label>
       <rdfs:label xml:lang="fr">Relation entre instanciations</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="es">Relación entre instanciaciones</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -19781,6 +20057,12 @@
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
    </owl:Class>
@@ -19834,11 +20116,27 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Agent and one Record Resource or
-         Instantiation on which the Agent has some intellectual property rights.</rdfs:comment>
+         Instantiation on which the Agent has or had some intellectual property
+         rights.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Intellectual Property Rights Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de propiedad intelectual</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de propriété intellectuelle</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de propiedad intelectual</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-08</dc:date>
+            <rdf:value xml:lang="en">In order to get a system of rolified Relation classes: added an
+               equivalentClass object property; replaced the specific object properties by the
+               generic ones in the subClassOf declarations.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -19849,14 +20147,6 @@
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-08</dc:date>
-            <rdf:value xml:lang="en">In order to get a system of rolified Relation classes: added an
-               equivalentClass object property; replaced the specific object properties by the
-               generic ones in the subClassOf declarations.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Can be used, when the record resource is a work, for specifying
@@ -19899,8 +20189,8 @@
          first one has some knowledge of the second one through time or space.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Knowing Of Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de conocimieto indirecto entre personas</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de connaissance à propos d’une personne</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de conocimieto indirecto entre personas</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -19911,14 +20201,14 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R050 and RiC-R050i
@@ -19945,12 +20235,27 @@
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least two Persons that directly know each other during
-         their existence. This relation is symmetric.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects at least two Persons who directly know each other during
+         their existence.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Knowing Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de conocimiento directo entre personas</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de connaissance entre personnes</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de conocimiento directo entre personas</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-08</dc:date>
+            <rdf:value xml:lang="en">In order to get a system of rolified Relation classes: added an
+               equivalentClass object property; replaced the specific object properties by the
+               generic ones in the subClassOf declarations.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -19963,36 +20268,37 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-08</dc:date>
-            <rdf:value xml:lang="en">In order to get a system of rolified Relation classes: added an
-               equivalentClass object property; replaced the specific object properties by the
-               generic ones in the subClassOf declarations.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">The relation implies that the two persons met or at least
+         corresponded with each other.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Cass implementation of RiC-R051 and RiC—R051i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Language -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Language">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Concept"/>
-      <rdfs:comment xml:lang="en">A spoken or written human language represented in the Record or
-         Record Part, or used by the Agent.</rdfs:comment>
+      <rdfs:comment xml:lang="en">A spoken or written human language represented in a Record
+         Resource or used by an Agent.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Language</rdfs:label>
       <rdfs:label xml:lang="fr">Langue</rdfs:label>
       <rdfs:label xml:lang="es">Lengua</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-10-23</dc:date>
-            <rdf:value xml:lang="en">Scope note from RiC-CM : deleted.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -20004,8 +20310,8 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2020-10-23</dc:date>
+            <rdf:value xml:lang="en">Scope note from RiC-CM : deleted.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A25 (Language
@@ -20053,11 +20359,18 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Person and at least one Group, when the
-         first one leads the second one.</rdfs:comment>
+         first one(s) lead(s) or led the second one(s).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Leadership Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de liderazgo</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de direction</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de liderazgo</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -20087,8 +20400,8 @@
       <rdfs:comment xml:lang="en">A status defined by law.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Legal Status</rdfs:label>
-      <rdfs:label xml:lang="es">Status jurídico</rdfs:label>
       <rdfs:label xml:lang="fr">Statut légal</rdfs:label>
+      <rdfs:label xml:lang="es">Status jurídico</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -20144,15 +20457,16 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Agent, and at least one Record Resource or
-         Instantiation that the Agent manages.</rdfs:comment>
+         Instantiation that the Agent manages or managed.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Management Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de gestión</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de gestion</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de gestión</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -20169,22 +20483,35 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R038 and RiC-R038i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Mandate -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Mandate">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
-      <rdfs:comment xml:lang="en">Delegation of authority by an Agent to another Agent to perform an
-         Activity.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Delegation of responsibility or authority by an Agent to another
+         Agent to perform an Activity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="fr">Mandat</rdfs:label>
       <rdfs:label xml:lang="en">Mandate</rdfs:label>
+      <rdfs:label xml:lang="fr">Mandat</rdfs:label>
       <rdfs:label xml:lang="es">Norma</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-04-21</dc:date>
-            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -20195,30 +20522,30 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
+            <dc:date>2023-04-21</dc:date>
+            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
             <dc:date>2020-10-23</dc:date>
             <rdf:value xml:lang="en">Scope note: made separate paragraphs and updated. Objective: to
                make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Mandate is a kind of Rule. A Mandate confers the authority or
-         competencies of Agents to perform a specified Activity. In addition to assigning an
-         Activity and delegating authority to perform the Activity to an Agent, a Mandate commonly
-         limits the Place (jurisdiction) and Date (time period) within which an Agent may perform
-         the Activity (where and when). Mandates exist in a specific social and cultural context,
-         and within that context are subject to change over time. While a Mandate may be tacit, in
-         whole or part, it may be explicitly expressed in a variety of documentary sources (for
-         example, constitutions, legislation, (legal) acts, statutes, legal codes, ordinances,
-         charges, charters, or mission statements). The evidence for identifying a Mandate may be
-         found in its entirety in one documentary source (for example, a law or regulation), or may
-         be found in two or more sources. A Mandate should not be confused with the one or more
-         documentary sources that serve as evidence of its identity. A documentary source is a
-         Record.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Mandate is a kind of Rule. A mandate confers the responsibility
+         or authority of an agent to perform a specified activity. In addition to assigning an
+         activity and delegating responsibility or authority to perform the activity to an agent, a
+         mandate commonly limits the place (jurisdiction) and date (time period) within which an
+         agent may perform the activity (where and when). Mandates exist in a specific social and
+         cultural context, and within that context are subject to change over time. While a mandate
+         may be tacit, in whole or part, it may be explicitly expressed in a variety of documentary
+         sources (for example, constitutions, legislation, (legal) acts, statutes, legal codes,
+         ordinances, charges, charters, or mission statements). The evidence for identifying a
+         mandate may be found in its entirety in one documentary source (for example, a law or
+         regulation), or may be found in two or more sources. A mandate should not be confused with
+         the one or more documentary sources that serve as evidence of its identity. A documentary
+         source is a record.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E17 (Mandate
          entity)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -20263,16 +20590,18 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Mandate, and at least one Agent, when the
-         first gives the second one the authority or competencies to act. May also involve one to
-         many Activities that the Mandate(s) assign(s) to the Agent(s).</rdfs:comment>
+         first gives or gave the second one the authority or competencies to act. May also involve
+         one to many Activities that the Mandate(s) assign(s) or assigned to the
+         Agent(s).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Mandate Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación normativa</rdfs:label>
       <rdfs:label xml:lang="fr">Relation impliquant un mandat</rdfs:label>
+      <rdfs:label xml:lang="es">Relación normativa</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -20281,6 +20610,12 @@
             <rdf:value xml:lang="en">In order to get a system of rolified Relation classes: added an
                equivalentClass object property; replaced the specific object properties by the
                generic ones in the subClassOf declarations.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -20298,6 +20633,27 @@
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R067 and RiC-R067i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
+   <!-- https://www.ica.org/standards/RiC/ontology#MandateType -->
+   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#MandateType">
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#RuleType"/>
+      <rdfs:comment xml:lang="en">Categorization of a Mandate.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">Mandate Type</rdfs:label>
+      <rdfs:label xml:lang="fr">Type de mandat</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de norma</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Added in RiC-0 1.0 as it has been added to RiC-CM
+               1.0.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">For example : charter, treaty, contract, letter of appointment,
+         papal mandate, episcopal mandate, ciurt mandate, election mandate, popular mandate, federal
+         mandate, etc.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A44 (Mandate Type
+         attribute).</RiCCMCorrespondingComponent>
+   </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Mechanism -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Mechanism">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
@@ -20306,13 +20662,26 @@
       <rdfs:comment xml:lang="en">A process or system created by a Person or Group that performs an
          Activity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Mecanismo</rdfs:label>
       <rdfs:label xml:lang="en">Mechanism</rdfs:label>
       <rdfs:label xml:lang="fr">Système</rdfs:label>
+      <rdfs:label xml:lang="es">Mecanismo</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the
+               skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -20322,16 +20691,12 @@
                enriched.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Mechanism is a kind of Agent. A Mechanism may have both
-         mechanical and software components, or may be exclusively software. A Mechanism acts in the
-         world producing physical or social effects, and frequently generates or modifies
-         Records.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Mechanism is a kind of Agent. A mechanism may have both
+         mechanical and software components or may be exclusively software. A mechanism acts in the
+         world producing physical or social effects and may generate or modify records. A mechanism
+         performs activities based on rules determined by the agent that designed and created it. A
+         mechanism has an essential, derivative relation with the designing and creating
+         agent.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E13 (Mechanism
          entity)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -20377,15 +20742,16 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects a Group and at least one Person, when the first one has
-         the second one(s) among its members.</rdfs:comment>
+         or had the second one(s) among its members.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Membership Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de membresía</rdfs:label>
       <rdfs:label xml:lang="fr">Relation d’appartenance</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de membresía</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -20400,6 +20766,12 @@
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R055 and RiC-R055i
@@ -20435,22 +20807,17 @@
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects an Instantiation and at least another Instantiation, when
-         the first is migrated into the second one(s).</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects an Instantiation and at least another Instantiation it
+         has been migrated into.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Migration Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de migración entre instanciaciones</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de migration</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de migración entre instanciaciones</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -20461,18 +20828,6 @@
                generic ones in the subClassOf declarations.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R015 and RiC-R015i
-         relations</RiCCMCorrespondingComponent>
-   </owl:Class>
-   <!-- https://www.ica.org/standards/RiC/ontology#Name -->
-   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Name">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
-      <rdfs:comment xml:lang="en">A label, title or term designating the entity in order to make it
-         distinguishable from other similar entities.</rdfs:comment>
-      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="en">Name</rdfs:label>
-      <rdfs:label xml:lang="fr">Nom</rdfs:label>
-      <rdfs:label xml:lang="es">Nombre</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -20485,6 +20840,41 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:scopeNote xml:lang="en">Use for digital instantiations.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R015 and RiC-R015i
+         relations</RiCCMCorrespondingComponent>
+   </owl:Class>
+   <!-- https://www.ica.org/standards/RiC/ontology#Name -->
+   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Name">
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Appellation"/>
+      <rdfs:comment xml:lang="en">A label, title or term designating an entity in order to make it
+         distinguishable from other similar entities.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">Name</rdfs:label>
+      <rdfs:label xml:lang="fr">Nom</rdfs:label>
+      <rdfs:label xml:lang="es">Nombre</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">Provides brief information about the content or other individual
+         characteristics of the entity being described, necessary to distinguish it from other
+         perhaps similar entities.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-A28 (Name attribute)
          (see also the name datatype property)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -20493,21 +20883,16 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#ActivityType"/>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#DemographicGroup"/>
       <rdfs:comment xml:lang="en">Categorization of a profession, trade, or craft pursued by a
-         person in fulfilment of an Activity.</rdfs:comment>
+         Person in fulfilment of an Activity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Occupation Type</rdfs:label>
-      <rdfs:label xml:lang="es">Tipo de ocupación</rdfs:label>
       <rdfs:label xml:lang="fr">Type d’occupation</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de ocupación</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-10-23</dc:date>
-            <rdf:value xml:lang="en">scope note: added.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -20518,15 +20903,33 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
             <dc:date>2023-04-19</dc:date>
             <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Occupation Type should not be confused with Position where, for
-         example, an Agent with the Occupation Type “lawyer” holds the Position of “legal counsel”
-         in an agency. Occupation Type is related to, but should not be confused with the domain or
-         field of Activity (Actvitity Type), such as an archivist who works in the domain of
-         archival science. Occupation Type is a kind of Demographic Group.</skos:scopeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2020-10-23</dc:date>
+            <rdf:value xml:lang="en">scope note: added.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">The pursuit of an occupation involves the performance of an
+         Activity. Successful performance of the Activity is based on the ability to perform related
+         competencies successfully. Such competencies may be acquired through education or
+         experience, or a combination of both. The authority of the Person to pursue the occupation
+         may be derived tacitly or explicitly from an external Agent, based on a demonstrated
+         mastery of the competency. An occupation may be pursued independently by a Person or a
+         Group, thereby contributing to the fulfilment of the function (activity) of the group.
+         Should not be confused with Position where, for example, an agent with the occupation type
+         "lawyer" holds the position of "legal counsel" in an agency. Related to but should not be
+         confused with the domain or field of activity, such as an archivist who works in the domain
+         of archival science.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A30 (Occupation Type
          attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -20583,20 +20986,14 @@
          the Agent which created it or the Activity from which it resulted.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Organic or functional provenance Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de procedencia orgánica or funcional</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de provenance organique ou fonctionnelle</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de procedencia orgánica or funcional</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
             <rdf:value xml:lang="en">In order to get a system of rolified Relation classes: added an
                equivalentClass object property; replaced the specific object properties by the
                generic ones in the subClassOf declarations.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -20610,6 +21007,12 @@
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">This relation stands for organic and for functional
@@ -20660,25 +21063,13 @@
          it.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Organic Provenance Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de procedencia orgánica</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de provenance organique</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de procedencia orgánica</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-07</dc:date>
-            <rdf:value xml:lang="en">Renamed the relation in order to make it clearer (its name was
-               AgentOriginationRelation).</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -20689,6 +21080,28 @@
                generic ones in the subClassOf declarations.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-07</dc:date>
+            <rdf:value xml:lang="en">Renamed the relation in order to make it clearer (its name was
+               AgentOriginationRelation).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">This is the most general organic provenance relation. Use it to
+         connect a record resource or instantiation with an agent only if it is not possible to use
+         a narrower, more specific relation, for example Creation Relation.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R026 and RiC-R026i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -20732,15 +21145,16 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Group, Person or Position, and at least a
-         Thing that these Agent(s) own(s).</rdfs:comment>
+         Thing that these Agent(s) own(s) or owned.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Ownership Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de posesión</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de propriété</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de posesión</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -20753,13 +21167,19 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
             <dc:date>2023-08-25</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Among other probably more rare use cases for archival
          description, can be used between agents (a person owns a corporate body, a corporate body
-         owns a mechanism), or between agents and record resources</skos:scopeNote>
+         owns a mechanism), or between agents and record resources.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R037 and RiC-R037i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -20793,22 +21213,17 @@
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least one Activity to at least one Agent, when the
-         first is performed by the second one(s).</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects at least one Activity to at least one Agent, that
+         performs or performed the activity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Performance Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de desarrollo funcional</rdfs:label>
       <rdfs:label xml:lang="fr">Relation entre activités et agents</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de desarrollo funcional</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -20819,6 +21234,18 @@
                generic ones in the subClassOf declarations.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R060 and RiC-R060i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -20826,23 +21253,22 @@
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Person">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
       <owl:disjointWith rdf:resource="https://www.ica.org/standards/RiC/ontology#Position"/>
-      <rdfs:comment xml:lang="en">A human being with a social identity or persona.</rdfs:comment>
+      <rdfs:comment xml:lang="en">An individual human being.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Person</rdfs:label>
-      <rdfs:label xml:lang="es">Persona</rdfs:label>
       <rdfs:label xml:lang="fr">Personne</rdfs:label>
+      <rdfs:label xml:lang="es">Persona</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-10-23</dc:date>
-            <rdf:value xml:lang="en">Scope note: made separate paragraphs and updated. Disjoint
-               with: enriched. Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-10-23</dc:date>
-            <rdf:value xml:lang="en">Scope note: made separate paragraphs and updated. Disjoint
-               with: enriched. Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -20865,23 +21291,35 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2020-10-23</dc:date>
+            <rdf:value xml:lang="en">Scope note: made separate paragraphs and updated. Disjoint
+               with: enriched. Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2020-10-23</dc:date>
+            <rdf:value xml:lang="en">Scope note: made separate paragraphs and updated. Disjoint
+               with: enriched. Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Person is a kind of Agent. Most commonly, a human being
-         (biological person) has a single coeval social identity or persona. In everyday discourse,
-         this is the “real person.” Less common though not rare, over the course of a lifetime,
-         personae in addition to the coeval (or “original”) persona may be associated with the human
-         being. Such “alternative personae” are most often created by the original person for
-         specific purposes. Under some circumstances, an alternative persona might eclipse or
-         replace the original person (Mark Twain eclipsing Samuel Clemens; John Wayne eclipsing
-         Marion Mitchell Morrison), that is, the social (shared) alternative identity becomes the
-         predominate identity. Less common is whentwo or more persons collaborate to create a shared
-         persona. Persona shared by two or more Persons constitute a kind of Group. Within the
-         archival context, the original Person generally will be the focus of the description, with
-         alternative personae noted. Exceptionally, an alternative persona may displace the coeval
-         persona.s.</skos:scopeNote>
+         (biological person) has a single socially constructed identity or persona. Less common
+         though not rare, one or more personae in addition to the original persona which emerges at
+         or near birth may be associated with the human being over the course of that human being’s
+         lifetime. Such "alternative personae" are most often created by the original person for
+         specific purposes. The original persona may, in everyday discourse, be regarded as “the
+         real person”. Under some circumstances, an alternative persona might eclipse or replace the
+         original person (Mark Twain eclipsing Samuel Clemens; John Wayne eclipsing Marion Mitchell
+         Morrison), that is, the alternative identity becomes the predominant identity. Less common
+         is when two or more persons collaborate to create a shared persona. A persona shared by two
+         or more persons constitutes a kind of group. Within the archival context, the description
+         of a person commonly will focus on the original associated persona, with alternative
+         personae noted. Exceptionally, an alternative persona may displace the original persona as
+         the focus of the description. Under some circumstances, for example, when record resources
+         are associated with two or more different personae of one person, describing the different
+         personae as separate though related persons may be desirable. Alternatively, a person may
+         change their identity over the course of their lifetime.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E08 (Person
          entity)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -20891,14 +21329,20 @@
       <rdfs:comment xml:lang="en">A delimitation of the physical territory of a
          Place.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">Physical Location</rdfs:label>
       <rdfs:label xml:lang="fr">Localisation physique</rdfs:label>
       <rdfs:label xml:lang="es">Localización física de lugar</rdfs:label>
-      <rdfs:label xml:lang="en">Physical Location</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-04-19</dc:date>
-            <rdf:value xml:lang="en">Removed the two 0.2 existing unnecessary
-               restrictions.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the
+               skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -20909,12 +21353,16 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-04-19</dc:date>
+            <rdf:value xml:lang="en">Removed the two 0.2 existing unnecessary
+               restrictions.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Usually associated to one to many Places, and known during some
-         time. A location may be linked to one to many Coordinates.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Used to describe basic human-readable text such as an address, a
+         cadastral reference, or less precise information found in a record. Use the coordinates
+         datatype property, or the Coordinates class to capture the geographical coordinates of the
+         Place. Use spatial relations (particularly 'has or had location') to capture a relation
+         between two places.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-A27 (Location
          attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -20923,13 +21371,26 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">Bounded, named geographic area or region.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">Place</rdfs:label>
       <rdfs:label xml:lang="fr">Lieu</rdfs:label>
       <rdfs:label xml:lang="es">Lugar</rdfs:label>
-      <rdfs:label xml:lang="en">Place</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the
+               skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -20940,25 +21401,17 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
             <dc:date>2020-10-23</dc:date>
             <rdf:value xml:lang="en">Comment: updated. Scope note: updated and made several
                paragraphs. Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">A Place may be a jurisdiction, a manmade structure, or a natural
-         feature. A manmade structure or natural feature may also be a jurisdiction. A Place may be
-         referenced to a Physical Location on the earth, or (if you don't want to use the
-         PhysicalLocation class) directly to geographic coordinates. Both jurisdictions and natural
-         features are historical entities. A Place thus may have begin and end dates, and changing
-         boundaries that result from human or natural events. A Jurisdiction is the bounded
-         geographic area within which an Agent has the authority to perform specified activities
-         constrained by rules.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">A jurisdiction is the bounded geographic area within which an
+         Agent has the authority to perform specified activities constrained by rules.
+         Jurisdictions, man-made structures, and natural features are historical entities. A Place
+         thus may have a beginning date and ending date and changing boundaries that result from
+         human or natural events. A Place may be systematically referenced to a location on the
+         earth (geographic coordinates).</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E22 (Place
          entity)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -20968,9 +21421,9 @@
       <rdfs:comment xml:lang="en">A label, title or term designating a Place in order to make it
          distinguishable from other similar entities.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">Place Name</rdfs:label>
       <rdfs:label xml:lang="fr">Nom de lieu</rdfs:label>
       <rdfs:label xml:lang="es">Nombre de lugar</rdfs:label>
-      <rdfs:label xml:lang="en">Place Name</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -21020,14 +21473,8 @@
          associated with the existence and lifecycle of the second one.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Place Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación con lugar</rdfs:label>
       <rdfs:label xml:lang="fr">Relation impliquant un lieu</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="es">Relación con lugar</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -21042,6 +21489,12 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R074 and RiC-R074i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -21051,12 +21504,12 @@
       <rdfs:comment xml:lang="en">Categorization of a Place.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Place Type</rdfs:label>
-      <rdfs:label xml:lang="es">Tipo de lugar</rdfs:label>
       <rdfs:label xml:lang="fr">Type de lieu</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de lugar</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-04-19</dc:date>
-            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -21067,8 +21520,8 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-04-19</dc:date>
+            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Broadly, a Place may be a member of three broad categories:
@@ -21087,13 +21540,6 @@
       <rdfs:label xml:lang="es">Puesto</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-10-23</dc:date>
-            <rdf:value xml:lang="en">Scope note: made separate paragraphs and updated. Disjoint
-               with: enriched. Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
@@ -21102,6 +21548,13 @@
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2020-10-23</dc:date>
+            <rdf:value xml:lang="en">Scope note: made separate paragraphs and updated. Disjoint
+               with: enriched. Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Position is a kind of Agent. Position is the intersection of a
@@ -21151,11 +21604,18 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Person, and at least one Position that the
-         Person occupies.</rdfs:comment>
+         Person(s) occupies or occupied.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Position Holding Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de ocupación entre una persona y un puesto</rdfs:label>
       <rdfs:label xml:lang="fr">Relation entre une personne et un poste</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de ocupación entre una persona y un puesto</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -21166,14 +21626,14 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R054 and RiC-R054i
@@ -21210,12 +21670,20 @@
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Group"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least one Position, and a Group, when the first one(s)
-         exist(s) in/is defined within the second one.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects at least one Position, and a Group, in which the
+         position(s) exist(s) or existed, or that is (are) defined by that group's organizational
+         structure.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Position to Group Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de ocupación entre un grupo y un puesto</rdfs:label>
       <rdfs:label xml:lang="fr">Relation entre un poste et un groupe</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de ocupación entre un grupo y un puesto</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -21226,14 +21694,14 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R056 and RiC-R056i
@@ -21242,12 +21710,25 @@
    <!-- https://www.ica.org/standards/RiC/ontology#ProductionTechniqueType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#ProductionTechniqueType">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
-      <rdfs:comment xml:lang="en">Categorization of the method used in the representation of
-         information on the Instantiation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">The method used in the representation of information on an
+         instantiation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Production Technique Type</rdfs:label>
-      <rdfs:label xml:lang="es">Tipo de técnica de producción</rdfs:label>
       <rdfs:label xml:lang="fr">Type de technique de production</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de técnica de producción</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -21258,12 +21739,6 @@
          <rdf:Description>
             <dc:date>2023-04-19</dc:date>
             <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -21301,18 +21776,18 @@
          a specific Record Set.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Proxy</rdfs:label>
-      <rdfs:label xml:lang="es">Proxy</rdfs:label>
       <rdfs:label xml:lang="fr">Proxy</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="es">Proxy</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Useful for handling in RDF the sequencing of records or records
@@ -21324,13 +21799,38 @@
    <!-- https://www.ica.org/standards/RiC/ontology#Record -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Record">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-      <rdfs:comment xml:lang="en">Information inscribed at least once by any method on any physical
-         carrier in any persistent, recoverable form by an Agent in the course of life or work
-         Activity.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Discrete information content formed and inscribed, at least once,
+         by any method on any carrier in any persistent, recoverable form by an Agent in the course
+         of life or work activity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Documento</rdfs:label>
-      <rdfs:label xml:lang="fr">Objet informationnel</rdfs:label>
       <rdfs:label xml:lang="en">Record</rdfs:label>
+      <rdfs:label xml:lang="fr">Objet informationnel</rdfs:label>
+      <rdfs:label xml:lang="es">Documento</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2021-02-08</dc:date>
+            <rdf:value xml:lang="en">Removed the Restriction.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2020-10-23</dc:date>
@@ -21338,42 +21838,38 @@
                make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2021-02-08</dc:date>
-            <rdf:value xml:lang="en">Removed the Restriction.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Record is a kind of Record Resource. A Record must have or have
-         had at least one Instantiation. A Record may have more than one Instantiation. A
-         re-instantiation of the record may be considered the same record or a new record, depending
-         on the context and of the functions that record serves. Such information may serve a
-         variety of purposes, though it always documents or is evidence of
-         Activity.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Record is a kind of Record Resource. A Record may itself contain
+         one or more Records, or may consist of one or more Record Parts. A Record must have or have
+         had at least one Instantiation. A Record may have more than one Instantiation. An
+         Instantiation derived from another Instantiation of a Record may be considered the
+         instantiation of the same Record or an instantiation of a new Record, depending on the
+         context. A Record may serve a variety of purposes, though it always documents or is
+         evidence of Activity.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E04 (Record
          entity)</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RecordPart -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordPart">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-      <rdfs:comment xml:lang="en">Part of a Record with discrete information content that
-         contributes to the Record's physical or intellectual completeness.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Component of a Record with independent information content that
+         contributes to the intellectual completeness of the Record.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Componente documental</rdfs:label>
-      <rdfs:label xml:lang="fr">Partie d’objet informationnel</rdfs:label>
       <rdfs:label xml:lang="en">Record Part</rdfs:label>
+      <rdfs:label xml:lang="fr">Partie d’objet informationnel</rdfs:label>
+      <rdfs:label xml:lang="es">Componente documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -21384,12 +21880,6 @@
          <rdf:Description>
             <dc:date>2021-02-08</dc:date>
             <rdf:value xml:lang="en">Removed the Restriction.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -21407,16 +21897,23 @@
    <!-- https://www.ica.org/standards/RiC/ontology#RecordResource -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <rdfs:comment xml:lang="en">A Record, Record Set, or Record Part produced or acquired and
-         retained by an Agent in the course of Activity.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Information produced or acquired and retained by an Agent in the
+         course of life or work activity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Record Resource</rdfs:label>
-      <rdfs:label xml:lang="es">Recurso documental</rdfs:label>
       <rdfs:label xml:lang="fr">Ressource archivistique</rdfs:label>
+      <rdfs:label xml:lang="es">Recurso documental</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2021-02-08</dc:date>
-            <rdf:value xml:lang="en">Removed one Restriction.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -21433,9 +21930,63 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
+            <dc:date>2021-02-08</dc:date>
+            <rdf:value xml:lang="en">Removed one Restriction.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
             <dc:date>2020-10-23</dc:date>
             <rdf:value xml:lang="en">Scope note: made separate paragraphs plus very few
                changes.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">Record resource is a kind of Thing. Producing a record resource
+         may imply either its initial creation or a reuse of previous existing information by
+         combination, rearrangement, selecting, reformatting, etc. Record set, record, and record
+         part are kinds of record resource. A record resource is evidence of the activity of an
+         agent. More than one agent may be involved in the creation of a record resource. The role
+         of the agent in creating the record resource may take different forms, for example,
+         authoring of an individual record, accumulating a record set, or arranging a record set.
+         Though a record, record set, and record part, under most circumstances, may be easily
+         distinguished from one another, identifying the boundary of each may frequently present
+         particular challenges. Documentary forms provide the rules governing the structure of many
+         types of records, providing criteria for identifying a record's boundary, and identifying
+         its essential parts. Many records, though, do not have well-established documentary forms,
+         particularly in the case of digital records, where it may be difficult to determine whether
+         individual elements represented in separate bitstreams are record parts, records, or record
+         sets. For example, is photographic information represented independently in a bitstream
+         embedded in a text document a record or a record part? Or is the same photographic
+         information attached to an email that maintains its independent representation, a record or
+         a record part? Information grouped for some purpose, for example, ZIP or TAR "file
+         compression" for saving storage space, presents a further challenge. One file comprises
+         multiple bitstreams subjected to techniques that remove bits that can be losslessly
+         recovered when decompressed. Under what circumstances is such a compressed bitstream a
+         record or a record set? Determining when an information object is a record, record set, or
+         record part is based on perspective and judgement exercised in a particular context. In one
+         context, the agent describing an information object may designate it a record, while
+         another agent in a different context may designate it a record part. Both designations are
+         supported by RiC-CM, and the significance of the difference for users of the records is
+         ameliorated by the fact that all of the attributes and relations employed in describing
+         record and record part are shared, as are many of the attributes and relations employed in
+         describing a record set.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E02 (Record Resource
+         entity)</RiCCMCorrespondingComponent>
+   </owl:Class>
+   <!-- https://www.ica.org/standards/RiC/ontology#RecordResourceExtent -->
+   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResourceExtent">
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Extent"/>
+      <rdfs:comment xml:lang="en">The quantity of information content, as human experienced,
+         contained in a Record Resource.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">Record Resource Extent</rdfs:label>
+      <rdfs:label xml:lang="fr">Mesure d’une ressource archivistique</rdfs:label>
+      <rdfs:label xml:lang="es">Extensión de recurso documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -21444,44 +21995,6 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Producing a record resource may imply either its newly creation
-         or a reuse of previous existing information by combination, rearrangement, selecting,
-         reformatting etc. Records, Record Sets, and Record Parts are all evidence of the activities
-         of an Agent. More than one Agent may be involved in the creation of a Record Resource. The
-         role of the Agent in creating the Record Resource may take different forms, for example,
-         authoring of an individual record, accumulating a set of records, or forming a set of
-         records. Though a Record, Record Set, and Record Part, under most circumstances, may be
-         easily distinguished from one another, frequently identifying the boundary of each and how
-         the “bounded information regions” interrelate, may present particular challenges.
-         Documentary Forms provide the rules governing many Records, providing criteria for
-         identifying its boundary, and identifying its essential Record Parts. Many Records, though,
-         do not have well-established documentary forms, particularly electronic records, where it
-         may be difficult to determine whether individual elements represented in separate
-         bitstreams are record parts, records, or record sets. For example, is a photograph
-         represented independently in a bitstream embedded in a text document a Record, or a Record
-         Part ? Or is the same photograph attached to an email, maintaining its independent
-         representation, a Record or a Record Part? When information is grouped for some purpose,
-         for example, zip or tar “file compression” for saving storage space, presents a further
-         challenge. One file comprises multiple bitstreams subjected to techniques that remove bits
-         that can be losslessly recovered when decompressed. Under what circumstances is such a
-         compressed bitstream a Record or a Record Set? Determining when an information object is a
-         Record, Record Part, or Record Set is based on perspective and judgement exercised in a
-         particular context. In one context, the Agent describing an information object may
-         designate it a Record, while another Agent in a different context may designate it a Record
-         Part. Both designations are supported by RiC, and the significance of the difference for
-         users of the records is ameliorated by the fact that attributes and relations employed in
-         describing each of the record entities are shared.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E02 (Record Resource
-         entity)</RiCCMCorrespondingComponent>
-   </owl:Class>
-   <!-- https://www.ica.org/standards/RiC/ontology#RecordResourceExtent -->
-   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResourceExtent">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Extent"/>
-      <rdfs:comment xml:lang="en">The extent of the content of a Record Resource.</rdfs:comment>
-      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Extensión de recurso documental</rdfs:label>
-      <rdfs:label xml:lang="fr">Mesure d’une ressource archivistique</rdfs:label>
-      <rdfs:label xml:lang="en">Record Resource Extent</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
@@ -21502,14 +22015,12 @@
                record resource extent</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Countable characteristics of the content of the Record Resource
-         expressed as a quantity.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">The method and precision of expressing the quantity of
+         information represented in a Record Resource will vary according to the kind of record
+         resource being described, processing economy constraints, etc. For Record Sets, quantity
+         may be expressed as number of records, or, for analogue records in particular, by the
+         physical storage dimensions of the members of the Record Set. For individual Records or
+         Record Parts, quantity may be expressed in more precise terms.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-A35 (Record Resource
          extent attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -21534,17 +22045,18 @@
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects two to more Record Resources when there is a genetic
-         relation between them. Genetic in this sense is as defined by diplomatics, i.e. the process
-         by which a Record Resource is developed.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects two or more record resources when there is a genetic link
+         between them. Genetic in this sense is as defined by diplomatics, i.e., the process by
+         which a record resource is developed.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Record Resource Genetic Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación genética entre recursos documentales</rdfs:label>
       <rdfs:label xml:lang="fr">Relation génétique entre des ressources archivistiques</rdfs:label>
+      <rdfs:label xml:lang="es">Relación genética entre recursos documentales</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -21559,6 +22071,12 @@
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R023 and RiC-023i
@@ -21604,17 +22122,18 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects at least one Agent, and one or more Record Resource or
-         Instantiation that the Agent holds.</rdfs:comment>
+         Instantiation that the Agent(s) hold(s) or held.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Record Resource Holding Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación entre agentes y recursos documentales que
-         conservan</rdfs:label>
       <rdfs:label xml:lang="fr">Relation entre agents et ressources archivistiques ou instantiations
          conservées</rdfs:label>
+      <rdfs:label xml:lang="es">Relación entre agentes y recursos documentales que
+         conservan</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -21629,6 +22148,12 @@
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R039 and RiC-039i
@@ -21666,15 +22191,17 @@
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">Connects a Record Resource to one or more Instantiations that
-         instantiate it.</rdfs:comment>
+         instantiate it, and which either may exist or may have been lost or
+         destroyed.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Record Resource to Instantiation Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación de recurso documental a instanciación</rdfs:label>
       <rdfs:label xml:lang="fr">Relation d’instanciation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación de recurso documental a instanciación</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -21687,10 +22214,19 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
             <dc:date>2023-08-25</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:scopeNote xml:lang="en">In some situations, it may be useful or necessary to connect a
+         record resource to an instantiation that no longer exists or has been lost, when some of
+         its characteristics are known from a source, such as an old finding aid.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R025 and RiC-R025i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -21718,18 +22254,13 @@
       <rdfs:comment xml:lang="en">Connects at least two Record Resources.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Record Resource to Record Resource Relation</rdfs:label>
-      <rdfs:label xml:lang="es">Relación entre recursos documentales</rdfs:label>
       <rdfs:label xml:lang="fr">Relation entre ressources archivistiques</rdfs:label>
+      <rdfs:label xml:lang="es">Relación entre recursos documentales</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the
+               skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -21740,22 +22271,56 @@
                generic ones in the subClassOf declarations.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">Use to connect two record resources only if it is not possible
+         to use a narrower, more specific relation, for example
+         RecordResourceGeneticRelation.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R022 and RiC-022i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RecordSet -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordSet">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-      <rdfs:comment xml:lang="en">One or more records that are associated by categorization and/or
-         physical aggregation by the creator or other Agent.</rdfs:comment>
+      <rdfs:comment xml:lang="en">One or more records that are grouped together by an Agent based on
+         the records sharing one or more attributes or relations.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Agrupación documental</rdfs:label>
-      <rdfs:label xml:lang="fr">Ensemble d’objets informationnels</rdfs:label>
       <rdfs:label xml:lang="en">Record Set</rdfs:label>
+      <rdfs:label xml:lang="fr">Ensemble d’objets informationnels</rdfs:label>
+      <rdfs:label xml:lang="es">Agrupación documental</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-04-19</dc:date>
+            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -21765,42 +22330,30 @@
                paragraphs. Objective: to make RiC-O compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-04-19</dc:date>
-            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Record Set is a kind of Record Resource. The Record members in a
+      <skos:scopeNote xml:lang="en">Record set is a kind of Record Resource. The member records in a
          Record Set may physically reside together, though physical proximity is not essential. In a
-         particular context, an Agent (e.g. administrator, records manager, archivist, end-user,
-         etc.) may select the Record members of a Record Set based on a shared attribute or
-         attributes, or a shared Relation or Relations. The grouping of the Records serves a purpose
-         or purposes specific to the context of the Agent. All Record members of a Record Set may
-         share the attribute of having been accumulated by the same Agent, or all share the same
-         Documentary Form Type and are created over time by the same Activity. A Record Set may
-         represent the act of classifying the Records in accordance with a formal classification
-         scheme that may be based on Activity, subject, organizational structure, or other criteria;
-         an act of archival arrangement (e.g. based on common provenance); or some other selection
-         and grouping that fulfils a particular purpose or purposes (e.g. a classification that
-         reflects or supports the purposes of a researcher). By exception, some Records are brought
-         together based on their not belonging in the context of selection to other designated
-         groups: a ‘Miscellaneous’ series, for example. A Record Set accumulated by an Agent in the
-         course of life or work Activity should be kept in a manner that preserves context and
-         evidential value. Records Sets may also contain other Records Sets. Both a Record Set and a
-         Record may simultaneously be a member of more than one Record Set, and over the course of
-         its existence, a Record Set or Record may be a member of an indeterminate number of Record
-         Sets in an indeterminate number of contexts. Record Sets and Records contained within a
-         Record Set may be ordered into a sequence based on a common property or relation, or common
-         properties or relations (e.g. alphabetical by Agent or related Place name; chronological
-         order by an allocated Date); or some other criterion (e.g. an imposed order by
-         relevance).</skos:scopeNote>
+         particular context, an Agent (for example, administrator, records manager, archivist,
+         end-user, etc.) may select the member records of a Record Set based on any shared attribute
+         or attributes, or any shared relation or relations. The grouping of the records serves a
+         purpose or purposes specific to the context of the Agent. For example, all member records
+         of a Record Set have been accumulated by the same Agent; have the same Documentary Form
+         Type; or are related to and document the same Activity. A Record Set may represent the act
+         of classifying the records in accordance with a formal classification scheme that may be
+         based on activity, subject, organizational structure, or other criteria; an act of archival
+         arrangement (for example, based on common provenance); or some other selection and grouping
+         that fulfils a particular purpose or purposes (for example, a classification that reflects
+         or supports the purposes of a researcher). By exception, some records are brought together
+         based on their not belonging in the context of selection to other designated groups: a
+         'Miscellaneous' series, for example. A Record Sset accumulated by an Agent in the course of
+         life or work activity should be described in a manner that preserves context and evidential
+         value. Record Sets may also contain other Record Sets. A Record Set or Record may
+         simultaneously be a member of more than one Record Set, and over the course of its
+         existence, a Record Set or Record may be a member of an indeterminate number of Record Sets
+         in an indeterminate number of contexts. Record Sets and Records contained within a Record
+         Set may be ordered into a sequence based on a common property or relation, or common
+         properties or relations (for example, alphabetical by agent or related place);
+         chronological order by creation date; or some other criterion (for example, an imposed
+         order by relevance).</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E03 (Record Set
          entity)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -21810,13 +22363,19 @@
       <rdfs:comment xml:lang="en">A broad categorization of the type of Record Set.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Record Set Type</rdfs:label>
-      <rdfs:label xml:lang="es">Tipo de agrupación documental</rdfs:label>
       <rdfs:label xml:lang="fr">Type d’ensemble d’objets informationnels</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de agrupación documental</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-10-23</dc:date>
-            <rdf:value xml:lang="en">scope note: updated. Objective: to make RiC-O compliant with
-               RiC-CM v0.2.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the
+               skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -21827,36 +22386,8 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
             <dc:date>2023-04-19</dc:date>
             <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Four instances of Record Set Type are included for now in RiC-O;
-         they also are instances of skos:Concept and, as such, part of a SKOS vocabulary. Record Set
-         Type may also be used to categorize types of Record Set that have not traditionally been
-         considered archival, e.g. search result list.</skos:scopeNote>
-      <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A36 (Record Set Type
-         attribute)</RiCCMCorrespondingComponent>
-   </owl:Class>
-   <!-- https://www.ica.org/standards/RiC/ontology#RecordState -->
-   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordState">
-      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
-      <rdfs:comment xml:lang="en">Categorization of the production or reproduction status of a
-         Record or Record Part.</rdfs:comment>
-      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Estado de documento</rdfs:label>
-      <rdfs:label xml:lang="en">Record State</rdfs:label>
-      <rdfs:label xml:lang="fr">État d’un objet informationnel</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -21864,6 +22395,35 @@
             <dc:date>2020-10-23</dc:date>
             <rdf:value xml:lang="en">scope note: updated. Objective: to make RiC-O compliant with
                RiC-CM v0.2.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">Four instances of Record Set Type are included for now in RiC-O;
+         they also are instances of skos:Concept and, as such, part of a SKOS vocabulary. Record Set
+         Type may also be used (or extended) to categorize types of Record Set that have not
+         traditionally been considered archival, e.g. search result list.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A36 (Record Set Type
+         attribute)</RiCCMCorrespondingComponent>
+   </owl:Class>
+   <!-- https://www.ica.org/standards/RiC/ontology#RecordState -->
+   <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RecordState">
+      <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
+      <rdfs:comment xml:lang="en">Description of the production or reproduction status of a Record
+         or Record Part.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">Record State</rdfs:label>
+      <rdfs:label xml:lang="fr">État d’un objet informationnel</rdfs:label>
+      <rdfs:label xml:lang="es">Estado de documento</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -21879,11 +22439,16 @@
                well as textual definition.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Can in particular refer to a record state of development or its
-         status of transmission once finished (draft, original, copy...). Specifying that a record
-         resource has state copy usually implies that another record resource existed or exists, of
-         which the one described is the copy. In such a case you can also use 'is copy of' object
-         property.</skos:scopeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2020-10-23</dc:date>
+            <rdf:value xml:lang="en">scope note: updated. Objective: to make RiC-O compliant with
+               RiC-CM v0.2.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">Can refer both to a record's stage of creation (for example
+         "draft") and its form of transmission when the record was received (for example
+         "copy").</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A39 (State
          attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -21897,21 +22462,28 @@
       </owl:equivalentClass>
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:comment xml:lang="en">The top level relation class. It connects at least two Things. An
-         instance of a Relation may have some datatype and object properties : a descriptive note
-         (datatype property) like any Thing ; certainty (for 'certain', 'quite probable',
+         instance of a Relation may have some datatype and object properties : a general description
+         (datatype property) like any Thing ; a certainty (for 'certain', 'quite probable',
          'uncertain','unknown'); a date (use either the date datatype property or the Date class and
          isAssociatedWithDate object property ; a state (relationState) ; a location (use Place
          class and isAssociatedWithPlace object property) ; a source of information that can be used
          as an evidence for it (use either source datatype property or hasSource object
          property).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Relación</rdfs:label>
       <rdfs:label xml:lang="en">Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation</rdfs:label>
+      <rdfs:label xml:lang="es">Relación</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-08</dc:date>
+            <rdf:value xml:lang="en">added the equivalence to relation_role.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -21922,8 +22494,8 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-08</dc:date>
-            <rdf:value xml:lang="en">added the equivalence to relation_role.</rdf:value>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -21942,16 +22514,29 @@
    <!-- https://www.ica.org/standards/RiC/ontology#RepresentationType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RepresentationType">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
-      <rdfs:comment xml:lang="en">Categorization of the method of recording the content type of a
-         Record Resource.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Method of recording the content type of an
+         Instantiation</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Representation Type</rdfs:label>
-      <rdfs:label xml:lang="es">Tipo de grabación</rdfs:label>
       <rdfs:label xml:lang="fr">Type de représentation</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de grabación</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -21967,34 +22552,26 @@
                compliant with RiC-CM v0.2.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Representation Type can be unmediated (which allows humans to
-         receive the message communicated without an intermediation of a device) and mediated (which
-         needs a device to decode the message). A lot of contemporary mediated types are digital.
-         Each Representation Type may present specific features: bit rate for audio, resolution for
-         digital images, encoding format for video etc. Depending of the type, properties may thus
-         be needed to describe their characteristics. Not be confused with Content Type or Carrier
-         Type since the form of representation can be independent of the communication or
-         carrier.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Can be unmediated (which allows humans to receive the message
+         communicated without an intermediation of a device) and mediated (which needs a device to
+         decode the message). A lot of contemporary mediated types are digital. Each representation
+         type may present specific features: bit rate for audio, resolution for digital images,
+         encoding format for video etc. Depending on the type, specific attributes may be added to
+         describe their characteristics.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A37 (Representation Type
          attribute)</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#RoleType -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#RoleType">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
-      <rdfs:comment xml:lang="en">The role an agent plays in some context (usually in some creation
-         relation). Not to be confused with a position (position of an agent in some group). For
-         example, a person who is the head of some corporate body may play the role of annotator (of
+      <rdfs:comment xml:lang="en">The role an Agent plays in some context (usually in some creation
+         relation). Not to be confused with a Position (position of an agent in some group). For
+         example, a Person who is the head of some Corporate bBdy may play the role of annotator (of
          a record) in a creation relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Role Type</rdfs:label>
-      <rdfs:label xml:lang="es">Tipo de rol</rdfs:label>
       <rdfs:label xml:lang="fr">Type de rôle</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de rol</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -22011,17 +22588,18 @@
    <!-- https://www.ica.org/standards/RiC/ontology#Rule -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#Rule">
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <rdfs:comment xml:lang="en">Conditions that govern the existence or authority of an Agent or
-         the performance of an Activity, or that contribute to the distinct characteristics of
-         things created or managed by an Agent.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Conditions that govern the existence, responsibility, or authority
+         of an Agent; or the performance of an Activity by an Agent; or that contribute to the
+         distinct characteristics of things created or managed by an Agent.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Regla</rdfs:label>
       <rdfs:label xml:lang="en">Rule</rdfs:label>
       <rdfs:label xml:lang="fr">Règle</rdfs:label>
+      <rdfs:label xml:lang="es">Regla</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -22032,9 +22610,8 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2020-10-23</dc:date>
-            <rdf:value xml:lang="en">Scope note: made separate paragraphs and updated. Objective: to
-               make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -22050,21 +22627,29 @@
                were recently changed in RiC-CM 0.2 full draft.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Rule can be related directly to Agent, Activity, or anything
-         created or managed by agents, such as a Record Resource or Instantiation. A Rule may be
-         unwritten or written or otherwise documented. Unwritten rules may include though are not
-         limited to the following: social mores, customs, or community expectations. Written rules
-         may include though are not limited to the following: constitutions, legislation, acts
-         (legal), statutes, legal codes, ordinances, charters, mission statements, regulations,
-         policies, procedures, instructions, codes of conduct or ethics, professional standards,
-         work assignments or work plans. The source or sources of some Rules are external to the
-         Agent (for example, expressed in elections, social mores, customs, community expectations,
-         laws, regulations, standards and best practice codes), while others are expressed within
-         the Agent’s immediate context (for example, policies, or written or verbal instructions).
-         The evidence for identifying Rules may be found in their entirety in one documentary source
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2020-10-23</dc:date>
+            <rdf:value xml:lang="en">Scope note: made separate paragraphs and updated. Objective: to
+               make RiC-O compliant with RiC-CM v0.2.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">Rule is a kind of Thing. Rule can be related directly to agent,
+         activity, or anything created or managed by agents, such as a record resource or
+         instantiation. A rule may be unwritten or written or otherwise documented. Unwritten rules
+         may include though are not limited to the following: social mores, customs, or community
+         expectations. Written rules may include though are not limited to the following:
+         constitutions, legislation, acts (legal), statutes, legal codes, ordinances, charters,
+         mission statements, regulations, policies, procedures, instructions, codes of conduct or
+         ethics, professional standards, work assignments, or work plans. The source or sources of
+         some rules governing the existence or activity of an agent may be external (for example,
+         expressed in elections, social mores, customs, community expectations, laws, regulations,
+         standards, and best practice codes), while others may be expressed within the immediate
+         context of an agent (for example, policies, or written or verbal instructions). The
+         evidence for identifying rules may be found in their entirety in one documentary source
          (for example, a law or regulation) or may be found in two or more sources. Rule should not
          be confused with the one or more documentary sources that serve as evidence of its
-         identity. A documentary source is a Record. </skos:scopeNote>
+         identity. A documentary source is a record.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-E16 (Rule
          entity)</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -22101,9 +22686,9 @@
       <rdfs:comment xml:lang="en">Connects at least one Rule to at least one Thing, when it is
          associated with existence and lifecycle of the Thing.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Relación con regla</rdfs:label>
-      <rdfs:label xml:lang="fr">Relation impliquant une règle</rdfs:label>
       <rdfs:label xml:lang="en">Rule Relation</rdfs:label>
+      <rdfs:label xml:lang="fr">Relation impliquant une règle</rdfs:label>
+      <rdfs:label xml:lang="es">Relación con regla</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -22133,8 +22718,15 @@
       <rdfs:comment xml:lang="en">Categorization of a Rule.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Rule Type</rdfs:label>
-      <rdfs:label xml:lang="es">Tipo de regla</rdfs:label>
       <rdfs:label xml:lang="fr">Type de règle</rdfs:label>
+      <rdfs:label xml:lang="es">Tipo de regla</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: added a
+               rico:RiCCMCorrespondingComponent.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -22143,14 +22735,14 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-04-19</dc:date>
-            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-04-19</dc:date>
+            <rdf:value xml:lang="en">Removed the 0.2 existing unnecessary restriction.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -22162,6 +22754,8 @@
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">For example, for rules that can be applied to record resources :
          access rule, use rule, etc.</skos:scopeNote>
+      <RiCCMCorrespondingComponent xml:lang="en">Corresponds to RiC-A45 (Rule Type
+         attribute).</RiCCMCorrespondingComponent>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#SequentialRelation -->
    <owl:Class rdf:about="https://www.ica.org/standards/RiC/ontology#SequentialRelation">
@@ -22193,16 +22787,17 @@
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least one Thing to at least one Thing that follows it
-         in some sequence.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects at least one Thing to at least one Thing that follows or
+         followed it in some sequence.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Relación secuencial</rdfs:label>
-      <rdfs:label xml:lang="fr">Relation séquentielle</rdfs:label>
       <rdfs:label xml:lang="en">Sequential Relation</rdfs:label>
+      <rdfs:label xml:lang="fr">Relation séquentielle</rdfs:label>
+      <rdfs:label xml:lang="es">Relación secuencial</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment), skos:scopeNote.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -22215,10 +22810,20 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
             <dc:date>2023-08-25</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:scopeNote xml:lang="en">The relation does not specify the criteria used for ordering the
+         sequence. There may be zero to many intermediate entities, ignored or unknown, in the
+         sequence between the two connected things. Can be used, for example, for specifying that a
+         record "has next" another record within a record set.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R008 and RiC-R008i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -22245,15 +22850,9 @@
       <rdfs:comment xml:lang="en">Connects at least two Persons, when they are
          siblings.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Relación familiar entre hermanos</rdfs:label>
-      <rdfs:label xml:lang="fr">Relation de fratrie</rdfs:label>
       <rdfs:label xml:lang="en">Sibling Relation</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="fr">Relation de fratrie</rdfs:label>
+      <rdfs:label xml:lang="es">Relación familiar entre hermanos</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -22266,6 +22865,12 @@
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R048 and RiC-R048i
@@ -22294,21 +22899,21 @@
       <rdfs:comment xml:lang="en">Connects at least two Persons, when they are
          spouses.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Relación matrimonial entre personas</rdfs:label>
-      <rdfs:label xml:lang="fr">Relation matrimoniale</rdfs:label>
       <rdfs:label xml:lang="en">Spouse Relation</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="fr">Relation matrimoniale</rdfs:label>
+      <rdfs:label xml:lang="es">Relación matrimonial entre personas</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
             <rdf:value xml:lang="en">In order to get a system of rolified Relation classes: added an
                equivalentClass object property; replaced the specific object properties by the
                generic ones in the subClassOf declarations.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -22350,12 +22955,19 @@
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least one Person to at least another Person, who is
-         their student.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects at least one Person to at least another Person, who is or
+         was their student.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Relación académica entre profesor y alumno</rdfs:label>
-      <rdfs:label xml:lang="fr">Relation entre enseignants et étudiants</rdfs:label>
       <rdfs:label xml:lang="en">Teaching Relation</rdfs:label>
+      <rdfs:label xml:lang="fr">Relation entre enseignants et étudiants</rdfs:label>
+      <rdfs:label xml:lang="es">Relación académica entre profesor y alumno</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -22366,14 +22978,14 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R053 and RiC-R053i
@@ -22412,9 +23024,16 @@
       <rdfs:comment xml:lang="en">Connects at least one Thing to at least one Thing that follows it
          in chronological order.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Relación temporal</rdfs:label>
-      <rdfs:label xml:lang="fr">Relation temporelle</rdfs:label>
       <rdfs:label xml:lang="en">Temporal Relation</rdfs:label>
+      <rdfs:label xml:lang="fr">Relation temporelle</rdfs:label>
+      <rdfs:label xml:lang="es">Relación temporal</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the
+               skos:scopeNote.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -22425,16 +23044,18 @@
       </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">There may be zero to many intermediate entities, ignored or
+         unknown, in the chronological sequence between the connected entities.</skos:scopeNote>
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R009 and RiC-R009i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
@@ -22443,15 +23064,9 @@
       <rdfs:comment xml:lang="en">Any idea, material thing, or event within the realm of human
          experience.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">Thing</rdfs:label>
       <rdfs:label xml:lang="fr">Chose</rdfs:label>
       <rdfs:label xml:lang="es">Cosa</rdfs:label>
-      <rdfs:label xml:lang="en">Thing</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2020-10-23</dc:date>
-            <rdf:value xml:lang="en">made separate paragraphs in the scope note.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -22462,6 +23077,12 @@
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2020-10-23</dc:date>
+            <rdf:value xml:lang="en">made separate paragraphs in the scope note.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Includes all RiC entities as well as any concept, material
@@ -22478,8 +23099,8 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Name"/>
       <rdfs:comment xml:lang="en">A name that is used for a Record Resource or a Rule</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="fr">Intitulé</rdfs:label>
       <rdfs:label xml:lang="en">Title</rdfs:label>
+      <rdfs:label xml:lang="fr">Intitulé</rdfs:label>
       <rdfs:label xml:lang="es">Título</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
@@ -22502,19 +23123,19 @@
       <rdfs:comment xml:lang="en">A superclass for any category of some thing. A type characterizes
          an entity.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Tipo</rdfs:label>
       <rdfs:label xml:lang="en">Type</rdfs:label>
       <rdfs:label xml:lang="fr">Type</rdfs:label>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-08-25</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
+      <rdfs:label xml:lang="es">Tipo</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-08-25</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
    </owl:Class>
@@ -22551,9 +23172,9 @@
       <rdfs:comment xml:lang="en">Connects a category (a Type) and at least one Thing that belongs
          to this category.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">Type Relation</rdfs:label>
       <rdfs:label xml:lang="fr">Relation de catégorisation</rdfs:label>
       <rdfs:label xml:lang="es">Tipo de relación</rdfs:label>
-      <rdfs:label xml:lang="en">Type Relation</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -22586,9 +23207,15 @@
          more informal units used in the archival context like number of boxes, pages or
          words.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Unidad de medida</rdfs:label>
       <rdfs:label xml:lang="en">Unit Of Measurement</rdfs:label>
       <rdfs:label xml:lang="fr">Unité de mesure</rdfs:label>
+      <rdfs:label xml:lang="es">Unidad de medida</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-02</dc:date>
+            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
@@ -22599,12 +23226,6 @@
          <rdf:Description>
             <dc:date>2023-08-25</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
-         </rdf:Description>
-      </skos:changeNote>
-      <skos:changeNote>
-         <rdf:Description>
-            <dc:date>2023-11-02</dc:date>
-            <rdf:value xml:lang="en">Added a new rdfs:label in Spanish.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -22645,12 +23266,19 @@
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects a Thing to at least one constitutive or component part of
-         that Thing.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Thing to at least one Thing that is or was a portion or
+         division of the whole Thing.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Relación entre todo y parte</rdfs:label>
-      <rdfs:label xml:lang="fr">Relation partitive</rdfs:label>
       <rdfs:label xml:lang="en">Whole Part Relation</rdfs:label>
+      <rdfs:label xml:lang="fr">Relation partitive</rdfs:label>
+      <rdfs:label xml:lang="es">Relación entre todo y parte</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>
@@ -22695,12 +23323,19 @@
             <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#Agent"/>
          </owl:Restriction>
       </rdfs:subClassOf>
-      <rdfs:comment xml:lang="en">Connects at least two Agents that have some type of work relation
-         in the course of their activities.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects at least two Agents that have or had some type of work
+         relation in the course of their activities.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="es">Relación profesional</rdfs:label>
-      <rdfs:label xml:lang="fr">Relation de travail</rdfs:label>
       <rdfs:label xml:lang="en">Work Relation</rdfs:label>
+      <rdfs:label xml:lang="fr">Relation de travail</rdfs:label>
+      <rdfs:label xml:lang="es">Relación profesional</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2023-11-12</dc:date>
+            <rdf:value xml:lang="en">Aligned with RiC-CM 1.0: updated the description
+               (rdfs:comment).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-08</dc:date>

--- a/ontology/current-version/RiC-O_1-0.rdf
+++ b/ontology/current-version/RiC-O_1-0.rdf
@@ -660,7 +660,7 @@
                   usedFromDate a subproperty of beginningDate, and usedToDate a subproperty of
                   endDate.</html:li>
                <html:li>2023, November 12: updated the classes in order to make them compliant with
-                  RiC-CM 1.0 attributes. Updated or added many rdfs:comment and skos:scopeNote,
+                  RiC-CM 1.0 entities and attributes. Updated or added many rdfs:comment and skos:scopeNote,
                   taking into account, as concerns the Relation classes, the fact that they are
                   n-ary. Created a new MandateType class, corresponding to RiC-A44 attribute in
                   RiC-CM 1.0. Also added a rdfs:isDefinedBy to skos:Concept, skos:ConceptScheme and


### PR DESCRIPTION
Updated the classes in order to make them compliant with RiC-CM 1.0 entities and attributes. In order to do this, updated or added many rdfs:comment and skos:scopeNote, taking into account, as concerns the Relation classes, the fact that they are n-ary. Created a new MandateType class, corresponding to RiC-A44 attribute in RiC-CM 1.0. Also added a rdfs:isDefinedBy to skos:Concept, skos:ConceptScheme and voaf:Vocabulary.