### PR TITLE
Implement rankInSequence and rankInHierarchy

### DIFF
--- a/ontology/current-version/RiC-O_1.1.rdf
+++ b/ontology/current-version/RiC-O_1.1.rdf
@@ -4446,15 +4446,21 @@
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
          <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#hasDirectConstituentOfProxy"/>
+            rdf:about="https://www.ica.org/standards/RiC/ontology#hasDirectConstituentProxy"/>
          <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Connects a Record to another Record or Record Part that is its
+      <rdfs:comment xml:lang="en">Connects a Record or Record Part to another Record or Record Part that is its
          direct constituent.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a directement pour constituant</rdfs:label>
       <rdfs:label xml:lang="en">has direct constituent</rdfs:label>
       <rdfs:label xml:lang="es">tiene directamente como elemento constitutivo</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-03</dc:date>
+            <rdf:value xml:lang="en">Fixed the property chain axiom.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>

--- a/ontology/current-version/RiC-O_1.1.rdf
+++ b/ontology/current-version/RiC-O_1.1.rdf
@@ -17641,6 +17641,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#proxyFor -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasProxy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:comment xml:lang="en">Connects a Proxy to the Record Resource it stands for in the

--- a/ontology/current-version/RiC-O_1.1.rdf
+++ b/ontology/current-version/RiC-O_1.1.rdf
@@ -985,8 +985,7 @@
                      hasMigrationDate, isMigrationDateOf and of migrationDate accordingly. Removed
                      the mention of Record Resource from the rdfs:comment of isMigrationDateOf and
                      migrationDate.</html:li>
-<<<<<<< HEAD
-                  <html:li>2025, March 4th: introduced datatype properties rankInSequence and
+<html:li>2025, March 4th: introduced datatype properties rankInSequence and
                      rankInHierarchy, expanded the range of proxyIn to any RecordResource and
                      tweaked the definition of it and proxyFor accordingly, added an inverse
                      property hasProxy for proxyFor, added two new sub-properties proxyInRecord and
@@ -994,17 +993,15 @@
                      of Proxy in sequences or hierarchies, and added one or two property chain
                      axioms involving rico:Proxy to a few object properties used to define sequences
                      or hierarchies.</html:li>
+                  <html:li>2025, March 13: added French and Spanish labels to the object properties
+                     that connect Date and Relation, and to the isOrganicProvenanceDateOf/hasOrganicProvenanceDate properties.
+                     Fixed the domain and a rdfs:subPropertyOf of isDateAssociatedWithRelation.
+                     Also added property chain axioms to hasDerivationDate, hasMigrationDate and to their
+                     inverse properties.</html:li>                 
                   <html:li>2025, April 2nd: reviewed the new properties for Proxies, hierarchies and
                      sequences. Fixed a few owl:inverseOf, owl:subPropertyOf and a property chain
                      axiom. Modified a few details in the rdfs:comment of those properties. Added
                      French and Spanish labels to these new properties.</html:li>
-=======
-                  <html:li>2025, March 13: added French and Spanish labels to the object properties
-                     that connect Date and Relation, and to the isOrganicProvenanceDateOf/hasOrganicProvenanceDate properties.
-                     Fixed the domain and a rdfs:subPropertyOf of isDateAssociatedWithRelation.
-                  Also added property chain axioms to hasDerivationDate, hasMigrationDate and to their
-                  inverse properties.</html:li>
->>>>>>> 1f964451cd490cc1c8f48cfd3bd2362a22702fb0
                </html:ul>
             </html:div>
          </html:div>
@@ -4047,16 +4044,12 @@
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
-<<<<<<< HEAD
-      <rdfs:comment xml:lang="en">Inverse of 'is creation date of' object property.</rdfs:comment>
-=======
-      <owl:propertyChainAxiom rdf:parseType="Collection">
+<owl:propertyChainAxiom rdf:parseType="Collection">
          <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
          <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#creationRelation_role"/>
          <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasDate"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is creation date of' object property</rdfs:comment>
->>>>>>> 1f964451cd490cc1c8f48cfd3bd2362a22702fb0
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour date de création</rdfs:label>
       <rdfs:label xml:lang="en">has creation date</rdfs:label>

--- a/ontology/current-version/RiC-O_1.1.rdf
+++ b/ontology/current-version/RiC-O_1.1.rdf
@@ -980,6 +980,14 @@
                      hasMigrationDate, isMigrationDateOf and of migrationDate accordingly. Removed
                      the mention of Record Resource from the rdfs:comment of isMigrationDateOf and
                      migrationDate.</html:li>
+                  <html:li>2025, March 4th: introduced datatype properties rankInSequence and
+                     rankInHierarchy, expanded the range of proxyIn to any RecordResource and tweaked
+                     the definition of it and proxyFor accordingly, added an inverse property
+                     hasProxy for proxyFor, added two new sub-properties proxyInRecord and
+                     proxyInRecordSet of ProxyIn, introduced 36 object
+                     properties pertaining to use of Proxy in sequences or hierarchies, and
+                     added one or two property chain axioms involving rico:Proxy to a few
+                     object properties used to define sequences or hierarchies.</html:li>
                </html:ul>
             </html:div>
          </html:div>
@@ -1594,7 +1602,7 @@
             rdf:about="https://www.ica.org/standards/RiC/ontology#mandateRelation_role"/>
          <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'authorizes' object property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'authorizes' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">authorized by</rdfs:label>
       <rdfs:label xml:lang="fr">autorisé par</rdfs:label>
@@ -2143,12 +2151,24 @@
          rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyPrecedesInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <rdfs:comment xml:lang="en">Connects a Thing to a Thing that it follows directly in some non
-         chronological sequence.</rdfs:comment>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyDirectlyFollowsInSequence"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
+      </owl:propertyChainAxiom>
+      <rdfs:comment xml:lang="en">Inverse of 'directly precedes in sequence' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">directly follows in sequence</rdfs:label>
       <rdfs:label xml:lang="es">sigue directamente en la secuencia</rdfs:label>
       <rdfs:label xml:lang="fr">suit directement dans la séquence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Tweaked the rdfs:comment to simply refer to its inverse property.
+               Also added a property chain axiom relating it to use of rico:Proxy.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-27</dc:date>
@@ -2173,6 +2193,28 @@
             <dc:date>2023-09-08</dc:date>
             <rdf:value xml:lang="en">Added transitive super-property and both present direct and
                past sequential relations as well as their respective inverse relations.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#directlyFollowsProxyInSequence -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#directlyFollowsProxyInSequence">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyFollowsInSequence"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#followsProxyInSequence"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyDirectlyPrecedesInSequence"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy directly precedes in sequence' object property.
+         </rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">directly follows proxy in sequence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
    </owl:ObjectProperty>
@@ -2219,6 +2261,27 @@
          </rdf:Description>
       </skos:changeNote>
    </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#directlyIncludesProxy -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#directlyIncludesProxy">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#includesProxy"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsDirectlyIncludedIn"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy is directly included in' object property.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">directly includes proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#directlyPrecedesInSequence -->
    <owl:ObjectProperty
       rdf:about="https://www.ica.org/standards/RiC/ontology#directlyPrecedesInSequence">
@@ -2228,12 +2291,25 @@
          rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyFollowsInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <rdfs:comment xml:lang="en">Connects a Thing to a Thing that it precedes directly in some non
-         chronological sequence.</rdfs:comment>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#directlyPrecedesProxyInSequence"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
+      </owl:propertyChainAxiom>
+      <rdfs:comment xml:lang="en">Connects a Thing to a Thing that it precedes directly in some
+         sequence (not necessarily defined or characterised chronologically).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">directly precedes in sequence</rdfs:label>
       <rdfs:label xml:lang="es">precede directamente en la secuencia</rdfs:label>
       <rdfs:label xml:lang="fr">précède directement dans la séquence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Tweaked the rdfs:comment to try to clarify what is
+               meant. Also added a property chain axiom relating it to use of rico:Proxy.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-27</dc:date>
@@ -2260,6 +2336,28 @@
                order to enable to express current, direct, sequential relations between things (the
                possibly indirect, transitive relation, superproperty of this one, being also
                added).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#directlyPrecedesProxyInSequence -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#directlyPrecedesProxyInSequence">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyPrecedesInSequence"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesProxyInSequence"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyDirectlyFollowsInSequence"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Connects a Record Resource to a proxy of a Record Resource that it precedes
+         directly in some sequence (not necessarily defined or characterised chronologically).</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">directly precedes proxy in sequence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
    </owl:ObjectProperty>
@@ -2615,12 +2713,19 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precededInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <rdfs:comment xml:lang="en">Connects a Thing to a Thing that it followed in some non
-         chronological sequence in the past.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Thing to a Thing that it followed in some
+         sequence (not necessarily defined or characterised chronologically) in the past.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a suivi dans la séquence</rdfs:label>
       <rdfs:label xml:lang="en">followed in sequence</rdfs:label>
       <rdfs:label xml:lang="es">seguía en la secuencia transitivo</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Tweaked the rdfs:comment to try to clarify what is
+               meant.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-27</dc:date>
@@ -2658,12 +2763,25 @@
          rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInSequenceTransitive"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <rdfs:comment xml:lang="en">Connects a Thing to a Thing that it directly or indirectly follows
-         in some non chronological sequence.</rdfs:comment>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#hasProxy"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFollowsInSequence"/>
+      </owl:propertyChainAxiom>
+      <rdfs:comment xml:lang="en">Inverse of 'precedes in sequence transitive' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">follows in sequence transitive</rdfs:label>
       <rdfs:label xml:lang="es">sigue en la secuencia transitivo</rdfs:label>
       <rdfs:label xml:lang="fr">suit dans la séquence transitif</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Tweaked the rdfs:comment to simply refer to its inverse
+               property. Also added a property chain axiom relating it to use of rico:Proxy.
+            </rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-27</dc:date>
@@ -2760,7 +2878,7 @@
             rdf:about="https://www.ica.org/standards/RiC/ontology#sequentialRelation_role"/>
          <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'precedesOrPreceded' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'precedes or preceded' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">follows or followed</rdfs:label>
       <rdfs:label xml:lang="es">sigue o seguía a</rdfs:label>
@@ -2795,6 +2913,25 @@
       </skos:changeNote>
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R008i ('follows or followed'
          relation)</RiCCMCorrespondingComponent>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#followsProxyInSequence -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#followsProxyInSequence">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInSequenceTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyPrecedesInSequence"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy precedes in sequence' object property.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">follows proxy in sequence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#functionalEquivalenceRelation_role -->
    <owl:ObjectProperty
@@ -3118,7 +3255,7 @@
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:comment xml:lang="en">Inverse of 'is accumulation date of' object
-         property</rdfs:comment>
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour date d'accumulation</rdfs:label>
       <rdfs:label xml:lang="en">has accumulation date</rdfs:label>
@@ -3398,7 +3535,7 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isBeginningDateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
-      <rdfs:comment xml:lang="en">Inverse of 'is beginning date of' object property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is beginning date of' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour date de début</rdfs:label>
       <rdfs:label xml:lang="en">has beginning date</rdfs:label>
@@ -3424,7 +3561,7 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isBirthDateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
-      <rdfs:comment xml:lang="en">Inverse of 'is birth date of' object property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is birth date of' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour date de naissance</rdfs:label>
       <rdfs:label xml:lang="en">has birth date</rdfs:label>
@@ -3451,7 +3588,7 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isBirthPlaceOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
-      <rdfs:comment xml:lang="en">Inverse of 'is birth place of' object property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is birth place of' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour lieu de naissance</rdfs:label>
       <rdfs:label xml:lang="en">has birth place</rdfs:label>
@@ -3647,6 +3784,38 @@
          </rdf:Description>
       </skos:changeNote>
    </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#hasConstituentProxy -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOf"/>
+      <rdfs:domain>
+         <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Record"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordPart"/>
+            </owl:unionOf>
+         </owl:Class>
+      </rdfs:domain>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasConstituentProxyTransitive"/>
+      </owl:propertyChainAxiom>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy is constituent of' object property.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">has constituent proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasConstituentTransitive -->
    <owl:ObjectProperty
       rdf:about="https://www.ica.org/standards/RiC/ontology#hasConstituentTransitive">
@@ -3673,6 +3842,12 @@
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasConstituent"/>
+      </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record or Record Part to another Record or Record Part
          that is its constituent, directly or indirectly. This is a transitive
          relation.</rdfs:comment>
@@ -3680,6 +3855,12 @@
       <rdfs:label xml:lang="fr">a pour constituant transitif</rdfs:label>
       <rdfs:label xml:lang="en">has constituent transitive</rdfs:label>
       <rdfs:label xml:lang="es">tiene como elemento constitutivo transitivo</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Added a property chain axiom relating it to use of rico:Proxy.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-27</dc:date>
@@ -3797,7 +3978,7 @@
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
-      <rdfs:comment xml:lang="en">Inverse of 'is creation date of' object property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is creation date of' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour date de création</rdfs:label>
       <rdfs:label xml:lang="en">has creation date</rdfs:label>
@@ -3914,7 +4095,7 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDeathDateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
-      <rdfs:comment xml:lang="en">Inverse of 'is death date of' object property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is death date of' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour date de décès</rdfs:label>
       <rdfs:label xml:lang="en">has death date</rdfs:label>
@@ -3941,7 +4122,7 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDeathPlaceOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Person"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Place"/>
-      <rdfs:comment xml:lang="en">Inverse of 'is death place of' object property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is death place of' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour lieu de décès</rdfs:label>
       <rdfs:label xml:lang="en">has death place</rdfs:label>
@@ -4165,12 +4346,24 @@
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#hasDirectConstituentOfProxy"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
+      </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record to another Record or Record Part that is its
          direct constituent.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a directement pour constituant</rdfs:label>
       <rdfs:label xml:lang="en">has direct constituent</rdfs:label>
       <rdfs:label xml:lang="es">tiene directamente como elemento constitutivo</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Added a property chain axiom relating it to use of rico:Proxy.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-27</dc:date>
@@ -4196,6 +4389,34 @@
                order to enable to express current, direct, partitive relations between records and
                other records or record parts (the possibly indirect, transitive relation,
                superproperty of this one, being also added).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#hasDirectConstituentProxy -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#hasDirectConstituentProxy">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsDirectConstituentOf"/>
+      <rdfs:domain>
+         <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Record"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordPart"/>
+            </owl:unionOf>
+         </owl:Class>
+      </rdfs:domain>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy is direct constituent of' object property.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">has direct constituent proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
    </owl:ObjectProperty>
@@ -4850,7 +5071,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:comment xml:lang="en">Inverse of 'is or was accumulation date of all members of' object
-         property</rdfs:comment>
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">has or had all members with accumulation date</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres ayant tous pour date
@@ -4912,7 +5133,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:comment xml:lang="en">Inverse of 'is or was creation date of all members of' object
-         property</rdfs:comment>
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">has or had all members with creation date</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres ayant tous pour date de
@@ -6374,7 +6595,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:comment xml:lang="en">Inverse of 'is or was accumulation date of most members of' object
-         property</rdfs:comment>
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">has or had most members with accumulation date</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres dont la plupart ont pour date
@@ -6398,7 +6619,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:comment xml:lang="en">Inverse of 'is or was creation date of most members of' object
-         property</rdfs:comment>
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">has or had most members with creation date</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres dont la plupart ont pour date de
@@ -6881,7 +7102,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:comment xml:lang="en">Inverse of 'is or was accumulation date of some members of' object
-         property</rdfs:comment>
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">has or had some members with accumulation date</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres ayant pour date
@@ -6943,7 +7164,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:comment xml:lang="en">Inverse of 'is or was creation date of some members of' object
-         property</rdfs:comment>
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">has or had some members with creation date</rdfs:label>
       <rdfs:label xml:lang="fr">inclut ou a inclus des membres ayant pour date de
@@ -7927,6 +8148,23 @@
          </rdf:Description>
       </skos:changeNote>
    </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#hasProxy -->
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasProxy">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy for' object property.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">has proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasPublicationDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasPublicationDate">
       <rdfs:subPropertyOf
@@ -7934,7 +8172,7 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPublicationDateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
-      <rdfs:comment xml:lang="en">Inverse of 'is publication date of' object property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is publication date of' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour date de publication</rdfs:label>
       <rdfs:label xml:lang="en">has publication date</rdfs:label>
@@ -8532,7 +8770,7 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isWithin"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
-      <rdfs:comment xml:lang="en">Inverse of 'is within' object property</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is within' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">contient</rdfs:label>
       <rdfs:label xml:lang="en">has within</rdfs:label>
@@ -8673,12 +8911,24 @@
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#includesProxy"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIncludes"/>
+      </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record Set to a Record or Record Set which it includes
          directly or indirectly. This is a transitive relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">includes transitive</rdfs:label>
       <rdfs:label xml:lang="fr">inclut transitif</rdfs:label>
       <rdfs:label xml:lang="es">incluye transitivo</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Added a property chain axiom relating it to use of rico:Proxy</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-27</dc:date>
@@ -8697,6 +8947,31 @@
             <rdf:value xml:lang="en">Object property added, along with its inverse property, in
                order to enable to express current partitive relations between Record Sets and their
                members (the past partitive relation also being added).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#includesProxy -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#includesProxy">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#includesProxy"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIncludesProxyTransitive"/>
+      </owl:propertyChainAxiom>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy is included in' object property.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">includes proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
    </owl:ObjectProperty>
@@ -9566,6 +9841,39 @@
          </rdf:Description>
       </skos:changeNote>
    </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#isConstituentOfProxy -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isConstituentOfProxy">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyHasConstituent"/>
+      <rdfs:domain>
+         <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Record"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordPart"/>
+            </owl:unionOf>
+         </owl:Class>
+      </rdfs:domain>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#isConstituentOfProxy"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOfProxyTransitive"/>
+      </owl:propertyChainAxiom>
+      <rdfs:comment xml:lang="en">Connects a Record or Record Part to a proxy of a Record or Record Part
+         of which it is a constituent, directly or indirectly.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">is constituent of proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isConstituentOfTransitive -->
    <owl:ObjectProperty
       rdf:about="https://www.ica.org/standards/RiC/ontology#isConstituentOfTransitive">
@@ -9592,6 +9900,18 @@
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#hasProxy"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyInRecord"/>
+      </owl:propertyChainAxiom>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#isConstituentOfProxy"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOf"/>
+      </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record or Record Part to another Record or Record Part
          of which it is a constituent, directly or indirectly. This is a transitive
          relation.</rdfs:comment>
@@ -9599,6 +9919,12 @@
       <rdfs:label xml:lang="es">es elemento constitutivo de transitivo</rdfs:label>
       <rdfs:label xml:lang="fr">est le constituant de transitif</rdfs:label>
       <rdfs:label xml:lang="en">is constituent of transitive</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Added two property chain axioms relating it to use of rico:Proxy.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-27</dc:date>
@@ -10151,12 +10477,24 @@
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#isDirectConstituentOfProxy"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
+      </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record or Record Part to another Record or Record Part
          of which it is a direct constituent.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="es">es elemento constitutivo directo de</rdfs:label>
       <rdfs:label xml:lang="fr">est un constituant direct de</rdfs:label>
       <rdfs:label xml:lang="en">is direct constituent of</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Added a property chain axiom relating it to use of rico:Proxy.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-27</dc:date>
@@ -10182,6 +10520,64 @@
                order to enable to express current, direct, partitive relations between records and
                other records or record parts (the possibly indirect, transitive relation,
                superproperty of this one, being also added).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#isDirectConstituentOfProxy -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isDirectConstituentOfProxy">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isConstituentOfProxy"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyHasDirectConstituent"/>
+      <rdfs:domain>
+         <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Record"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordPart"/>
+            </owl:unionOf>
+         </owl:Class>
+      </rdfs:domain>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Connects a Record or Record Part to a proxy of a Record or Record
+         Part which it is a direct constituent of.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">is direct constituent of proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#isDirectlyIncludedInProxy -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isDirectlyIncludedInProxy">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isIncludedInProxy"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyDirectlyIncludes"/>
+      <rdfs:domain>
+         <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Record"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
+            </owl:unionOf>
+         </owl:Class>
+      </rdfs:domain>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Connects a Record or Record Set to a proxy of a Record
+         Set which it is directly included in.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">is directly included in proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
    </owl:ObjectProperty>
@@ -10884,6 +11280,39 @@
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R035 ('is functionally equivalent to'
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#isIncludedInProxy -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isIncludedInProxy">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIncludes"/>
+      <rdfs:domain>
+         <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Record"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
+            </owl:unionOf>
+         </owl:Class>
+      </rdfs:domain>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#isIncludedInProxy"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedInProxyTransitive"/>
+      </owl:propertyChainAxiom>
+      <rdfs:comment xml:lang="en">Connects a Record or Record Set to a proxy of a Record Set
+         which it is included in, directly or indirectly.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">is constituent of proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isIdentifierTypeOf -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isIdentifierTypeOf">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrWasTypeOf"/>
@@ -10939,12 +11368,30 @@
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#hasProxy"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyInRecordSet"/>
+      </owl:propertyChainAxiom>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#isIncludedInProxy"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn"/>
+      </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record to a Record or Record Set in which it is
          directly or indirectly included. This is a transitive relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est inclus dans transitif</rdfs:label>
       <rdfs:label xml:lang="es">está incluido en transitivo</rdfs:label>
       <rdfs:label xml:lang="en">is included in transitive</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Added two property chain axioms relating it to use of rico:Proxy.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-27</dc:date>
@@ -13640,8 +14087,7 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#regulatesOrRegulated"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
-      <rdfs:comment xml:lang="en">Inverse of the 'regulates or regulated' object
-         property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'regulates or regulated' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été régulé par</rdfs:label>
       <rdfs:label xml:lang="es">está o estaba regulado por</rdfs:label>
@@ -15210,7 +15656,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#UnitOfMeasurement"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Extent"/>
       <rdfs:comment xml:lang="en">Inverse of 'has unit of measurement' object
-         property</rdfs:comment>
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="es">es unidad de medida de</rdfs:label>
       <rdfs:label xml:lang="fr">est l’unité de mesure de</rdfs:label>
@@ -15919,7 +16365,7 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Event"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:comment xml:lang="en">Inverse of 'is date of occurrence of' object
-         property</rdfs:comment>
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour date d'occurrence</rdfs:label>
       <rdfs:label xml:lang="en">occurred at date</rdfs:label>
@@ -16353,12 +16799,18 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followedInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <rdfs:comment xml:lang="en">Connects a Thing to a Thing that followed it in some non
-         chronological sequence in the past.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Thing to a Thing that followed it in some
+         sequence (not necessarily defined or characterised chronologically) in the past.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a précédé dans la séquence</rdfs:label>
       <rdfs:label xml:lang="en">preceded in sequence</rdfs:label>
       <rdfs:label xml:lang="es">precedía secuencialmente a</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Tweaked the rdfs:comment to try to clarify what is meant.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-27</dc:date>
@@ -16397,12 +16849,26 @@
          rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInSequenceTransitive"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#precedesProxyInSequence"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
+      </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Thing to a Thing that follows it directly or indirectly
-         in some non chronological sequence. This is a transitive relation.</rdfs:comment>
+         in some sequence (not necessarily defined or characterised chronologically). This is a
+         transitive relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="es">precede secuencialmente a transitivo</rdfs:label>
       <rdfs:label xml:lang="en">precedes in sequence transitive</rdfs:label>
       <rdfs:label xml:lang="fr">précède dans la séquence transitif</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Tweaked the rdfs:comment to try to clarify what is meant. Also
+              added a property chain axiom relating it to use of rico:Proxy.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-27</dc:date>
@@ -16545,17 +17011,231 @@
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R008 ('precedes or preceded'
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#precedesProxyInSequence -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#precedesProxyInSequence">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInSequenceTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyFollowsInSequence"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#precedesProxyInSequence"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyPrecedesProxyInSequenceTransitive"/>
+      </owl:propertyChainAxiom>
+      <rdfs:comment xml:lang="en">Connects a Record Resource to a proxy of a Record Resource that it precedes
+         directly or indirectly in some sequence (not necessarily defined or characterised
+         chronologically).</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">precedes proxy in sequence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyDirectlyFollowsInSequence -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyDirectlyFollowsInSequence">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyFollowsInSequence"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyFollowsInSequence"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyPrecedesProxyInSequence"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+      <rdfs:comment xml:lang="en">Inverse of 'directly precedes proxy in sequence' object property.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy directly follows in sequence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyDirectlyFollowsProxyInSequence -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyDirectlyFollowsProxyInSequence">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyFollowsInSequence"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyFollowsProxyInSequenceTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyDirectlyPrecedesProxyInSequence"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy directly precedes proxy in sequence' object property.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy directly follows proxy in sequence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyDirectlyIncludes -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyDirectlyIncludes">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIncludes"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectlyIncludedInProxy"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range>
+         <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Record"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
+            </owl:unionOf>
+         </owl:Class>
+      </rdfs:range>
+      <rdfs:comment xml:lang="en">Inverse of 'is directly included in proxy' object property.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy directly includes</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyDirectlyIncludesProxy -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyDirectlyIncludesProxy">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIncludesProxyTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsDirectlyIncludedInProxy"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy is directly included in' object property.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy directly includes proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyDirectlyPrecedesInSequence -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyDirectlyPrecedesInSequence">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyPrecedesInSequence"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyPrecedesInSequence"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyFollowsProxyInSequence"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+      <rdfs:comment xml:lang="en">Connects a proxy for a Record Resource to a Record Resource
+         which it precedes directly in some sequence (not necessarily defined or characterised
+         chronologically).</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy directly precedes in sequence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyDirectlyPrecedesProxyInSequence -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyDirectlyPrecedesProxyInSequence">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyPrecedesInSequence"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyDirectlyFollowsProxyInSequence"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Connects a proxy of a Record Resource to a proxy of another Record
+         Resource that it precedes directly in some sequence (not necessarily defined or characterised
+         chronologically).</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy directly precedes proxy in sequence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyFollowsInSequence -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFollowsInSequence">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInSequenceTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesProxyInSequence"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFollowsProxyInSequenceTransitive"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFollowsInSequence"/>
+      </owl:propertyChainAxiom>
+      <rdfs:comment xml:lang="en">Inverse of 'precedes proxy in sequence' object property.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy follows in sequence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyFollowsProxyInSequenceTransitive -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFollowsProxyInSequenceTransitive">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInSequenceTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyPrecedesProxyInSequenceTransitive"/>
+      <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy recedes proxy in sequence transitive' object property.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy follows proxy in sequence transitive</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#proxyFor -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:comment xml:lang="en">Connects a Proxy to the Record Resource it stands for in the
-         specific context of a Record Set.</rdfs:comment>
+         context of a specific Record Resource.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="es">es proxy para</rdfs:label>
       <rdfs:label xml:lang="en">proxy for</rdfs:label>
       <rdfs:label xml:lang="fr">proxy pour</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Changed the rdfs:comment to allow for a context of a
+              Record Resource of any kind, not only a Record Set.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -16569,17 +17249,126 @@
          </rdf:Description>
       </skos:changeNote>
    </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyHasConstituent -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasConstituent">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isConstituentOfProxy"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range>
+         <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Record"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordPart"/>
+            </owl:unionOf>
+         </owl:Class>
+      </rdfs:range>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasConstituentProxyTransitive"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasConstituent"/>
+      </owl:propertyChainAxiom>
+      <rdfs:comment xml:lang="en">Inverse of 'is constituent of proxy' object property.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy has constituent</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyHasConstituentProxyTransitive -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasConstituentProxyTransitive">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOfProxyTransitive"/>
+      <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy is constituent of proxy transitive' object property. This
+         is a transitive relation.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy has constituent proxy transitive</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyHasDirectConstituent -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasDirectConstituent">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyHasConstituent"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectConstituentOfProxy"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range>
+         <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Record"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordPart"/>
+            </owl:unionOf>
+         </owl:Class>
+      </rdfs:range>
+      <rdfs:comment xml:lang="en">Inverse of 'is direct constituent of proxy' object property.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy has direct constituent</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyHasDirectConstituentProxy -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasDirectConstituentProxy">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyHasConstituentProxyTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsDirectConstituentOfProxy"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy is direct constituent of' object property.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy has direct constituent proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#proxyIn -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIn">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
-      <rdfs:comment xml:lang="en">Connects a Proxy to the Record Set in which it stands for
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+      <rdfs:comment xml:lang="en">Connects a Proxy to the Record Resource in which it stands for
          (represents) another Record Resource.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="es">es proxy en</rdfs:label>
       <rdfs:label xml:lang="fr">proxy dans</rdfs:label>
       <rdfs:label xml:lang="en">proxy in</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Changed the range and rdfs:comment to allow any
+               Record Resource, not only a Record Set.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -16590,6 +17379,339 @@
          <rdf:Description>
             <dc:date>2023-08-28</dc:date>
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyIncludes -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIncludes">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isIncludedInProxy"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range>
+         <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Record"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
+            </owl:unionOf>
+         </owl:Class>
+      </rdfs:range>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIncludesProxyTransitive"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIncludes"/>
+      </owl:propertyChainAxiom>
+      <rdfs:comment xml:lang="en">Inverse of 'is included in proxy' object property.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy includes</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyIncludesProxyTransitive -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIncludesProxyTransitive">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedInProxyTransitive"/>
+      <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy is included in proxy transitive' object property. This
+         is a transitive relation.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy includes proxy transitive</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyInRecord -->
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#proxyInRecord">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIn"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Record"/>
+      <rdfs:comment xml:lang="en">Connects a Proxy to a Record in which it stands for
+         (represents) a Record Part or another Record.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy in record</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyInRecordSet -->
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#proxyInRecordSet">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIn"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
+      <rdfs:comment xml:lang="en">Connects a Proxy to a Record Set in which it stands for
+         (represents) a Record or another Record Set.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy in record set</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOf -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOf">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range>
+         <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Record"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordPart"/>
+            </owl:unionOf>
+         </owl:Class>
+      </rdfs:range>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOfProxyTransitive"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOf"/>
+      </owl:propertyChainAxiom>
+      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Part to a Record
+         or Record Part which it is a constituent of, directly or indirectly.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy is constituent of</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOfProxyTransitive -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOfProxyTransitive">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyHasConstituentProxyTransitive"/>
+      <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Part to a proxy for
+         another Record or Record Part which it is a constituent of, directly or indirectly. This is
+         a transitive relation.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy is constituent of proxy transitive</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyIsDirectConstituentOf -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsDirectConstituentOf">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOf"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range>
+         <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Record"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordPart"/>
+            </owl:unionOf>
+         </owl:Class>
+      </rdfs:range>
+      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Part to another
+         Record or Record Part which the first is a direct constituent of.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy is direct constituent of</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyIsDirectConstituentOfProxy -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsDirectConstituentOfProxy">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOfProxyTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyHasDirectConstituentProxy"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Part to a proxy for
+         another Record or Record Part of which the first is a direct constituent.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy is direct constituent of proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyIsDirectlyIncludedIn -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsDirectlyIncludedIn">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyIncludesProxy"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
+      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Set to another Record Set
+         which the first is directly included in.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy is directly included in</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyIsDirectlyIncludedInProxy -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsDirectlyIncludedInProxy">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedInProxyTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyDirectlyIncludesProxy"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Set to a proxy for
+         a Record Set which it is directly included in.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy is directly included in proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#includesProxy"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedInProxyTransitive"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn"/>
+      </owl:propertyChainAxiom>
+      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Set to a Record
+         Set which it is included in, directly or indirectly.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy is included in</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyIsIncludedInProxyTransitive -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedInProxyTransitive">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIncludesProxyTransitive"/>
+      <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Set to a proxy for
+         a Record Set which it is included in, directly or indirectly. This is
+         a transitive relation.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy is included in proxy transitive</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyPrecedesInSequence -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyPrecedesInSequence">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInSequenceTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#followsProxyInSequence"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyPrecedesProxyInSequenceTransitive"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyPrecedesInSequence"/>
+      </owl:propertyChainAxiom>
+      <rdfs:comment xml:lang="en">Connects a proxy for a Record Resource to a Record Resource which
+         the first precedes directly or indirectly in sequence (not necessarily defined or
+         characterised chronologically).</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy precedes in sequence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+   </owl:ObjectProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#proxyPrecedesProxyInSequenceTransitive -->
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyPrecedesProxyInSequenceTransitive">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#precedesInSequenceTransitive"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyFollowsProxyInSequenceTransitive"/>
+      <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+      <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+      <rdfs:comment xml:lang="en">Connects a Proxy for a Record Resource to a Proxy for another Record
+         Resource which directly or indirectly follows the first in some sequence (not necessarily
+         defined or characterised chronologically). This is a transitive relation.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">proxy precedes proxy in sequence transitive</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
    </owl:ObjectProperty>
@@ -20181,6 +21303,77 @@
       </skos:changeNote>
       <skos:scopeNote xml:lang="en">Use if you use the Extent class and its properties for handling
          an accurate description of the extent of a resource.</skos:scopeNote>
+   </owl:DatatypeProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#rankInHierarchy -->
+   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#rankInHierarchy">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#textualValue"/>
+      <rdfs:domain>
+         <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+            </owl:unionOf>
+         </owl:Class>
+      </rdfs:domain>
+      <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+      <rdfs:comment xml:lang="en">The rank of a record resource, or a proxy for it, in a hierarchy.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">rank in hierarchy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">The object properties rico:directlyIncludes and rico:hasDirectConstituent,
+         or variants of these which are sub-properties of rico:hasOrHadPart, should always be used to express
+         hierarchies in RiC-O. This datatype property may be used in addition (never independently) for
+         convenience, but it should be ensured that it is compatible with (e.g. computed using) the
+         hierarchical object properties in the intended context (e.g. a hierarchy of Record Parts in a given
+         Record), i.e. if Record Part A rico:hasDirectConstituent Record Part B, then the rico:rankInHierarchy
+         of Record Part B must strictly greater than rico:rankInHierarchy of Record Resource A, and no other
+         Record Part in that context should have rico:rankInHierarchy between that of Record Part A and
+         Record Part B.
+
+         For a given Record Resource, rico:rankInHierarchy should never be used more than once. If a
+         RecordResource belongs to more than one hierarchy, a rico:Proxy of the Record Resource should be
+         introduced, and rico:rankInHierarchy have source such a proxy, in all cases except (possibly) the
+         first.</skos:scopeNote>
+   </owl:DatatypeProperty>
+   <!-- https://www.ica.org/standards/RiC/ontology#rankInSequence -->
+   <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#rankInSequence">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#textualValue"/>
+      <rdfs:domain>
+         <owl:Class>
+            <owl:unionOf rdf:parseType="Collection">
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Proxy"/>
+            </owl:unionOf>
+         </owl:Class>
+      </rdfs:domain>
+      <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+      <rdfs:comment xml:lang="en">The rank of a record resource, or a proxy for it, in a sequence.</rdfs:comment>
+      <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="en">rank in sequence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:scopeNote xml:lang="en">The object property rico:precedesOrPreceded or one of its sub-properties
+         should always be used to express sequences in RiC-O. This datatype property may be used in
+         addition (never independently) for convenience, but it should be ensured that it is compatible with
+         (e.g. computed using) the sequential object properties in the intended context (e.g. the Records in
+         a given Record Set), i.e. if Record Resource A rico:precedesOrPreceded Record Resource B, then the
+         rico:rankInSequence of Record Resource B must be strictly greater than rico:rankInSequence of
+         Record Resource A, and no other Record Resource in that context should have rico:rankInSequence
+         between that of Record Resource A and Record Resource B.
+
+         For a given Record Resource, rico:rankInSequence should never be used more than once. If a
+         Record Resource belongs to more than one sequence, a rico:Proxy of the Record Resource should be
+         introduced, and rico:rankInSequence have source such a proxy, in all cases except (possibly) the
+         first.</skos:scopeNote>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceExtent -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceExtent">
@@ -25391,15 +26584,24 @@
             <owl:qualifiedCardinality
                rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
                >1</owl:qualifiedCardinality>
-            <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
+            <owl:onClass rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
          </owl:Restriction>
       </rdfs:subClassOf>
       <rdfs:comment xml:lang="en">A Proxy represents (stands for) a Record Resource as it exists in
-         a specific Record Set.</rdfs:comment>
+         a specific other Record Resource.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">Proxy</rdfs:label>
       <rdfs:label xml:lang="es">Proxy</rdfs:label>
       <rdfs:label xml:lang="fr">Proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-03-04</dc:date>
+            <rdf:value xml:lang="en">Changed range of proxyIn restriction and rdfs:comment to allow
+               any Record Resource, not only a Record Set. Also tweaked the scope note to refer to
+               the new datatype properties rico:rankInSequence and rico:rankInHierarchy, and to
+               generalise it to different kinds of Record Resources.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2023-11-02</dc:date>
@@ -25412,10 +26614,13 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Useful for handling in RDF the sequencing of records or records
-         sets in the context of a Record set. A Record Resource has only one Proxy in the context of
-         one specific Record Set. It may have many Proxies simultaneously or through
-         time.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Useful e.g. in conjunction with rico:rankInSequence for describing
+         sequences of Records or Record Sets in the context of a Record Set,
+         or of Record Parts and Records in the context of a Record; or in conjunction with
+         rico:rankInHierarchy for describing hierarchies of Records and/or Record Parts in the context
+         of a Record Set, Record, or Record Part. A Record Resource has only one Proxy in the context of
+         one specific Record Set, Record, or Record Part. It may have many Proxies
+         simultaneously or through time.</skos:scopeNote>
       <closeTo xml:lang="en">ORE Proxy (http://www.openarchives.org/ore/terms/Proxy)</closeTo>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Record -->

--- a/ontology/current-version/RiC-O_1.1.rdf
+++ b/ontology/current-version/RiC-O_1.1.rdf
@@ -988,6 +988,10 @@
                      of Proxy in sequences or hierarchies, and added one or two property chain
                      axioms involving rico:Proxy to a few object properties used to define sequences
                      or hierarchies.</html:li>
+                  <html:li>2025, April 2nd: reviewed the new properties for Proxies, hierarchies and
+                     sequences. Fixed a few owl:inverseOf, owl:subPropertyOf and a property chain
+                     axiom. Modified a few details in the rdfs:comment of those properties. Added
+                     French and Spanish labels to these new properties.</html:li>
                </html:ul>
             </html:div>
          </html:div>
@@ -2206,6 +2210,14 @@
       <rdfs:comment xml:lang="en">Inverse of 'proxy directly precedes in sequence' object property. </rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">directly follows proxy in sequence</rdfs:label>
+      <rdfs:label xml:lang="es">sigue directamente el proxy en la secuencia</rdfs:label>
+      <rdfs:label xml:lang="fr">suit directement le proxy dans la séquence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -2268,6 +2280,14 @@
          property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">directly includes proxy</rdfs:label>
+      <rdfs:label xml:lang="fr">inclut directement le proxy</rdfs:label>
+      <rdfs:label xml:lang="es">incluye directamente el proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -2347,6 +2367,14 @@
          chronologically).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">directly precedes proxy in sequence</rdfs:label>
+      <rdfs:label xml:lang="es">precede directamente el proxy en la secuencia</rdfs:label>
+      <rdfs:label xml:lang="fr">précède directement le proxy dans la séquence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -2919,6 +2947,14 @@
          property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">follows proxy in sequence</rdfs:label>
+      <rdfs:label xml:lang="es">sigue el proxy en la secuencia</rdfs:label>
+      <rdfs:label xml:lang="fr">suit le proxy dans la séquence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -3800,7 +3836,15 @@
       <rdfs:comment xml:lang="en">Inverse of 'proxy is constituent of' object
          property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="fr">a pour constituant le proxy</rdfs:label>
       <rdfs:label xml:lang="en">has constituent proxy</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como elemento constitutivo el proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-04-02</dc:date>
@@ -4411,7 +4455,15 @@
       <rdfs:comment xml:lang="en">Inverse of 'proxy is direct constituent of' object
          property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="fr">a pour constituant direct le proxy</rdfs:label>
       <rdfs:label xml:lang="en">has direct constituent proxy</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como directo elemento constitutivo el proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -8155,7 +8207,15 @@
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:comment xml:lang="en">Inverse of 'proxy for' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="fr">a pour proxy</rdfs:label>
       <rdfs:label xml:lang="en">has proxy</rdfs:label>
+      <rdfs:label xml:lang="es">tiene como proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -8963,6 +9023,14 @@
       <rdfs:comment xml:lang="en">Inverse of 'proxy is included in' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">includes proxy</rdfs:label>
+      <rdfs:label xml:lang="fr">inclut le proxy</rdfs:label>
+      <rdfs:label xml:lang="es">incluye el proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-04-02</dc:date>
@@ -9867,7 +9935,15 @@
       <rdfs:comment xml:lang="en">Connects a Record or Record Part to a Proxy of a Record or Record
          Part of which it is a constituent, directly or indirectly.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="es">es elemento constitutivo del proxy</rdfs:label>
+      <rdfs:label xml:lang="fr">est le constituant du proxy</rdfs:label>
       <rdfs:label xml:lang="en">is constituent of proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -10543,7 +10619,15 @@
       <rdfs:comment xml:lang="en">Connects a Record or Record Part to a Proxy of a Record or Record
          Part which it is a direct constituent of.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="es">es elemento constitutivo directo del proxy</rdfs:label>
+      <rdfs:label xml:lang="fr">est un constituant direct du proxy</rdfs:label>
       <rdfs:label xml:lang="en">is direct constituent of proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -10570,7 +10654,15 @@
       <rdfs:comment xml:lang="en">Connects a Record or Record Set to a Proxy of a Record Set which
          it is directly included in.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="es">está directamente incluido en el proxy</rdfs:label>
+      <rdfs:label xml:lang="fr">est directement inclus dans le proxy</rdfs:label>
       <rdfs:label xml:lang="en">is directly included in proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -11300,7 +11392,15 @@
       <rdfs:comment xml:lang="en">Connects a Record or Record Set to a Proxy of a Record Set which
          it is included in, directly or indirectly.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
-      <rdfs:label xml:lang="en">is constituent of proxy</rdfs:label>
+      <rdfs:label xml:lang="es">está incluido en el proxy</rdfs:label>
+      <rdfs:label xml:lang="fr">est inclus dans le proxy</rdfs:label>
+      <rdfs:label xml:lang="en">is included in proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17022,7 +17122,15 @@
          precedes directly or indirectly in some sequence (not necessarily defined or characterised
          chronologically).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="es">precede el proxy en la secuencia</rdfs:label>
+      <rdfs:label xml:lang="fr">précède le proxy dans la séquence</rdfs:label>
       <rdfs:label xml:lang="en">precedes proxy in sequence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17045,6 +17153,14 @@
          property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy directly follows in sequence</rdfs:label>
+      <rdfs:label xml:lang="es">proxy sigue directamente en la secuencia</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy suit directement dans la séquence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17067,6 +17183,14 @@
          property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy directly follows proxy in sequence</rdfs:label>
+      <rdfs:label xml:lang="es">proxy sigue directamente el proxy en la secuencia</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy suit directement le proxy dans la séquence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17093,6 +17217,14 @@
          property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy directly includes</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy inclut directement</rdfs:label>
+      <rdfs:label xml:lang="es">proxy incluye directamente</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17114,6 +17246,14 @@
          property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy directly includes proxy</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy inclut directement le proxy</rdfs:label>
+      <rdfs:label xml:lang="es">proxy incluye directamente el proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17137,6 +17277,14 @@
          chronologically).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy directly precedes in sequence</rdfs:label>
+      <rdfs:label xml:lang="es">proxy precede directamente en la secuencia</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy précède directement dans la séquence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17160,6 +17308,14 @@
          characterised chronologically).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy directly precedes proxy in sequence</rdfs:label>
+      <rdfs:label xml:lang="es">proxy precede directamente el proxy en la secuencia</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy précède directement le proxy dans la séquence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-04-01</dc:date>
@@ -17192,6 +17348,14 @@
          property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy follows in sequence</rdfs:label>
+      <rdfs:label xml:lang="es">proxy sigue en la secuencia</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy suit dans la séquence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17213,6 +17377,14 @@
          property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy follows proxy in sequence transitive</rdfs:label>
+      <rdfs:label xml:lang="es">proxy sigue el proxy en la secuencia transitivo</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy suit le proxy dans la séquence transitif</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17274,7 +17446,15 @@
       <rdfs:comment xml:lang="en">Inverse of 'is constituent of proxy' object
          property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="fr">proxy a pour constituant</rdfs:label>
       <rdfs:label xml:lang="en">proxy has constituent</rdfs:label>
+      <rdfs:label xml:lang="es">proxy tiene como elemento constitutivo</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17295,7 +17475,16 @@
       <rdfs:comment xml:lang="en">Inverse of 'proxy is constituent of proxy transitive' object
          property. This is a transitive relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="fr">proxy a pour constituant le proxy (transitif)</rdfs:label>
       <rdfs:label xml:lang="en">proxy has constituent proxy transitive</rdfs:label>
+      <rdfs:label xml:lang="es">proxy tiene como elemento constitutivo el proxy
+         (transitivo)</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17323,7 +17512,15 @@
       <rdfs:comment xml:lang="en">Inverse of 'is direct constituent of proxy' object
          property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="fr">proxy a pour constituant direct</rdfs:label>
       <rdfs:label xml:lang="en">proxy has direct constituent</rdfs:label>
+      <rdfs:label xml:lang="es">proxy tiene como directo elemento constitutivo</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17344,7 +17541,15 @@
       <rdfs:comment xml:lang="en">Inverse of 'proxy is direct constituent of' object
          property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="fr">proxy a pour constituant direct le proxy</rdfs:label>
       <rdfs:label xml:lang="en">proxy has direct constituent proxy</rdfs:label>
+      <rdfs:label xml:lang="es">proxy tiene como directo elemento constitutivo el proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17405,6 +17610,14 @@
       <rdfs:comment xml:lang="en">Inverse of 'is included in proxy' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy includes</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy inclut</rdfs:label>
+      <rdfs:label xml:lang="es">proxy incluye</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17426,6 +17639,14 @@
          property. This is a transitive relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy includes proxy transitive</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy inclut le proxy (transitif)</rdfs:label>
+      <rdfs:label xml:lang="es">proxy incluye el proxy (transitivo)</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17441,7 +17662,15 @@
       <rdfs:comment xml:lang="en">Connects a Proxy to a Record in which it stands for (represents) a
          Record Part or another Record.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="fr">proxy dans l’objet informationnel</rdfs:label>
+      <rdfs:label xml:lang="es">proxy en el documento</rdfs:label>
       <rdfs:label xml:lang="en">proxy in record</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17457,7 +17686,15 @@
       <rdfs:comment xml:lang="en">Connects a Proxy to a Record Set in which it stands for
          (represents) a Record or another Record Set.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="fr">proxy dans l’ensemble d’objets informationnels</rdfs:label>
+      <rdfs:label xml:lang="es">proxy en la agrupación documental</rdfs:label>
       <rdfs:label xml:lang="en">proxy in record set</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17488,7 +17725,15 @@
       <rdfs:comment xml:lang="en">Connects a Proxy of a Record or Record Part to a Record or Record
          Part which it is a constituent of, directly or indirectly.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="fr">proxy est un constituant de</rdfs:label>
+      <rdfs:label xml:lang="es">proxy es un elemento constitutivo de</rdfs:label>
       <rdfs:label xml:lang="en">proxy is constituent of</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17510,7 +17755,15 @@
          Record or Record Part which it is a constituent of, directly or indirectly. This is a
          transitive relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="es">proxy es elemento constitutivo del proxy (transitivo)</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy est un constituant du proxy (transitif)</rdfs:label>
       <rdfs:label xml:lang="en">proxy is constituent of proxy transitive</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17538,12 +17791,14 @@
       <rdfs:comment xml:lang="en">Connects a Proxy of a Record or Record Part to another Record or
          Record Part which the first is a direct constituent of.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="es">proxy es elemento constitutivo directo de</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy est un constituant direct de</rdfs:label>
       <rdfs:label xml:lang="en">proxy is direct constituent of</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-04-02</dc:date>
-            <rdf:value xml:lang="en">Fixed the owl:inverseOf property (was
-               hasConstituentProxy).</rdf:value>
+            <rdf:value xml:lang="en">Fixed the owl:inverseOf property (was hasConstituentProxy).
+               Added the French and Spanish labels.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -17566,7 +17821,15 @@
       <rdfs:comment xml:lang="en">Connects a Proxy of a Record or Record Part to a Proxy of another
          Record or Record Part of which the first is a direct constituent.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="es">proxy es elemento constitutivo directo del proxy</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy est un constituant direct du proxy</rdfs:label>
       <rdfs:label xml:lang="en">proxy is direct constituent of proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17586,7 +17849,15 @@
       <rdfs:comment xml:lang="en">Connects a Proxy of a Record or Record Set to another Record Set
          which the first is directly included in.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="es">proxy está directamente incluido en</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy est directement inclus dans</rdfs:label>
       <rdfs:label xml:lang="en">proxy is directly included in</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17607,7 +17878,15 @@
       <rdfs:comment xml:lang="en">Connects a Proxy of a Record or Record Set to a Proxy of a Record
          Set which it is directly included in.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="es">proxy está directamente incluido en el proxy</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy est directement inclus dans le proxy</rdfs:label>
       <rdfs:label xml:lang="en">proxy is directly included in proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17630,7 +17909,15 @@
       <rdfs:comment xml:lang="en">Connects a Proxy of a Record or Record Set to a Record Set which
          it is included in, directly or indirectly.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="es">proxy está incluido en</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy est inclus dans</rdfs:label>
       <rdfs:label xml:lang="en">proxy is included in</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17652,7 +17939,15 @@
          Set which it is included in, directly or indirectly. This is a transitive
          relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="es">proxy está incluido en el proxy (transitivo)</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy est inclus dans le proxy (transitif)</rdfs:label>
       <rdfs:label xml:lang="en">proxy is included in proxy transitive</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17679,7 +17974,15 @@
          the first precedes directly or indirectly in some sequence (not necessarily defined or
          characterised chronologically).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="es">proxy precede en la secuencia</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy précède dans la séquence</rdfs:label>
       <rdfs:label xml:lang="en">proxy precedes in sequence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17701,7 +18004,15 @@
          Resource which directly or indirectly follows the first in some sequence (not necessarily
          defined or characterised chronologically). This is a transitive relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
+      <rdfs:label xml:lang="es">proxy precede el proxy en la secuencia (transitivo)</rdfs:label>
+      <rdfs:label xml:lang="fr">proxy précède le proxy dans la séquence (transitif)</rdfs:label>
       <rdfs:label xml:lang="en">proxy precedes proxy in sequence transitive</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Added the French and Spanish labels.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>

--- a/ontology/current-version/RiC-O_1.1.rdf
+++ b/ontology/current-version/RiC-O_1.1.rdf
@@ -993,13 +993,7 @@
          </html:div>
       </skos:historyNote>
    </owl:Ontology>
-   <!--
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Annotation properties
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
+   <!-- /////////////////////////////////////////////////////////////////////////////////////// // // Annotation properties // /////////////////////////////////////////////////////////////////////////////////////// -->
    <!-- http://creativecommons.org/ns#license -->
    <owl:AnnotationProperty rdf:about="http://creativecommons.org/ns#license">
       <rdfs:isDefinedBy rdf:resource="http://creativecommons.org/ns#"/>
@@ -1138,13 +1132,7 @@
       </skos:changeNote>
       <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
    </owl:AnnotationProperty>
-   <!--
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Object Properties
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
+   <!-- /////////////////////////////////////////////////////////////////////////////////////// // // Object Properties // /////////////////////////////////////////////////////////////////////////////////////// -->
    <!-- http://www.w3.org/2004/02/skos/core#hasTopConcept -->
    <owl:ObjectProperty rdf:about="http://www.w3.org/2004/02/skos/core#hasTopConcept">
       <owl:inverseOf rdf:resource="http://www.w3.org/2004/02/skos/core#topConceptOf"/>
@@ -2151,15 +2139,11 @@
          rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyPrecedesInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <!--<owl:propertyChainAxiom rdf:parseType="Collection">
+      <!--<owl:propertyChainAxiom rdf:parseType="Collection"> <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyDirectlyFollowsInSequence"/> <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/> </owl:propertyChainAxiom>-->
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#hasProxy"/>
          <rdf:Description
             rdf:about="https://www.ica.org/standards/RiC/ontology#proxyDirectlyFollowsInSequence"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
-      </owl:propertyChainAxiom>-->
-      <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#hasProxy"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyDirectlyFollowsInSequence"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'directly precedes in sequence' object
          property.</rdfs:comment>
@@ -3796,7 +3780,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasConstituentProxy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy">
       <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOf"/>
       <rdfs:domain>
          <owl:Class>
@@ -3817,6 +3801,13 @@
          property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">has constituent proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Fixed the owl:subPropertyOf (was set to
+               isPartOfTransitive).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -8960,7 +8951,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#includesProxy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#includesProxy">
       <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
@@ -8972,6 +8963,13 @@
       <rdfs:comment xml:lang="en">Inverse of 'proxy is included in' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">includes proxy</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Fixed the owl:inverseOf (was set to
+               isPartOfTransitive).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -9866,7 +9864,7 @@
             rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOfProxyTransitive"
          />
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Connects a Record or Record Part to a proxy of a Record or Record
+      <rdfs:comment xml:lang="en">Connects a Record or Record Part to a Proxy of a Record or Record
          Part of which it is a constituent, directly or indirectly.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">is constituent of proxy</rdfs:label>
@@ -10542,7 +10540,7 @@
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Connects a Record or Record Part to a proxy of a Record or Record
+      <rdfs:comment xml:lang="en">Connects a Record or Record Part to a Proxy of a Record or Record
          Part which it is a direct constituent of.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">is direct constituent of proxy</rdfs:label>
@@ -10569,7 +10567,7 @@
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Connects a Record or Record Set to a proxy of a Record Set which
+      <rdfs:comment xml:lang="en">Connects a Record or Record Set to a Proxy of a Record Set which
          it is directly included in.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">is directly included in proxy</rdfs:label>
@@ -11299,7 +11297,7 @@
             rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedInProxyTransitive"
          />
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Connects a Record or Record Set to a proxy of a Record Set which
+      <rdfs:comment xml:lang="en">Connects a Record or Record Set to a Proxy of a Record Set which
          it is included in, directly or indirectly.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">is constituent of proxy</rdfs:label>
@@ -16263,8 +16261,6 @@
       <RiCCMCorrespondingComponent xml:lang="en">RiC-R015 ('migrated into'
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
-
-
    <!-- https://www.ica.org/standards/RiC/ontology#migrationRelation_role -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelation_role">
       <rdfs:subPropertyOf
@@ -17453,7 +17449,6 @@
          </rdf:Description>
       </skos:changeNote>
    </owl:ObjectProperty>
-
    <!-- https://www.ica.org/standards/RiC/ontology#proxyInRecordSet -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#proxyInRecordSet">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIn"/>
@@ -17490,7 +17485,7 @@
          <rdf:Description
             rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOf"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Part to a Record or Record
+      <rdfs:comment xml:lang="en">Connects a Proxy of a Record or Record Part to a Record or Record
          Part which it is a constituent of, directly or indirectly.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy is constituent of</rdfs:label>
@@ -17511,9 +17506,9 @@
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Part to a proxy for
-         another Record or Record Part which it is a constituent of, directly or indirectly. This is
-         a transitive relation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Proxy of a Record or Record Part to a Proxy of another
+         Record or Record Part which it is a constituent of, directly or indirectly. This is a
+         transitive relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy is constituent of proxy transitive</rdfs:label>
       <skos:changeNote>
@@ -17529,7 +17524,8 @@
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOf"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectConstituentProxy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range>
          <owl:Class>
@@ -17539,10 +17535,17 @@
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
-      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Part to another Record or
+      <rdfs:comment xml:lang="en">Connects a Proxy of a Record or Record Part to another Record or
          Record Part which the first is a direct constituent of.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy is direct constituent of</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Fixed the owl:inverseOf property (was
+               hasConstituentProxy).</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17560,8 +17563,8 @@
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyHasDirectConstituentProxy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Part to a proxy for
-         another Record or Record Part of which the first is a direct constituent.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Proxy of a Record or Record Part to a Proxy of another
+         Record or Record Part of which the first is a direct constituent.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy is direct constituent of proxy</rdfs:label>
       <skos:changeNote>
@@ -17580,7 +17583,7 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyIncludesProxy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
-      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Set to another Record Set
+      <rdfs:comment xml:lang="en">Connects a Proxy of a Record or Record Set to another Record Set
          which the first is directly included in.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy is directly included in</rdfs:label>
@@ -17601,8 +17604,8 @@
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyDirectlyIncludesProxy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Set to a proxy for a
-         Record Set which it is directly included in.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Proxy of a Record or Record Set to a Proxy of a Record
+         Set which it is directly included in.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy is directly included in proxy</rdfs:label>
       <skos:changeNote>
@@ -17624,7 +17627,7 @@
             rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedInProxyTransitive"/>
          <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Set to a Record Set which
+      <rdfs:comment xml:lang="en">Connects a Proxy of a Record or Record Set to a Record Set which
          it is included in, directly or indirectly.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy is included in</rdfs:label>
@@ -17645,8 +17648,8 @@
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Set to a proxy for a
-         Record Set which it is included in, directly or indirectly. This is a transitive
+      <rdfs:comment xml:lang="en">Connects a Proxy of a Record or Record Set to a Proxy of a Record
+         Set which it is included in, directly or indirectly. This is a transitive
          relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy is included in proxy transitive</rdfs:label>
@@ -17694,10 +17697,9 @@
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Connects a Proxy of a Record Resource to a Proxy of another
-         Record Resource which directly or indirectly follows the first in some sequence (not
-         necessarily defined or characterised chronologically). This is a transitive
-         relation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Proxy of a Record Resource to a Proxy of another Record
+         Resource which directly or indirectly follows the first in some sequence (not necessarily
+         defined or characterised chronologically). This is a transitive relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy precedes proxy in sequence transitive</rdfs:label>
       <skos:changeNote>
@@ -19179,13 +19181,7 @@
          instance to itself, in order to be able to infer, using OWL-RL and property paths, the two
          shortcuts corresponding to this n-ary class.</skos:scopeNote>
    </owl:ObjectProperty>
-   <!--
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Data Properties
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
+   <!-- /////////////////////////////////////////////////////////////////////////////////////// // // Data Properties // /////////////////////////////////////////////////////////////////////////////////////// -->
    <!-- https://www.ica.org/standards/RiC/ontology#accruals -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#accruals">
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
@@ -21309,8 +21305,8 @@
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
-      <rdfs:comment xml:lang="en">The rank of a record resource, or of a proxy for it, in a
-         hierarchy.</rdfs:comment>
+      <rdfs:comment xml:lang="en">The rank of a Record Resource, or of a Proxy that stands for it,
+         in a hierarchy.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">rank in hierarchy</rdfs:label>
       <skos:changeNote>
@@ -21348,8 +21344,8 @@
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
-      <rdfs:comment xml:lang="en">The rank of a record resource, or of a proxy for it, in a
-         sequence.</rdfs:comment>
+      <rdfs:comment xml:lang="en">The rank of a Record Resource, or of a Proxy that stands for it,
+         in a sequence.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">rank in sequence</rdfs:label>
       <skos:changeNote>
@@ -21361,16 +21357,17 @@
       <skos:scopeNote xml:lang="en">The object property rico:precedesOrPreceded or one of its
          sub-properties should always be used to express sequences in RiC-O. The rico:rankInSequence
          datatype property should only be used in addition (never independently), for convenience
-         (for example to help display or query a graph). But it should be ensured that it reflects and is
-         compatible with (e.g. computed using) the sequential object properties in the intended
-         context (e.g. the Records in a given Record Set). Thus, if, for example, Record Resource A
-         rico:precedesOrPreceded Record Resource B, then the rico:rankInSequence of Record Resource
-         B must be strictly greater than rico:rankInSequence of Record Resource A, and no other
-         Record Resource in that context should have rico:rankInSequence between that of Record
-         Resource A and Record Resource B. For a given Record Resource, rico:rankInSequence should
-         never be used more than once. If a Record Resource belongs to more than one sequence, a
-         rico:Proxy of the Record Resource should be introduced, and rico:rankInSequence have source
-         such a proxy, in all cases except (possibly) the first.</skos:scopeNote>
+         (for example to help display or query a graph). But it should be ensured that it reflects
+         and is compatible with (e.g. computed using) the sequential object properties in the
+         intended context (e.g. the Records in a given Record Set). Thus, if, for example, Record
+         Resource A rico:precedesOrPreceded Record Resource B, then the rico:rankInSequence of
+         Record Resource B must be strictly greater than rico:rankInSequence of Record Resource A,
+         and no other Record Resource in that context should have rico:rankInSequence between that
+         of Record Resource A and Record Resource B. For a given Record Resource,
+         rico:rankInSequence should never be used more than once. If a Record Resource belongs to
+         more than one sequence, a rico:Proxy of the Record Resource should be introduced, and
+         rico:rankInSequence have source such a proxy, in all cases except (possibly) the
+         first.</skos:scopeNote>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceExtent -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceExtent">
@@ -22133,13 +22130,7 @@
          </rdf:Description>
       </skos:changeNote>
    </owl:DatatypeProperty>
-   <!--
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Classes
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
+   <!-- /////////////////////////////////////////////////////////////////////////////////////// // // Classes // /////////////////////////////////////////////////////////////////////////////////////// -->
    <!-- http://purl.org/vocommons/voaf#Vocabulary -->
    <owl:Class rdf:about="http://purl.org/vocommons/voaf#Vocabulary">
       <rdfs:isDefinedBy rdf:resource="http://purl.org/vocommons/voaf"/>
@@ -28378,13 +28369,7 @@
       <RiCCMCorrespondingComponent xml:lang="en">Class implementation of RiC-R046 and RiR046i
          relations</RiCCMCorrespondingComponent>
    </owl:Class>
-   <!--
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Individuals
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
+   <!-- /////////////////////////////////////////////////////////////////////////////////////// // // Individuals // /////////////////////////////////////////////////////////////////////////////////////// -->
    <!-- https://www.ica.org/standards/RiC/ontology -->
    <owl:NamedIndividual rdf:about="https://www.ica.org/standards/RiC/ontology">
       <rdf:type rdf:resource="http://purl.org/vocommons/voaf#Vocabulary"/>

--- a/ontology/current-version/RiC-O_1.1.rdf
+++ b/ontology/current-version/RiC-O_1.1.rdf
@@ -947,11 +947,12 @@
                   <html:li>2024, October 22: went back from 2.0.0 to v1.1, following a decision made
                      by the RiC-O team today. Modified the ontology metadata (owl:versionInfo,
                      rdfs:label, dcterms:title). Renamed the file.</html:li>
-                  <html:li>2024, December 19: added relationHasDate and isDateAssociatedWithRelation object properties,
-                  to connect n-ary Relation classes and Dates. Added hasOrganicProvenanceDate and isOrganicProvenanceDateOf
-                  object properties (with property chain axioms to connect
-                  those properties to the OrganicProvenanceRelation). Added property chain axioms to 
-                  hasCreationDate, hasAccumulationDate, and to their inverse properties.</html:li>
+                  <html:li>2024, December 19: added relationHasDate and isDateAssociatedWithRelation
+                     object properties, to connect n-ary Relation classes and Dates. Added
+                     hasOrganicProvenanceDate and isOrganicProvenanceDateOf object properties (with
+                     property chain axioms to connect those properties to the
+                     OrganicProvenanceRelation). Added property chain axioms to hasCreationDate,
+                     hasAccumulationDate, and to their inverse properties.</html:li>
                   <html:li>2024, December 23: added the following datatype properties:
                      accumulationDate, allMembersWithAccumulationDate,
                      someMembersWithAccumulationDate (subproperties of date);
@@ -985,7 +986,7 @@
                      hasMigrationDate, isMigrationDateOf and of migrationDate accordingly. Removed
                      the mention of Record Resource from the rdfs:comment of isMigrationDateOf and
                      migrationDate.</html:li>
-<html:li>2025, March 4th: introduced datatype properties rankInSequence and
+                  <html:li>2025, March 4th: introduced datatype properties rankInSequence and
                      rankInHierarchy, expanded the range of proxyIn to any RecordResource and
                      tweaked the definition of it and proxyFor accordingly, added an inverse
                      property hasProxy for proxyFor, added two new sub-properties proxyInRecord and
@@ -994,10 +995,11 @@
                      axioms involving rico:Proxy to a few object properties used to define sequences
                      or hierarchies.</html:li>
                   <html:li>2025, March 13: added French and Spanish labels to the object properties
-                     that connect Date and Relation, and to the isOrganicProvenanceDateOf/hasOrganicProvenanceDate properties.
-                     Fixed the domain and a rdfs:subPropertyOf of isDateAssociatedWithRelation.
-                     Also added property chain axioms to hasDerivationDate, hasMigrationDate and to their
-                     inverse properties.</html:li>                 
+                     that connect Date and Relation, and to the
+                     isOrganicProvenanceDateOf/hasOrganicProvenanceDate properties. Fixed the domain
+                     and a rdfs:subPropertyOf of isDateAssociatedWithRelation. Also added property
+                     chain axioms to hasDerivationDate, hasMigrationDate and to their inverse
+                     properties.</html:li>
                   <html:li>2025, April 2nd: reviewed the new properties for Proxies, hierarchies and
                      sequences. Fixed a few owl:inverseOf, owl:subPropertyOf and a property chain
                      axiom. Modified a few details in the rdfs:comment of those properties. Added
@@ -1992,7 +1994,6 @@
          </rdf:Description>
       </skos:changeNote>
    </owl:ObjectProperty>
-   
    <!-- https://www.ica.org/standards/RiC/ontology#derivationRelation_role -->
    <owl:ObjectProperty
       rdf:about="https://www.ica.org/standards/RiC/ontology#derivationRelation_role">
@@ -2154,7 +2155,6 @@
          rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyPrecedesInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <!--<owl:propertyChainAxiom rdf:parseType="Collection"> <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyDirectlyFollowsInSequence"/> <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/> </owl:propertyChainAxiom>-->
       <owl:propertyChainAxiom rdf:parseType="Collection">
          <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#hasProxy"/>
          <rdf:Description
@@ -3281,7 +3281,8 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasAccumulationDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasAccumulationDate">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrganicProvenanceDate"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrganicProvenanceDate"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAccumulationDateOf"/>
       <rdfs:domain>
          <owl:Class>
@@ -3294,8 +3295,10 @@
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelation_role"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelation_role"/>
          <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasDate"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is accumulation date of' object
@@ -3307,8 +3310,9 @@
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2024-12-19</dc:date>
-            <rdf:value xml:lang="en">Connect to AccumulationRelation via a sub-property chain, and make
-               a sub-property of the new object property 'hasOrganicProvenanceDate'.</rdf:value>
+            <rdf:value xml:lang="en">Connect to AccumulationRelation via a sub-property chain, and
+               make a sub-property of the new object property
+               'hasOrganicProvenanceDate'.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -4032,7 +4036,8 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasCreationDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasCreationDate">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasBeginningDate"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrganicProvenanceDate"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrganicProvenanceDate"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isCreationDateOf"/>
       <rdfs:domain>
          <owl:Class>
@@ -4044,9 +4049,11 @@
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
-<owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#creationRelation_role"/>
+      <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#creationRelation_role"/>
          <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasDate"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is creation date of' object property</rdfs:comment>
@@ -4057,8 +4064,8 @@
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2024-12-19</dc:date>
-            <rdf:value xml:lang="en">Connect to CreationRelation via a sub-property chain, and make a
-               sub-property of the new object property 'hasOrganicProvenanceDate'.</rdf:value>
+            <rdf:value xml:lang="en">Connect to CreationRelation via a sub-property chain, and make
+               a sub-property of the new object property 'hasOrganicProvenanceDate'.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -8148,28 +8155,35 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasOrganicProvenanceDate -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrganicProvenanceDate">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrganicProvenanceDateOf"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#hasOrganicProvenanceDate">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isOrganicProvenanceDateOf"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#organicProvenanceRelation_role"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#thingIsSourceOfRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#organicProvenanceRelation_role"/>
          <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasDate"/>
       </owl:propertyChainAxiom>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour date de provenance organique</rdfs:label>
       <rdfs:label xml:lang="en">has organic provenance date</rdfs:label>
       <rdfs:label xml:lang="es">tiene como fecha de procedencia orgánica</rdfs:label>
-      <rdfs:comment xml:lang="en">Inverse of 'is date associated with organic provenance of' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is date associated with organic provenance of' object
+         property.</rdfs:comment>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-13</dc:date>
@@ -9273,8 +9287,10 @@
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWithRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelation_role"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWithRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#accumulationRelation_role"/>
          <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Date to a Record Resource or Instantiation that was or
@@ -9292,8 +9308,9 @@
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2024-12-19</dc:date>
-            <rdf:value xml:lang="en">Connect to AccumulationRelation via a sub-property chain, and make
-               a sub-property of the new 'isOrganicProvenanceDateOf' object property.</rdf:value>
+            <rdf:value xml:lang="en">Connect to AccumulationRelation via a sub-property chain, and
+               make a sub-property of the new 'isOrganicProvenanceDateOf' object
+               property.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -10259,8 +10276,10 @@
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWithRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#creationRelation_role"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWithRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#creationRelation_role"/>
          <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Date to a Record Resource or Instantiation that was or
@@ -10278,8 +10297,8 @@
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2024-12-19</dc:date>
-            <rdf:value xml:lang="en">Connect to CreationRelation via a sub-property chain, and make a
-               sub-property of the new 'isOrganicProvenanceDateOf' object property.</rdf:value>
+            <rdf:value xml:lang="en">Connect to CreationRelation via a sub-property chain, and make
+               a sub-property of the new 'isOrganicProvenanceDateOf' object property.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -10408,9 +10427,12 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isDateAssociatedWithRelation -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWithRelation">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWithRelation">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#thingIsContextOfRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
@@ -10422,7 +10444,8 @@
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-13</dc:date>
-            <rdf:value xml:lang="en">Added French and Spanish labels; fixed the first rdfs:subPropertyOf and the rdfs:domain.</rdf:value>
+            <rdf:value xml:lang="en">Added French and Spanish labels; fixed the first
+               rdfs:subPropertyOf and the rdfs:domain.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -10580,8 +10603,10 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWithRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#derivationRelation_role"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWithRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#derivationRelation_role"/>
          <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Date to an Instantiation from which a new Instantiation
@@ -11751,8 +11776,10 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWithRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelation_role"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWithRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#migrationRelation_role"/>
          <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Date to an Instantiation that was or will be migrated
@@ -11810,25 +11837,31 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isOrganicProvenanceDateOf -->
-   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isOrganicProvenanceDateOf">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrganicProvenanceDate"/>
+   <owl:ObjectProperty
+      rdf:about="https://www.ica.org/standards/RiC/ontology#isOrganicProvenanceDateOf">
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWith"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasOrganicProvenanceDate"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:range>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Instantiation"/>
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWithRelation"/>
-         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#organicProvenanceRelation_role"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWithRelation"/>
+         <rdf:Description
+            rdf:about="https://www.ica.org/standards/RiC/ontology#organicProvenanceRelation_role"/>
          <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasSource"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Connects a Date associated with the organic provenance of a Record Resource or
-         Instantiation to that Record Resource or Instantiation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Date associated with the organic provenance of a Record
+         Resource or Instantiation to that Record Resource or Instantiation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="es">es la fecha de procedencia orgánica de</rdfs:label>
       <rdfs:label xml:lang="fr">est la date de provenance organique de</rdfs:label>
@@ -18512,9 +18545,12 @@
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#relationHasDate -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#relationHasDate">
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
-      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
-      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWithRelation"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#relationHasContext"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isAssociatedWithDate"/>
+      <owl:inverseOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDateAssociatedWithRelation"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Relation"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
       <rdfs:comment xml:lang="en">Connects an n-ary Relation to a Date.</rdfs:comment>

--- a/ontology/current-version/RiC-O_1.1.rdf
+++ b/ontology/current-version/RiC-O_1.1.rdf
@@ -981,13 +981,13 @@
                      the mention of Record Resource from the rdfs:comment of isMigrationDateOf and
                      migrationDate.</html:li>
                   <html:li>2025, March 4th: introduced datatype properties rankInSequence and
-                     rankInHierarchy, expanded the range of proxyIn to any RecordResource and tweaked
-                     the definition of it and proxyFor accordingly, added an inverse property
-                     hasProxy for proxyFor, added two new sub-properties proxyInRecord and
-                     proxyInRecordSet of ProxyIn, introduced 36 object
-                     properties pertaining to use of Proxy in sequences or hierarchies, and
-                     added one or two property chain axioms involving rico:Proxy to a few
-                     object properties used to define sequences or hierarchies.</html:li>
+                     rankInHierarchy, expanded the range of proxyIn to any RecordResource and
+                     tweaked the definition of it and proxyFor accordingly, added an inverse
+                     property hasProxy for proxyFor, added two new sub-properties proxyInRecord and
+                     proxyInRecordSet of ProxyIn, introduced 36 object properties pertaining to use
+                     of Proxy in sequences or hierarchies, and added one or two property chain
+                     axioms involving rico:Proxy to a few object properties used to define sequences
+                     or hierarchies.</html:li>
                </html:ul>
             </html:div>
          </html:div>
@@ -2151,22 +2151,34 @@
          rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyPrecedesInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <owl:propertyChainAxiom rdf:parseType="Collection">
+      <!--<owl:propertyChainAxiom rdf:parseType="Collection">
          <rdf:Description
             rdf:about="https://www.ica.org/standards/RiC/ontology#proxyDirectlyFollowsInSequence"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
+      </owl:propertyChainAxiom>-->
+      <owl:propertyChainAxiom rdf:parseType="Collection">
          <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
+            rdf:about="https://www.ica.org/standards/RiC/ontology#hasProxy"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyDirectlyFollowsInSequence"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'directly precedes in sequence' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'directly precedes in sequence' object
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">directly follows in sequence</rdfs:label>
       <rdfs:label xml:lang="es">sigue directamente en la secuencia</rdfs:label>
       <rdfs:label xml:lang="fr">suit directement dans la séquence</rdfs:label>
       <skos:changeNote>
          <rdf:Description>
+            <dc:date>2025-04-02</dc:date>
+            <rdf:value xml:lang="en">Fixed the property chain axiom.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
+      <skos:changeNote>
+         <rdf:Description>
             <dc:date>2025-03-04</dc:date>
-            <rdf:value xml:lang="en">Tweaked the rdfs:comment to simply refer to its inverse property.
-               Also added a property chain axiom relating it to use of rico:Proxy.</rdf:value>
+            <rdf:value xml:lang="en">Tweaked the rdfs:comment to simply refer to its inverse
+               property. Also added a property chain axiom relating it to use of
+               rico:Proxy.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -2207,8 +2219,7 @@
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyDirectlyPrecedesInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Inverse of 'proxy directly precedes in sequence' object property.
-         </rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy directly precedes in sequence' object property. </rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">directly follows proxy in sequence</rdfs:label>
       <skos:changeNote>
@@ -2262,17 +2273,15 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#directlyIncludesProxy -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#directlyIncludesProxy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#includesProxy"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#directlyIncludesProxy">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#includesProxy"/>
       <owl:inverseOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsDirectlyIncludedIn"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Inverse of 'proxy is directly included in' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy is directly included in' object
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">directly includes proxy</rdfs:label>
       <skos:changeNote>
@@ -2294,8 +2303,7 @@
       <owl:propertyChainAxiom rdf:parseType="Collection">
          <rdf:Description
             rdf:about="https://www.ica.org/standards/RiC/ontology#directlyPrecedesProxyInSequence"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Thing to a Thing that it precedes directly in some
          sequence (not necessarily defined or characterised chronologically).</rdfs:comment>
@@ -2306,8 +2314,8 @@
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
-            <rdf:value xml:lang="en">Tweaked the rdfs:comment to try to clarify what is
-               meant. Also added a property chain axiom relating it to use of rico:Proxy.</rdf:value>
+            <rdf:value xml:lang="en">Tweaked the rdfs:comment to try to clarify what is meant. Also
+               added a property chain axiom relating it to use of rico:Proxy.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -2350,8 +2358,9 @@
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyDirectlyFollowsInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Connects a Record Resource to a proxy of a Record Resource that it precedes
-         directly in some sequence (not necessarily defined or characterised chronologically).</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Record Resource to a Proxy of a Record Resource that it
+         precedes directly in some sequence (not necessarily defined or characterised
+         chronologically).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">directly precedes proxy in sequence</rdfs:label>
       <skos:changeNote>
@@ -2713,8 +2722,8 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#precededInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <rdfs:comment xml:lang="en">Connects a Thing to a Thing that it followed in some
-         sequence (not necessarily defined or characterised chronologically) in the past.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Thing to a Thing that it followed in some sequence (not
+         necessarily defined or characterised chronologically) in the past.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a suivi dans la séquence</rdfs:label>
       <rdfs:label xml:lang="en">followed in sequence</rdfs:label>
@@ -2764,12 +2773,12 @@
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#hasProxy"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#hasProxy"/>
          <rdf:Description
             rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFollowsInSequence"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'precedes in sequence transitive' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'precedes in sequence transitive' object
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">follows in sequence transitive</rdfs:label>
       <rdfs:label xml:lang="es">sigue en la secuencia transitivo</rdfs:label>
@@ -2915,15 +2924,15 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#followsProxyInSequence -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#followsProxyInSequence">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#followsProxyInSequence">
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInSequenceTransitive"/>
       <owl:inverseOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyPrecedesInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Inverse of 'proxy precedes in sequence' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy precedes in sequence' object
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">follows proxy in sequence</rdfs:label>
       <skos:changeNote>
@@ -3785,12 +3794,10 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#hasConstituentProxy -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy">
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOf"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOf"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -3801,12 +3808,13 @@
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy"/>
          <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasConstituentProxyTransitive"/>
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasConstituentProxyTransitive"
+         />
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'proxy is constituent of' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy is constituent of' object
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">has constituent proxy</rdfs:label>
       <skos:changeNote>
@@ -3843,10 +3851,9 @@
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasConstituent"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasConstituent"
+         />
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record or Record Part to another Record or Record Part
          that is its constituent, directly or indirectly. This is a transitive
@@ -3858,7 +3865,8 @@
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
-            <rdf:value xml:lang="en">Added a property chain axiom relating it to use of rico:Proxy.</rdf:value>
+            <rdf:value xml:lang="en">Added a property chain axiom relating it to use of
+               rico:Proxy.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -4349,8 +4357,7 @@
       <owl:propertyChainAxiom rdf:parseType="Collection">
          <rdf:Description
             rdf:about="https://www.ica.org/standards/RiC/ontology#hasDirectConstituentOfProxy"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record to another Record or Record Part that is its
          direct constituent.</rdfs:comment>
@@ -4361,7 +4368,8 @@
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
-            <rdf:value xml:lang="en">Added a property chain axiom relating it to use of rico:Proxy.</rdf:value>
+            <rdf:value xml:lang="en">Added a property chain axiom relating it to use of
+               rico:Proxy.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -4395,8 +4403,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasDirectConstituentProxy -->
    <owl:ObjectProperty
       rdf:about="https://www.ica.org/standards/RiC/ontology#hasDirectConstituentProxy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy"/>
       <owl:inverseOf
@@ -4410,7 +4417,8 @@
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Inverse of 'proxy is direct constituent of' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy is direct constituent of' object
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">has direct constituent proxy</rdfs:label>
       <skos:changeNote>
@@ -8151,8 +8159,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#hasProxy -->
    <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#hasProxy">
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isRelatedTo"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:comment xml:lang="en">Inverse of 'proxy for' object property.</rdfs:comment>
@@ -8172,7 +8179,8 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isPublicationDateOf"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Date"/>
-      <rdfs:comment xml:lang="en">Inverse of 'is publication date of' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is publication date of' object
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a pour date de publication</rdfs:label>
       <rdfs:label xml:lang="en">has publication date</rdfs:label>
@@ -8912,10 +8920,8 @@
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#includesProxy"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIncludes"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#includesProxy"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIncludes"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record Set to a Record or Record Set which it includes
          directly or indirectly. This is a transitive relation.</rdfs:comment>
@@ -8926,7 +8932,8 @@
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
-            <rdf:value xml:lang="en">Added a property chain axiom relating it to use of rico:Proxy</rdf:value>
+            <rdf:value xml:lang="en">Added a property chain axiom relating it to use of
+               rico:Proxy</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -8951,17 +8958,14 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#includesProxy -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#includesProxy">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#includesProxy">
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#includesProxy"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#includesProxy"/>
          <rdf:Description
             rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIncludesProxyTransitive"/>
       </owl:propertyChainAxiom>
@@ -9842,12 +9846,10 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isConstituentOfProxy -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isConstituentOfProxy">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isConstituentOfProxy">
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyHasConstituent"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyHasConstituent"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -9861,10 +9863,11 @@
          <rdf:Description
             rdf:about="https://www.ica.org/standards/RiC/ontology#isConstituentOfProxy"/>
          <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOfProxyTransitive"/>
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOfProxyTransitive"
+         />
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Connects a Record or Record Part to a proxy of a Record or Record Part
-         of which it is a constituent, directly or indirectly.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Record or Record Part to a proxy of a Record or Record
+         Part of which it is a constituent, directly or indirectly.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">is constituent of proxy</rdfs:label>
       <skos:changeNote>
@@ -9901,10 +9904,8 @@
          </owl:Class>
       </rdfs:range>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#hasProxy"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyInRecord"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#hasProxy"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyInRecord"/>
       </owl:propertyChainAxiom>
       <owl:propertyChainAxiom rdf:parseType="Collection">
          <rdf:Description
@@ -9922,7 +9923,8 @@
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
-            <rdf:value xml:lang="en">Added two property chain axioms relating it to use of rico:Proxy.</rdf:value>
+            <rdf:value xml:lang="en">Added two property chain axioms relating it to use of
+               rico:Proxy.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -10480,8 +10482,7 @@
       <owl:propertyChainAxiom rdf:parseType="Collection">
          <rdf:Description
             rdf:about="https://www.ica.org/standards/RiC/ontology#isDirectConstituentOfProxy"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record or Record Part to another Record or Record Part
          of which it is a direct constituent.</rdfs:comment>
@@ -10492,7 +10493,8 @@
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
-            <rdf:value xml:lang="en">Added a property chain axiom relating it to use of rico:Proxy.</rdf:value>
+            <rdf:value xml:lang="en">Added a property chain axiom relating it to use of
+               rico:Proxy.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -10526,8 +10528,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#isDirectConstituentOfProxy -->
    <owl:ObjectProperty
       rdf:about="https://www.ica.org/standards/RiC/ontology#isDirectConstituentOfProxy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#isConstituentOfProxy"/>
       <owl:inverseOf
@@ -10555,12 +10556,10 @@
    <!-- https://www.ica.org/standards/RiC/ontology#isDirectlyIncludedInProxy -->
    <owl:ObjectProperty
       rdf:about="https://www.ica.org/standards/RiC/ontology#isDirectlyIncludedInProxy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#isIncludedInProxy"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyDirectlyIncludes"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyDirectlyIncludes"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -10570,8 +10569,8 @@
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Connects a Record or Record Set to a proxy of a Record
-         Set which it is directly included in.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Record or Record Set to a proxy of a Record Set which
+         it is directly included in.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">is directly included in proxy</rdfs:label>
       <skos:changeNote>
@@ -11281,12 +11280,10 @@
          relation)</RiCCMCorrespondingComponent>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#isIncludedInProxy -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#isIncludedInProxy">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#isIncludedInProxy">
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIncludes"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIncludes"/>
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
@@ -11297,13 +11294,13 @@
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#isIncludedInProxy"/>
          <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#isIncludedInProxy"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedInProxyTransitive"/>
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedInProxyTransitive"
+         />
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Connects a Record or Record Set to a proxy of a Record Set
-         which it is included in, directly or indirectly.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Record or Record Set to a proxy of a Record Set which
+         it is included in, directly or indirectly.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">is constituent of proxy</rdfs:label>
       <skos:changeNote>
@@ -11369,16 +11366,12 @@
       </rdfs:domain>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#hasProxy"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyInRecordSet"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#hasProxy"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyInRecordSet"/>
       </owl:propertyChainAxiom>
       <owl:propertyChainAxiom rdf:parseType="Collection">
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#isIncludedInProxy"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#isIncludedInProxy"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Record to a Record or Record Set in which it is
          directly or indirectly included. This is a transitive relation.</rdfs:comment>
@@ -11389,7 +11382,8 @@
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
-            <rdf:value xml:lang="en">Added two property chain axioms relating it to use of rico:Proxy.</rdf:value>
+            <rdf:value xml:lang="en">Added two property chain axioms relating it to use of
+               rico:Proxy.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -14087,7 +14081,8 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#regulatesOrRegulated"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Rule"/>
-      <rdfs:comment xml:lang="en">Inverse of 'regulates or regulated' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'regulates or regulated' object
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">est ou a été régulé par</rdfs:label>
       <rdfs:label xml:lang="es">está o estaba regulado por</rdfs:label>
@@ -16799,8 +16794,8 @@
       <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#followedInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Thing"/>
-      <rdfs:comment xml:lang="en">Connects a Thing to a Thing that followed it in some
-         sequence (not necessarily defined or characterised chronologically) in the past.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Thing to a Thing that followed it in some sequence (not
+         necessarily defined or characterised chronologically) in the past.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="fr">a précédé dans la séquence</rdfs:label>
       <rdfs:label xml:lang="en">preceded in sequence</rdfs:label>
@@ -16808,7 +16803,8 @@
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
-            <rdf:value xml:lang="en">Tweaked the rdfs:comment to try to clarify what is meant.</rdf:value>
+            <rdf:value xml:lang="en">Tweaked the rdfs:comment to try to clarify what is
+               meant.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -16852,8 +16848,7 @@
       <owl:propertyChainAxiom rdf:parseType="Collection">
          <rdf:Description
             rdf:about="https://www.ica.org/standards/RiC/ontology#precedesProxyInSequence"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFor"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Connects a Thing to a Thing that follows it directly or indirectly
          in some sequence (not necessarily defined or characterised chronologically). This is a
@@ -16866,7 +16861,7 @@
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
             <rdf:value xml:lang="en">Tweaked the rdfs:comment to try to clarify what is meant. Also
-              added a property chain axiom relating it to use of rico:Proxy.</rdf:value>
+               added a property chain axiom relating it to use of rico:Proxy.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -17024,10 +17019,11 @@
          <rdf:Description
             rdf:about="https://www.ica.org/standards/RiC/ontology#precedesProxyInSequence"/>
          <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyPrecedesProxyInSequenceTransitive"/>
+            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyPrecedesProxyInSequenceTransitive"
+         />
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Connects a Record Resource to a proxy of a Record Resource that it precedes
-         directly or indirectly in some sequence (not necessarily defined or characterised
+      <rdfs:comment xml:lang="en">Connects a Record Resource to a Proxy of a Record Resource that it
+         precedes directly or indirectly in some sequence (not necessarily defined or characterised
          chronologically).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">precedes proxy in sequence</rdfs:label>
@@ -17049,7 +17045,8 @@
          rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyPrecedesProxyInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-      <rdfs:comment xml:lang="en">Inverse of 'directly precedes proxy in sequence' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'directly precedes proxy in sequence' object
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy directly follows in sequence</rdfs:label>
       <skos:changeNote>
@@ -17070,7 +17067,8 @@
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyDirectlyPrecedesProxyInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Inverse of 'proxy directly precedes proxy in sequence' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy directly precedes proxy in sequence' object
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy directly follows proxy in sequence</rdfs:label>
       <skos:changeNote>
@@ -17081,12 +17079,9 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#proxyDirectlyIncludes -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyDirectlyIncludes">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIncludes"/>
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#proxyDirectlyIncludes">
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIncludes"/>
       <owl:inverseOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectlyIncludedInProxy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
@@ -17098,7 +17093,8 @@
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
-      <rdfs:comment xml:lang="en">Inverse of 'is directly included in proxy' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is directly included in proxy' object
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy directly includes</rdfs:label>
       <skos:changeNote>
@@ -17111,15 +17107,15 @@
    <!-- https://www.ica.org/standards/RiC/ontology#proxyDirectlyIncludesProxy -->
    <owl:ObjectProperty
       rdf:about="https://www.ica.org/standards/RiC/ontology#proxyDirectlyIncludesProxy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIncludesProxyTransitive"/>
       <owl:inverseOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsDirectlyIncludedInProxy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Inverse of 'proxy is directly included in' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy is directly included in' object
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy directly includes proxy</rdfs:label>
       <skos:changeNote>
@@ -17140,8 +17136,8 @@
          rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyFollowsProxyInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
-      <rdfs:comment xml:lang="en">Connects a proxy for a Record Resource to a Record Resource
-         which it precedes directly in some sequence (not necessarily defined or characterised
+      <rdfs:comment xml:lang="en">Connects a Proxy of a Record Resource to a Record Resource which
+         it precedes directly in some sequence (not necessarily defined or characterised
          chronologically).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy directly precedes in sequence</rdfs:label>
@@ -17157,15 +17153,24 @@
       rdf:about="https://www.ica.org/standards/RiC/ontology#proxyDirectlyPrecedesProxyInSequence">
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyPrecedesInSequence"/>
+      <rdfs:subPropertyOf
+         rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyPrecedesProxyInSequenceTransitive"/>
       <owl:inverseOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyDirectlyFollowsProxyInSequence"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Connects a proxy of a Record Resource to a proxy of another Record
-         Resource that it precedes directly in some sequence (not necessarily defined or characterised
-         chronologically).</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Proxy of a Record Resource to a Proxy of another Record
+         Resource that it precedes directly in some sequence (not necessarily defined or
+         characterised chronologically).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy directly precedes proxy in sequence</rdfs:label>
+      <skos:changeNote>
+         <rdf:Description>
+            <dc:date>2025-04-01</dc:date>
+            <rdf:value xml:lang="en">Added a second owl:subPropertyOf with target
+               'proxyPrecedesProxyInSequenceTransitive'.</rdf:value>
+         </rdf:Description>
+      </skos:changeNote>
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
@@ -17174,8 +17179,7 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#proxyFollowsInSequence -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFollowsInSequence">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFollowsInSequence">
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#followsInSequenceTransitive"/>
       <owl:inverseOf
@@ -17188,7 +17192,8 @@
          <rdf:Description
             rdf:about="https://www.ica.org/standards/RiC/ontology#proxyFollowsInSequence"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'precedes proxy in sequence' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'precedes proxy in sequence' object
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy follows in sequence</rdfs:label>
       <skos:changeNote>
@@ -17208,7 +17213,8 @@
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Inverse of 'proxy recedes proxy in sequence transitive' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy recedes proxy in sequence transitive' object
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy follows proxy in sequence transitive</rdfs:label>
       <skos:changeNote>
@@ -17232,8 +17238,8 @@
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
-            <rdf:value xml:lang="en">Changed the rdfs:comment to allow for a context of a
-              Record Resource of any kind, not only a Record Set.</rdf:value>
+            <rdf:value xml:lang="en">Changed the rdfs:comment to allow for a context of a Record
+               Resource of any kind, not only a Record Set.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -17250,12 +17256,10 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#proxyHasConstituent -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasConstituent">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasConstituent">
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isConstituentOfProxy"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isConstituentOfProxy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range>
          <owl:Class>
@@ -17268,10 +17272,11 @@
       <owl:propertyChainAxiom rdf:parseType="Collection">
          <rdf:Description
             rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasConstituentProxyTransitive"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasConstituent"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasConstituent"
+         />
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Inverse of 'is constituent of proxy' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is constituent of proxy' object
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy has constituent</rdfs:label>
       <skos:changeNote>
@@ -17291,8 +17296,8 @@
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Inverse of 'proxy is constituent of proxy transitive' object property. This
-         is a transitive relation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy is constituent of proxy transitive' object
+         property. This is a transitive relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy has constituent proxy transitive</rdfs:label>
       <skos:changeNote>
@@ -17305,8 +17310,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#proxyHasDirectConstituent -->
    <owl:ObjectProperty
       rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasDirectConstituent">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyHasConstituent"/>
       <owl:inverseOf
@@ -17320,7 +17324,8 @@
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
-      <rdfs:comment xml:lang="en">Inverse of 'is direct constituent of proxy' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'is direct constituent of proxy' object
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy has direct constituent</rdfs:label>
       <skos:changeNote>
@@ -17333,15 +17338,15 @@
    <!-- https://www.ica.org/standards/RiC/ontology#proxyHasDirectConstituentProxy -->
    <owl:ObjectProperty
       rdf:about="https://www.ica.org/standards/RiC/ontology#proxyHasDirectConstituentProxy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasDirectPart"/>
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyHasConstituentProxyTransitive"/>
       <owl:inverseOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsDirectConstituentOfProxy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Inverse of 'proxy is direct constituent of' object property.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy is direct constituent of' object
+         property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy has direct constituent proxy</rdfs:label>
       <skos:changeNote>
@@ -17365,8 +17370,8 @@
       <skos:changeNote>
          <rdf:Description>
             <dc:date>2025-03-04</dc:date>
-            <rdf:value xml:lang="en">Changed the range and rdfs:comment to allow any
-               Record Resource, not only a Record Set.</rdf:value>
+            <rdf:value xml:lang="en">Changed the range and rdfs:comment to allow any Record
+               Resource, not only a Record Set.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
       <skos:changeNote>
@@ -17383,12 +17388,10 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#proxyIncludes -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIncludes">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIncludes">
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#hasPartTransitive"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isIncludedInProxy"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isIncludedInProxy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range>
          <owl:Class>
@@ -17401,8 +17404,7 @@
       <owl:propertyChainAxiom rdf:parseType="Collection">
          <rdf:Description
             rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIncludesProxyTransitive"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIncludes"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIncludes"/>
       </owl:propertyChainAxiom>
       <rdfs:comment xml:lang="en">Inverse of 'is included in proxy' object property.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
@@ -17424,8 +17426,8 @@
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Inverse of 'proxy is included in proxy transitive' object property. This
-         is a transitive relation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Inverse of 'proxy is included in proxy transitive' object
+         property. This is a transitive relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy includes proxy transitive</rdfs:label>
       <skos:changeNote>
@@ -17440,8 +17442,8 @@
       <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIn"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Record"/>
-      <rdfs:comment xml:lang="en">Connects a Proxy to a Record in which it stands for
-         (represents) a Record Part or another Record.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Proxy to a Record in which it stands for (represents) a
+         Record Part or another Record.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy in record</rdfs:label>
       <skos:changeNote>
@@ -17469,12 +17471,10 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOf -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOf">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOf">
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range>
          <owl:Class>
@@ -17490,8 +17490,8 @@
          <rdf:Description
             rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOf"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Part to a Record
-         or Record Part which it is a constituent of, directly or indirectly.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Part to a Record or Record
+         Part which it is a constituent of, directly or indirectly.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy is constituent of</rdfs:label>
       <skos:changeNote>
@@ -17526,12 +17526,10 @@
    <!-- https://www.ica.org/standards/RiC/ontology#proxyIsDirectConstituentOf -->
    <owl:ObjectProperty
       rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsDirectConstituentOf">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOf"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#hasConstituentProxy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range>
          <owl:Class>
@@ -17541,8 +17539,8 @@
             </owl:unionOf>
          </owl:Class>
       </rdfs:range>
-      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Part to another
-         Record or Record Part which the first is a direct constituent of.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Part to another Record or
+         Record Part which the first is a direct constituent of.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy is direct constituent of</rdfs:label>
       <skos:changeNote>
@@ -17555,8 +17553,7 @@
    <!-- https://www.ica.org/standards/RiC/ontology#proxyIsDirectConstituentOfProxy -->
    <owl:ObjectProperty
       rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsDirectConstituentOfProxy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsConstituentOfProxyTransitive"/>
       <owl:inverseOf
@@ -17577,12 +17574,10 @@
    <!-- https://www.ica.org/standards/RiC/ontology#proxyIsDirectlyIncludedIn -->
    <owl:ObjectProperty
       rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsDirectlyIncludedIn">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyIncludesProxy"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#directlyIncludesProxy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Set to another Record Set
@@ -17599,16 +17594,15 @@
    <!-- https://www.ica.org/standards/RiC/ontology#proxyIsDirectlyIncludedInProxy -->
    <owl:ObjectProperty
       rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsDirectlyIncludedInProxy">
-      <rdfs:subPropertyOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
+      <rdfs:subPropertyOf rdf:resource="https://www.ica.org/standards/RiC/ontology#isDirectPartOf"/>
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedInProxyTransitive"/>
       <owl:inverseOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#proxyDirectlyIncludesProxy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Set to a proxy for
-         a Record Set which it is directly included in.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Set to a proxy for a
+         Record Set which it is directly included in.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy is directly included in proxy</rdfs:label>
       <skos:changeNote>
@@ -17619,22 +17613,19 @@
       </skos:changeNote>
    </owl:ObjectProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn -->
-   <owl:ObjectProperty
-      rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn">
+   <owl:ObjectProperty rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn">
       <rdfs:subPropertyOf
          rdf:resource="https://www.ica.org/standards/RiC/ontology#isPartOfTransitive"/>
-      <owl:inverseOf
-         rdf:resource="https://www.ica.org/standards/RiC/ontology#includesProxy"/>
+      <owl:inverseOf rdf:resource="https://www.ica.org/standards/RiC/ontology#includesProxy"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#RecordSet"/>
       <owl:propertyChainAxiom rdf:parseType="Collection">
          <rdf:Description
             rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedInProxyTransitive"/>
-         <rdf:Description
-            rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn"/>
+         <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#proxyIsIncludedIn"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Set to a Record
-         Set which it is included in, directly or indirectly.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Set to a Record Set which
+         it is included in, directly or indirectly.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy is included in</rdfs:label>
       <skos:changeNote>
@@ -17654,9 +17645,9 @@
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Set to a proxy for
-         a Record Set which it is included in, directly or indirectly. This is
-         a transitive relation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a proxy for a Record or Record Set to a proxy for a
+         Record Set which it is included in, directly or indirectly. This is a transitive
+         relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy is included in proxy transitive</rdfs:label>
       <skos:changeNote>
@@ -17681,8 +17672,8 @@
          <rdf:Description
             rdf:about="https://www.ica.org/standards/RiC/ontology#proxyPrecedesInSequence"/>
       </owl:propertyChainAxiom>
-      <rdfs:comment xml:lang="en">Connects a proxy for a Record Resource to a Record Resource which
-         the first precedes directly or indirectly in sequence (not necessarily defined or
+      <rdfs:comment xml:lang="en">Connects a Proxy of a Record Resource to a Record Resource which
+         the first precedes directly or indirectly in some sequence (not necessarily defined or
          characterised chronologically).</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy precedes in sequence</rdfs:label>
@@ -17703,9 +17694,10 @@
       <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
       <rdfs:domain rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
       <rdfs:range rdf:resource="https://www.ica.org/standards/RiC/ontology#Proxy"/>
-      <rdfs:comment xml:lang="en">Connects a Proxy for a Record Resource to a Proxy for another Record
-         Resource which directly or indirectly follows the first in some sequence (not necessarily
-         defined or characterised chronologically). This is a transitive relation.</rdfs:comment>
+      <rdfs:comment xml:lang="en">Connects a Proxy of a Record Resource to a Proxy of another
+         Record Resource which directly or indirectly follows the first in some sequence (not
+         necessarily defined or characterised chronologically). This is a transitive
+         relation.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">proxy precedes proxy in sequence transitive</rdfs:label>
       <skos:changeNote>
@@ -21310,13 +21302,15 @@
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Proxy"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
-      <rdfs:comment xml:lang="en">The rank of a record resource, or a proxy for it, in a hierarchy.</rdfs:comment>
+      <rdfs:comment xml:lang="en">The rank of a record resource, or of a proxy for it, in a
+         hierarchy.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">rank in hierarchy</rdfs:label>
       <skos:changeNote>
@@ -21325,20 +21319,21 @@
             <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">The object properties rico:directlyIncludes and rico:hasDirectConstituent,
-         or variants of these which are sub-properties of rico:hasOrHadPart, should always be used to express
-         hierarchies in RiC-O. This datatype property may be used in addition (never independently) for
-         convenience, but it should be ensured that it is compatible with (e.g. computed using) the
-         hierarchical object properties in the intended context (e.g. a hierarchy of Record Parts in a given
-         Record), i.e. if Record Part A rico:hasDirectConstituent Record Part B, then the rico:rankInHierarchy
-         of Record Part B must strictly greater than rico:rankInHierarchy of Record Resource A, and no other
-         Record Part in that context should have rico:rankInHierarchy between that of Record Part A and
-         Record Part B.
-
-         For a given Record Resource, rico:rankInHierarchy should never be used more than once. If a
-         RecordResource belongs to more than one hierarchy, a rico:Proxy of the Record Resource should be
-         introduced, and rico:rankInHierarchy have source such a proxy, in all cases except (possibly) the
-         first.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">The object properties rico:directlyIncludes and
+         rico:hasDirectConstituent, or variants of these which are sub-properties of
+         rico:hasOrHadPart, should always be used to express hierarchies in RiC-O. The
+         rico:rankInHierarchy datatype property should only be used in addition (never
+         independently), for convenience (for example to help display or query a graph). But it
+         should be ensured that it reflects and is compatible with (e.g. computed using) the
+         hierarchical object properties in the intended context (e.g. a hierarchy of Record Parts in
+         a given Record). Thus, if, for example, Record Part A rico:hasDirectConstituent Record Part
+         B, then the rico:rankInHierarchy of Record Part B must be strictly greater than
+         rico:rankInHierarchy of Record Part A, and no other Record Part in that context should have
+         rico:rankInHierarchy between that of Record Part A and Record Part B. For a given Record
+         Resource, rico:rankInHierarchy should never be used more than once. If a Record Resource
+         belongs to more than one hierarchy, a rico:Proxy of the Record Resource should be
+         introduced, and rico:rankInHierarchy have source such a proxy, in all cases except
+         (possibly) the first.</skos:scopeNote>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#rankInSequence -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#rankInSequence">
@@ -21346,13 +21341,15 @@
       <rdfs:domain>
          <owl:Class>
             <owl:unionOf rdf:parseType="Collection">
-               <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
+               <rdf:Description
+                  rdf:about="https://www.ica.org/standards/RiC/ontology#RecordResource"/>
                <rdf:Description rdf:about="https://www.ica.org/standards/RiC/ontology#Proxy"/>
             </owl:unionOf>
          </owl:Class>
       </rdfs:domain>
       <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
-      <rdfs:comment xml:lang="en">The rank of a record resource, or a proxy for it, in a sequence.</rdfs:comment>
+      <rdfs:comment xml:lang="en">The rank of a record resource, or of a proxy for it, in a
+         sequence.</rdfs:comment>
       <rdfs:isDefinedBy rdf:resource="https://www.ica.org/standards/RiC/ontology"/>
       <rdfs:label xml:lang="en">rank in sequence</rdfs:label>
       <skos:changeNote>
@@ -21361,19 +21358,19 @@
             <rdf:value xml:lang="en">Introduced in RiC-O 1.1.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">The object property rico:precedesOrPreceded or one of its sub-properties
-         should always be used to express sequences in RiC-O. This datatype property may be used in
-         addition (never independently) for convenience, but it should be ensured that it is compatible with
-         (e.g. computed using) the sequential object properties in the intended context (e.g. the Records in
-         a given Record Set), i.e. if Record Resource A rico:precedesOrPreceded Record Resource B, then the
-         rico:rankInSequence of Record Resource B must be strictly greater than rico:rankInSequence of
-         Record Resource A, and no other Record Resource in that context should have rico:rankInSequence
-         between that of Record Resource A and Record Resource B.
-
-         For a given Record Resource, rico:rankInSequence should never be used more than once. If a
-         Record Resource belongs to more than one sequence, a rico:Proxy of the Record Resource should be
-         introduced, and rico:rankInSequence have source such a proxy, in all cases except (possibly) the
-         first.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">The object property rico:precedesOrPreceded or one of its
+         sub-properties should always be used to express sequences in RiC-O. The rico:rankInSequence
+         datatype property should only be used in addition (never independently), for convenience
+         (for example to help display or query a graph). But it should be ensured that it reflects and is
+         compatible with (e.g. computed using) the sequential object properties in the intended
+         context (e.g. the Records in a given Record Set). Thus, if, for example, Record Resource A
+         rico:precedesOrPreceded Record Resource B, then the rico:rankInSequence of Record Resource
+         B must be strictly greater than rico:rankInSequence of Record Resource A, and no other
+         Record Resource in that context should have rico:rankInSequence between that of Record
+         Resource A and Record Resource B. For a given Record Resource, rico:rankInSequence should
+         never be used more than once. If a Record Resource belongs to more than one sequence, a
+         rico:Proxy of the Record Resource should be introduced, and rico:rankInSequence have source
+         such a proxy, in all cases except (possibly) the first.</skos:scopeNote>
    </owl:DatatypeProperty>
    <!-- https://www.ica.org/standards/RiC/ontology#recordResourceExtent -->
    <owl:DatatypeProperty rdf:about="https://www.ica.org/standards/RiC/ontology#recordResourceExtent">
@@ -26614,13 +26611,13 @@
             <rdf:value xml:lang="en">Added a new rdfs:label in French.</rdf:value>
          </rdf:Description>
       </skos:changeNote>
-      <skos:scopeNote xml:lang="en">Useful e.g. in conjunction with rico:rankInSequence for describing
-         sequences of Records or Record Sets in the context of a Record Set,
-         or of Record Parts and Records in the context of a Record; or in conjunction with
-         rico:rankInHierarchy for describing hierarchies of Records and/or Record Parts in the context
-         of a Record Set, Record, or Record Part. A Record Resource has only one Proxy in the context of
-         one specific Record Set, Record, or Record Part. It may have many Proxies
-         simultaneously or through time.</skos:scopeNote>
+      <skos:scopeNote xml:lang="en">Useful e.g. in conjunction with rico:rankInSequence for
+         describing sequences of Records or Record Sets in the context of a Record Set, or of Record
+         Parts and Records in the context of a Record; or in conjunction with rico:rankInHierarchy
+         for describing hierarchies of Records and/or Record Parts in the context of a Record Set,
+         Record, or Record Part. A Record Resource has only one Proxy in the context of one specific
+         Record Set, Record, or Record Part. It may have many Proxies simultaneously or through
+         time.</skos:scopeNote>
       <closeTo xml:lang="en">ORE Proxy (http://www.openarchives.org/ore/terms/Proxy)</closeTo>
    </owl:Class>
    <!-- https://www.ica.org/standards/RiC/ontology#Record -->


### PR DESCRIPTION
Along with various object properties involving rico:Proxy which relate to sequences or hierarchies, namely those listed below, as well as tweaking a few other object properties and the rico:Proxy class itself to be a little more general, and/or to add a property chain axiom or two relating them to use of rico:Proxy:

proxyDirectlyFollowsInSequence
directlyPrecedesProxyInSequence
proxyDirectlyPrecedesInSequence
directlyFollowsProxyInSequence
proxyFollowsInSequence
precedesProxyInSequence
proxyPrecedesInSequence
followsProxyInSequence
proxyDirectlyFollowsProxyInSequence
proxyDirectlyPrecedesProxyInSequence
proxyFollowsProxyInSequenceTransitive
proxyPrecedesProxyInSequenceTransitive

proxyIsDirectConstituentOf
hasDirectConstituentProxy
proxyHasDirectConstituent
isDirectConstituentOfProxy
proxyIsConstituentOf
hasConstituentProxy
proxyHasConstituent
isConstituentOfProxy
proxyIsDirectConstituentOfProxy
proxyHasDirectConstituentProxy
proxyIsConstituentOfProxyTransitive
proxyHasConstituentProxyTransitive

proxyIsDirectlyIncludedIn
directlyIncludesProxy
proxyDirectlyIncludes
isDirectlyIncludedInProxy
proxyIsIncludedIn
includesProxy
proxyIncludes
isIncludedInProxy
proxyIsDirectlyIncludedInProxy
proxyDirectlyIncludesProxy
proxyIsIncludedInProxyTransitive
proxyIncludesProxyTransitive