### PR TITLE
Fix typo

### DIFF
--- a/ontology/current-version/HTML_view/RiC-O_1-0_documentation.html
+++ b/ontology/current-version/HTML_view/RiC-O_1-0_documentation.html
@@ -6669,7 +6669,7 @@
                <dt>Definition</dt>
                <dd>The role an Agent plays in some context (usually in some creation
          relation). Not to be confused with a Position (position of an agent in some group). For
-         example, a Person who is the head of some Corporate bBdy may play the role of annotator (of
+         example, a Person who is the head of some Corporate Body may play the role of annotator (of
          a record) in a creation relation.</dd>
             </dl>
             <dl>

--- a/ontology/current-version/RiC-O_1-0.rdf
+++ b/ontology/current-version/RiC-O_1-0.rdf
@@ -24707,7 +24707,7 @@
       <rdfs:subClassOf rdf:resource="https://www.ica.org/standards/RiC/ontology#Type"/>
       <rdfs:comment xml:lang="en">The role an Agent plays in some context (usually in some creation
          relation). Not to be confused with a Position (position of an agent in some group). For
-         example, a Person who is the head of some Corporate bBdy may play the role of annotator (of
+         example, a Person who is the head of some Corporate Body may play the role of annotator (of
          a record) in a creation relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Role Type</rdfs:label>


### PR DESCRIPTION
Corporate B**b**dy -> Corporate Body

Edited in both the RDF and the HTML file, but perhaps it's more convenient to remove the HTML file change and regenerate the documentation altogether.